### PR TITLE
Add Miner Address to Storage Deal

### DIFF
--- a/network-protocols.md
+++ b/network-protocols.md
@@ -99,6 +99,9 @@ type StorageDealProposal struct {
     // miner using on-chain information.
     Payment PaymentInfo
 
+    // MinerAddress is the address of the storage miner in the deal proposal
+    MinerAddress Address
+
     ClientAddress Address
     Signature Signature
 }


### PR DESCRIPTION
Add miner address to storage deal to allow multiple, non-duplicate deals
from the same client with the same data and different miners.

Part of resolving https://github.com/filecoin-project/go-filecoin/issues/1143.