### PR TITLE
Add ChannelMsgCid to PaymentInfo network data structure

### DIFF
--- a/network-protocols.md
+++ b/network-protocols.md
@@ -118,7 +118,7 @@ type PaymentInfo struct {
     // ChannelMsgCid is the B58 encoded CID of the message used to create the
     // channel. Adding the message cid allows the miner to wait until the
     // channel is accepted on chain.
-    ChannelMsgCid string
+    ChannelMsgCid cid.Cid
 
     // Vouchers is a set of payments from the client to the miner that can be
     // cashed out contingent on the agreed upon data being provably within a


### PR DESCRIPTION
### Problem

Storage proposals are sent directly to miners off chain, but payments to the miner are made through a payment channel that is created on chain. Clients can create payments and propose a deal as a single command and there's no guarantee the payment channel will appear on chain (for the miner) before the miner receives the proposal even if the client waits for the channel to appear on chain locally.

### Solution

Add the message cid of the payment channel creation command to the `DealProposal`'s `PaymentInfo`. This way the miner can wait for the payment channel using existing message waiting functionality.

Note, the proposal is cbor encoded before sending and cbor encoding treats Cid's as links (which would be broken in this case), so the Cid is sent as a string.