### PR TITLE
faster chain sync protocol, interem solution

### DIFF
--- a/network-protocols.md
+++ b/network-protocols.md
@@ -375,3 +375,48 @@ type RetrievePieceChunk struct {
 ```
 
 TODO: document the query deal interaction
+
+# BlockSync
+
+The blocksync protocol is a small protocol that allows Filecoin nodes to request ranges of blocks from each other. It is a simple request/response protocol with a protocol ID of `/fil/sync/blk/0.0.0`. It uses CBOR-RPC.
+
+```go
+type BlockSyncRequest struct {
+    Start Cid
+    RequestLength uint64
+}
+```
+
+The request requests a chain of a given length by the hash of its highest block.
+
+```go
+type BlockSyncResponse struct {
+    Blocks []Block
+    
+    Status uint
+    Message string
+}
+```
+
+The response contains the chain of requested blocks, in reverse iteration order, the zero'th block should be the block referenced by `request.Start`, and the following N blocks should be its N parents, and so on. This is done to streamline validation.
+
+Possible error codes:
+
+```go
+const (
+	Success = 0
+    
+    // Sent back fewer blocks than requested
+    PartialResponse = 101
+    
+    // request.Start not found
+    BlockNotFound = 201
+    
+    // requester is making too many requests
+    GoAway = 202
+    
+    // Internal Error
+    InternalError = 203
+)
+```
+

--- a/operation.md
+++ b/operation.md
@@ -28,7 +28,11 @@ Listen for messages on the messages pubsub channel (See [message propagation](da
 - Run the DHT protocol for aiding node discovery
   - libp2p-kad-dht, with just 'find node' RPCs enabled.
 
+## Bitswap for data requests
 
+Run bitswap to fetch and serve data (such as messages) to and from other filecoin nodes. This is used to fill in missing bits during block propogation, and also to fetch data during sync.
+
+There is not yet an official spec for bitswap, but [the protobufs](https://github.com/ipfs/go-bitswap/blob/master/message/pb/message.proto) should help in the interim.
 
 ## Mining
 

--- a/sync.md
+++ b/sync.md
@@ -81,6 +81,7 @@ func (syncer *Syncer) SyncBootstrap() {
     // Fetch all the messages for all the blocks in this chain
     // There are many ways to make this more efficient. For now, do the dumb thing
     blockSet.ForEach(func(b Block) {
+        // FetchMessages should use bitswap to fetch any messages we don't have locally
         FetchMessages(b)
     })
     
@@ -151,7 +152,8 @@ func (syncer *Syncer) SyncCaughtUp(maybeHead TipSet) error {
 
 
 func (syncer *Syncer) collectChainCaughtUp(maybeHead TipSet) (Chain, error) {
-	ts := tipsetFromCidOverNet(newHead) // lookup over network
+	// fetch tipset and messages via bitswap
+	ts := tipsetFromCidOverNet(newHead) 
 
 	var chain Chain
 	for {
@@ -163,7 +165,8 @@ func (syncer *Syncer) collectChainCaughtUp(maybeHead TipSet) (Chain, error) {
 
 		chain.InsertFront(ts)
 
-		if syncer.store.Contains(ts) { // Store has record of this tipset.
+		if syncer.store.Contains(ts) { 
+			// Store has record of this tipset.
 			return chain, nil
 		}
 		parent := ts.ParentCid()

--- a/sync.md
+++ b/sync.md
@@ -17,49 +17,119 @@ type Syncer struct {
 
 	// The known genesis tipset
 	genesis TipSet
+    
+    // the current mode the syncer is in
+    syncMode SyncMode
 
 	// TipSets known to be invalid
 	bad BadTipSetCache
+    
+    // handle to the block sync service
+    bsync BlockSync
+    
+    // peer heads
+    // Note: clear cache on disconnects
+    peerHeads map[PeerID]Cid
+}
+
+const BootstrapPeerThreshold = 5
+
+// InformNewHead informs the syncer about a new potential tipset
+// This should be called when connecting to new peers, and additionally
+// when receiving new blocks from the network
+func (syncer *Syncer) InformNewHead(from PeerID, head TipSet) {
+    switch syncer.syncMode {
+    case Bootstrap:
+        go SyncBootstrap(from, head)
+    case CaughtUp:
+        go syncer.SyncCaughtUp(blk)
+    }
 }
 
 // SyncBootstrap is used to synchronise your chain when first joining
 // the network, or when rejoining after significant downtime.
-func (syncer *Syncer) SyncBootstrap(newHead TipSet) error {
-	chain := syncer.collectChainBootstrap(newHead)
-
-	for _, ts := range chain {
-		// Fetch the messages for the tipset now, so that we can properly
-		// validate the state transitions.
-		ts.FetchMessages()
-
-		if err := consensus.Validate(ts, store); err != nil {
-			return err
-		}
-		syncer.store.PutTipSet(ts)
-	}
-
-	syncer.head = chain.End()
-
-	return nil
+func (syncer *Syncer) SyncBootstrap() {
+    syncer.syncLock.Lock()
+    defer syncer.syncLock.Unlock()
+    syncer.peerHeads[from] = head
+    if len(syncer.peerHeads) < BootstrapPeerThreshold {
+        // not enough peers to sync yet...
+        return
+    }
+    
+    selectedHead := selectHead(syncer.peerHeads)
+    
+    cur := selectedHead
+    var blockSet BlockSet
+    for head.Height() > 0 {
+        // NB: GetBlocks validates that the blocks are in-fact the ones we
+        // requested, and that they are correctly linked to eachother. It does
+        // not validate any state transitions
+        blks := syncer.bsync.GetBlocks(head, RequestWidth)
+        blockSet.Insert(blks)
+            
+        head = blks.Last().Parents()
+    }
+    
+    genesis := blockSet.GetByHeight(0)
+    if genesis != syncer.genesis {
+        // TODO: handle this...
+        Error("We synced to the wrong chain!")
+        return
+    }
+    
+    // Fetch all the messages for all the blocks in this chain
+    // There are many ways to make this more efficient. For now, do the dumb thing
+    blockSet.ForEach(func(b Block) {
+        FetchMessages(b)
+    })
+    
+    // Now, to validate some state transitions
+    base := genesis
+    for i := 1; i < selectedHead.Height(); i++ {
+        next := blockSet.GetByHeight(i)
+        if !ValidateTransition(base, next) {
+            // TODO: do something productive here...
+            Error("invalid state transition")
+            return
+        }
+    }
+    
+    blockSet.PersistTo(syncer.store)
+    syncer.head = bset.Head()
+    syncer.syncMode = CaughtUp
 }
 
-func (syncer *Syncer) collectChainBootstrap(newHead types.SortedCidSet) Chain {
-	var chain Chain
+func selectHead(heads map[PeerID]TipSet) TipSet {
+    headsArr := toArray(heads)
+    sel := headsArr[0]
+    for i := 1; i < len(headsArr); i++ {
+        cur := headsArr[i]
+        
+        if cur.IsAncestorOf(sel) {
+            continue
+        }
+        if sel.IsAncestorOf(cur) {
+            sel = cur
+            continue
+        }
+        
+        nca := NearestCommonAncestor(cur, sel)
+        if sel.Height() - nca.Height() > ForkLengthThreshold {
+        	// TODO: handle this better than refusing to sync
+        	Fatal("Conflict exists in heads set")
+        }
 
-	for cur := newHead; !cur.Equals(syncer.Genesis); {
-		ts := tipsetFromCidOverNet(cur) // lookup over network
-
-		chain.InsertFront(ts)
-
-		cur = ts.Parent()
-	}
-
-	return chain
+        if cur.Weight() > sel.Weight() {
+            sel = cur
+        }
+    }
+    return sel
 }
 
 // SyncCaughtUp is used to stay in sync once caught up to
 // the rest of the network.
-func (syncer *Syncer) SyncCaughtUp(maybeHead types.SortedCidSet) error {
+func (syncer *Syncer) SyncCaughtUp(maybeHead TipSet) error {
 	chain, err := syncer.collectChainCaughtUp(maybeHead)
 	if err != nil {
 		return err
@@ -108,7 +178,7 @@ func (syncer *Syncer) collectChainCaughtUp(maybeHead TipSet) (Chain, error) {
 ## Syncing Mode
 A filecoin node syncs in `syncing` mode when entering the network for the first time, or after being separated for a sufficiently long period of time.  The exact period of time comes from the consensus protocol (TODO specify more concretely, for example how does this relate to the consensus.Punctual method?).
 
-During `syncing` mode a node learns about the newest head of the blockchain through the secure bootstrapping protocol. (TODO: specify our security model and the bootstrapping protocol.).  The syncing protocol then traverses the links by fetching parents from the network.  After caching the chain up to the genesis block (which is known as a protocol parameter), the syncing protocol validates the chain tipset by tipset using consensus validation rules.  If validation passes the node's head is updated to the head tipset received from bootstrapping.
+During `syncing` mode a node learns about the newest head of the blockchain through the secure bootstrapping protocol. The syncing protocol then syncs the block headers for that entire chain, and validates their linking. It then fetches all the messages for the chain, and checks all the state transitions between the blocks and that the blocks were correctly created.  If validation passes the node's head is updated to the head tipset received from bootstrapping.
 
 In this mode of operation a filecoin node should not mine or send messages as it will not be able to successfully generate heaviest blocks or reference the correct state of the chain to verify that messages will execute as expected.
 


### PR DESCRIPTION
We don't yet have graphsync, which would help us avoid having to write our own custom protocol here. But its not that much overhead. The changes to the sync process will still work fine once we have graphsync too.

This isnt as fast as some other chain sync protocols, but its quite simple, and low-trust (downloading a potentially large snapshot is how other protocols gain speed here, but that requires a bit of trust in the other party to not send bad data). There are many improvements we can make, but I think we should opt for simple and fast to implement for now.