### PR TITLE
 rm dup protection from deal proposals

### DIFF
--- a/network-protocols.md
+++ b/network-protocols.md
@@ -87,13 +87,6 @@ type StorageDealProposal struct {
     // Duration is how long the file should be stored for
     Duration NumBlocks
 
-    // LastDuplicate is a string of the CID of the last proposal created with
-    // identical values. This field effectively changes the CID of the current
-    // proposal, preventing collisions. This field can also be used for looking
-    // up previous proposals, however it will not be considered a reliable
-    // source for this information as data can be lost.
-    LastDuplicate String
-
     // PaymentRef is a reference to the mechanism that the proposer
     // will use to pay the miner. It should be verifiable by the
     // miner using on-chain information.


### PR DESCRIPTION
this is no longer necessary as payment channels make proposals unique. also, this is a nice to have feature for users, not really something that we should encode in spec. as part of https://github.com/filecoin-project/go-filecoin/issues/1853 we are going to move to a softer version of this i think, just checking for piece id and miner are the same. in any case, it is not protocol affecting its entirely on the implementation whethre it wants to be careful or not.