### PR TITLE
Update Deals Proposal to ProposalCid

### DIFF
--- a/network-protocols.md
+++ b/network-protocols.md
@@ -90,28 +90,28 @@ Legal values for `DealState` are as follows:
 
 ```go
 const (
-    // Unset implies a programmer error. This value should never appear
+	// Unset implies a programmer error. This value should never appear
     // in an actual message
     Unset = 0
     
-    // Unknown signifies an unknown negotiation
-    Unknown = 1
+	// Unknown signifies an unknown negotiation
+	Unknown = 1
 
-    // Rejected means the deal was rejected for some reason
-    Rejected = 2
+	// Rejected means the deal was rejected for some reason
+	Rejected = 2
 
-    // Accepted means the deal was accepted but hasnt yet started
-    Accepted = 3
+	// Accepted means the deal was accepted but hasnt yet started
+	Accepted = 3
 
-    // Started means the deal has started and the transfer is in progress
-    Started = 4
+	// Started means the deal has started and the transfer is in progress
+	Started = 4
 
-    // Failed means the deal has failed for some reason
-    Failed = 5
+	// Failed means the deal has failed for some reason
+	Failed = 5
 
-    // Complete means the deal is complete, and the sector that the deal is contained
+	// Complete means the deal is complete, and the sector that the deal is contained
     // in has been sealed and its commitment posted on chain.
-    Complete = 6
+	Complete = 6
     
     // Staged is used by the storage deal protocol to indicate the data has been
     // received and staged into a sector, but is not sealed yet


### PR DESCRIPTION
A change in https://github.com/filecoin-project/go-filecoin/pull/1526 renamed this field from `Proposal` to `ProposalCid`. We also update the formatting in this section to use spaces instead of tabs.