### PR TITLE
add payer to PaymentInfo

### DIFF
--- a/network-protocols.md
+++ b/network-protocols.md
@@ -105,7 +105,7 @@ type PaymentInfo struct {
     PayChActor Address
 
     // Payer is the address of the owner of the payment channel
-    Payer address.Address
+    Payer Address
 
     // Channel is the ID of the specific channel the client will
     // use to pay the miner. It must already have sufficient funds locked up


### PR DESCRIPTION
The `DealProposal` does not currently contain the address of the client's account actor. We need this address both to locate the payment channel used for payment and to validate the signatures of the payment vouchers. This PR adds `Payer` to the `PaymentInfo` section of the deal proposal.