### PR TITLE
Add spec for multisig actor wallet

### DIFF
--- a/actors.md
+++ b/actors.md
@@ -877,6 +877,27 @@ func RemoveSigner(signer Address) {
 }
 ```
 
+### SwapSigner
+
+```go
+func SwapSigner(old, new Address) {
+  if msg.From != self.Address {
+    Fatal("swap signer must be called by wallet itself")
+  }
+  if !isSigner(old) {
+    Fatal("given old address was not a signer")
+  }
+  if isSigner(new) {
+    Fatal("given new address was already a signer")
+  }
+
+  self.Signers.Remove(old)
+  self.Signers.Append(new)
+}
+```
+
+
+
 ### ChangeRequirement
 
 ```go

--- a/actors.md
+++ b/actors.md
@@ -740,6 +740,15 @@ type Transaction struct {
 
 #### Constructor
 
+>  This method sets up the initial state for the multisig account
+
+#### Parameters
+
+| Name     | Type       | Description                                         |
+| -------- | ---------- | ------------------------------------------------------------ |
+| `signers`   | `[]Address`      | The addresses that will be the signatories of this wallet. |
+| `required` | `uint` | The number of signatories required to perform a transaction.       |
+
 ```go
 func Multisig(signers []Address, required uint) {
     self.Signers = signers
@@ -750,6 +759,15 @@ func Multisig(signers []Address, required uint) {
 
 
 ### Propose
+
+> Propose is used to propose a new transaction to be sent by this multisig. The proposer must be a signer, and the proposal also serves as implicit approval from the proposer. If only a single signature is required, then the transaction is executed immediately.
+
+| Name     | Type       | Description  |
+| --- | --- | --- |
+| `to` |  `Address` | The address of the target of the proposed transaction. |
+|  `value` | `TokenAmount` | The amount of funds to send with the proposed transaction |
+|  `method` | `string` | The method that will be invoked on the proposed transactions target. |
+| `params` | `[]byte` | The parameters that will be passed to the method invocation on the proposed transactions target. |
 
 ```go
 func Propose(to Address, value TokenAmount, method string, params []byte) uint64 {
@@ -781,6 +799,13 @@ func Propose(to Address, value TokenAmount, method string, params []byte) uint64
 ```
 
 ### Approve
+
+> Approve is called by a signer to approve a given transaction. If their approval pushes the approvals for this transaction over the threshold, the transaction is executed.
+
+| Name     | Type       | Description  |
+| --- | --- | --- |
+| `txid` |  `uint64` | The ID of the transaction to approve. |
+
 
 ```go
 func Approve(txid uint64) {


### PR DESCRIPTION
In order to provide a reasonable solution to holding filecoin at launch, we add a multisig account actor.

The design is modeled after the [gnosis multisig wallet](https://github.com/gnosis/MultiSigWallet/blob/master/contracts/MultiSigWallet.sol), but with only the bare minimum of features (no spend limits or anything funky).

Some design choices that may be worth discussing:

* Transactions are kept around after being executed or canceled, and cleared later by an explicit call to clear transactions. This is done to make auditing easier, seeing transaction history simply requires a lookup in the current state tree, as opposed to crawling back through the chain (being more friendly to lite clients). The alternative is to remove the transaction from the actor state as soon as it is finished. I'm on the fence about which option is best.

* Transactions may be canceled by any of the signers. This seems the simplest approach, though if a signer were to be 'rogue' then they could make it very difficult to spend any funds, or even remove them as a signer. This could be circumvented by asking a miner to mine their transactions all at the same time, preventing the rogue signer from cancelling it. One alternative is to just not have cancelations, and let the 'bad' transaction just hang out forever (bad solution IMO). Another would be to implement some 'required threshold' for canceling a request, this feels a little heavy to me but I could be convinced.

* Self modification methods (add/rm signer, change req) are implemented by doing a multisig transaction invoking the desired method on the contract itself. This means we only have to implement the 'signature threshold' logic in one place, and is generally simpler to reason about. If someone has strong feelings about this, i'm open to discuss.