### PR TITLE
Init actor sketch

### DIFF
--- a/actors.md
+++ b/actors.md
@@ -4,8 +4,45 @@ Any implementations of the Filecoin actors must be exactly byte for byte compati
 
 This spec decsribes a set of actors that operate within the [Filecoin State Machine](state-machine.md). All types are defined in [the basic type encoding spec](data-structures.md#basic-type-encodings).
 
+
 - [Storage Market Actor](#storage-market-actor)
 - [Storage Miner Actor](#storage-miner-actor)
+
+## Init Actor
+The init actor is responsible for creating new actors on the filecoin network. This is a built-in actor and cannot be replicated. In the future, this actor will be responsible for loading new code into the system (for user programmable actors).
+
+```go
+type InitActor struct {
+    NextActorID uint64
+}
+```
+
+#### Exec
+
+Parameters:
+
+- code Cid
+- params []byte
+
+TODO: the type of params should probably just be variadic set of arguments. Making it be a `[]byte` here kinda sucks
+
+```go
+func Exec(code Cid, params []byte) Address {
+    actorID := self.NextActorID
+    self.NextActorID++
+
+    if code == InitActorCodeCid {
+        Fatal("cannot launch additional init actor instance")
+    }
+
+    addr := VM.CreateActor(code, msg.Value, DecodeParams(params))
+
+    // TODO: where is this mapping stored?
+    SetIDMapping(actorID, addr)
+
+    return addr
+}
+```
 
 ## Storage Market Actor
 
@@ -38,12 +75,12 @@ func CreateStorageMiner(pubkey PublicKey, pledge BytesAmount, pid PeerID) Addres
     if pledge < MinimumPledge {
         Fatal("Pledge too low")
     }
-    
+
     if msg.Value < MinimumCollateral(pledge) {
         Fatal("not enough funds to cover required collateral")
     }
-    
-    newminer := VM.CreateActor(MinerActor, msg.Value, pubkey, pledge, pid)
+
+    newminer := InitActor.Exec(MinerActorCodeCid, EncodeParams(pubkey, pledge, pid))
 
     self.Miners.Add(newminer)
 
@@ -65,22 +102,22 @@ func SlashConsensusFault(block1, block2 BlockHeader) {
 	if block1.Height != block2.Height {
         Fatal("cannot slash miner for blocks of differing heights")
     }
-    
+
     if !ValidateSignature(block1.Signature) || !ValidateSignature(block2.Signature) {
         Fatal("Invalid blocks")
     }
-    
+
     if AuthorOf(block1) != AuthorOf(block2) {
         Fatal("blocks must be from the same miner")
     }
-    
+
     miner := AuthorOf(block1)
-    
+
     // TODO: Some of the slashed collateral should be paid to the slasher
-    
+
     // Burn all of the miners collateral
     miner.BurnCollateral()
-    
+
     // Remove the miner from the list of network miners
     self.Miners.Remove(miner)
     self.UpdateStorage(-1 * miner.Power)
@@ -105,7 +142,7 @@ func UpdateStorage(delta Integer) {
     if !self.Miners.Has(msg.From) {
         Fatal("update storage must only be called by a miner actor")
     }
-    
+
     self.TotalStorage += delta
 }
 ```
@@ -168,7 +205,7 @@ type StorageMiner struct {
     // being 'done'. The collateral for them is still being held until the next PoSt
     // submission in case early sector removal penalization is needed.
     NextDoneSet SectorSet
-    
+
     // ArbitratedDeals is the set of deals this miner has been slashed for since the
     // last post submission
     ArbitratedDeals CidSet
@@ -189,7 +226,7 @@ func StorageMinerActor(pubkey PublicKey, pledge BytesAmount, pid PeerID) {
     if msg.Value < CollateralForPledgeSize(pledge) {
         Fatal("not enough collateral given")
     }
-    
+
     self.Owner = message.From
     self.PublicKey = pubkey
     self.PeerID = pid
@@ -200,7 +237,7 @@ func StorageMinerActor(pubkey PublicKey, pledge BytesAmount, pid PeerID) {
 
 ### AddAsk
 
-Parameters: 
+Parameters:
 - price TokenAmount
 - ttl Integer
 
@@ -211,19 +248,19 @@ func AddAsk(price TokenAmount, ttl Integer) AskID {
     if msg.From != self.Worker {
         Fatal("Asks may only be added via the worker address")
     }
-    
+
     // Filter out expired asks
     self.Asks.FilterExpired()
-    
+
     askid := self.NextAskID
     self.NextAskID++
-    
+
     self.Asks.Append(Ask{
         Price: price,
         Expiry: CurrentBlockHeight + ttl,
         ID: askid,
     })
-    
+
     return askid
 }
 ```
@@ -249,29 +286,29 @@ func CommitSector(comm Commitment, proof *SealProof) SectorID {
     if !miner.ValidatePoRep(comm, miner.PublicKey, proof) {
         Fatal("bad proof!")
     }
-    
+
     // make sure the miner isnt trying to submit a pre-existing sector
     if !miner.EnsureSectorIsUnique(comm) {
         Fatal("sector already committed!")
     }
-    
+
     // make sure the miner has enough collateral to add more storage
     // currently, all sectors are the same size, and require the same collateral
     // in the future, we may have differently sized sectors and need special handling
     coll = CollateralForSector()
-    
+
     if coll < miner.Collateral {
         Fatal("not enough collateral")
     }
-    
+
     miner.Collateral -= coll
     miner.ActiveCollateral += coll
-    
+
     sectorId = miner.Sectors.Add(commR)
     // TODO: sectors IDs might not be that useful. For now, this should just be the number of
     // the sector within the set of sectors, but that can change as the miner experiences
     // failures.
-    
+
     // if miner is not mining, start their proving period now
     // Note: As written here, every miners first PoSt will only be over one sector.
     // We could set up a 'grace period' for starting mining that would allow miners
@@ -281,7 +318,7 @@ func CommitSector(comm Commitment, proof *SealProof) SectorID {
        miner.ProvingSet = miner.Sectors
        miner.ProvingPeriodEnd = chain.Now() + ProvingPeriodDuration
     }
-    
+
     return sectorId
 }
 ```
@@ -302,68 +339,68 @@ func SubmitPost(proofs []PoStProof, faults []FaultSet, recovered BitField, done 
     if msg.From != miner.Worker {
         Fatal("not authorized to submit post for miner")
     }
-    
+
     // ensure the fault sets properly stack, recovered is a subset of the combined
     // fault sets, and that done does not intersect with either, and that all sets
     // only reference sectors that currently exist
     if !miner.ValidateFaultSets(faults, recovered, done) {
         Fatal("fault sets invalid")
     }
-    
+
     var feesRequired TokenAmount
-    
+
     if chain.Now() > miner.ProvingPeriodEnd + GenerationAttackTime {
         // TODO: determine what exactly happens here. Is the miner permanently banned?
         Fatal("Post submission too late")
     } else if chain.Now() > miner.ProvingPeriodEnd {
         feesRequired += ComputeLateFee(chain.Now() - miner.ProvingPeriodEnd)
     }
-    
+
     feesRequired += ComputeTemporarySectorFailureFee(recovered)
-    
+
     if msg.Value < feesRequired {
         Fatal("not enough funds to pay post submission fees")
     }
-    
+
     // we want to ensure that the miner can submit more fees than required, just in case
     if msg.Value > feesRequired {
         Refund(msg.Value - feesRequired)
     }
-    
+
 
     if !CheckPostProofs(proofs, faults) {
         Fatal("proofs invalid")
     }
-    
+
     permLostSet = AggregateBitfields(faults).Subtract(recovered)
-    
+
     // adjust collateral for 'done' sectors
     miner.ActiveCollateral -= CollateralForSectors(miner.NextDoneSet)
     miner.Collateral += CollateralForSectors(miner.NextDoneSet)
-    
+
     // penalize collateral for lost sectors
     miner.ActiveCollateral -= CollateralForSectors(permLostSet)
-    
+
     // burn funds for fees and collateral penalization
     BurnFunds(miner, CollateralForSectors(permLostSet) + feesRequired)
-    
+
     // update sector sets and proving set
     miner.Sectors.Subtract(done)
     miner.Sectors.Subtract(permLostSet)
-    
+
     // update miner power to the amount of data actually proved during
     // the last proving period.
     oldPower := miner.Power
     miner.Power = SizeOf(Filter(miner.ProvingSet, faults))
     StorageMarket.UpdateStorage(miner.Power - oldPower)
-    
+
     miner.ProvingSet = miner.Sectors
-    
+
     // NEEDS REVIEW: early submission of PoSts may give the miner extra time for
     // their next PoSt, which could compound. Does the beacon reseeding for Posts
     // address this well enough?
     miner.ProvingPeriodEnd = miner.ProvingPeriodEnd + ProvingPeriodDuration
-    
+
     // update next done set
     miner.NextDoneSet = done
     miner.ArbitratedDeals.Clear()
@@ -385,7 +422,7 @@ func IncreasePledge(addspace BytesAmount) {
     if miner.Collateral + msg.Value < CollateralForPledge(addspace + miner.PledgeBytes) {
         Fatal("not enough total collateral for the requested pledge")
     }
-    
+
     miner.Collateral += msg.Value
     miner.PledgeBytes += addspace
 }
@@ -404,22 +441,22 @@ func SlashStorageFault() {
 	if self.SlashedAt > 0 {
         Fatal("miner already slashed")
 	}
-	
+
     if chain.Now() <= miner.ProvingPeriodEnd + GenerationAttackTime {
     	Fatal("miner is not yet tardy")
     }
-    
+
     if miner.ProvingSet.Size() == 0 {
         Fatal("miner is inactive")
     }
-    
+
     // Strip miner of their power
     StorageMarketActor.UpdateStorage(-1 * self.Power)
     self.Power = 0
-    
+
     // TODO: make this less hand wavey
     BurnCollateral(self.ConsensusCollateral)
-    
+
     self.SlashedAt = CurrentBlockHeight
 }
 ```
@@ -452,31 +489,31 @@ func AbitrateDeal(d Deal) {
     if !ValidateSignature(d, self.Worker) {
         Fatal("invalid signature on deal")
     }
-    
+
     if CurrentBlockHeight < d.StartTime {
         Fatal("Deal not yet started")
     }
-    
+
     if d.Expiry < CurrentBlockHeight {
         Fatal("Deal is expired")
     }
-    
+
     if !self.NextDoneSet.Has(d.PieceCommitment.Sector) {
-        Fatal("Deal agreement not broken, or arbitration too late") 
+        Fatal("Deal agreement not broken, or arbitration too late")
     }
-    
+
     if self.ArbitratedDeals.Has(d.PieceRef) {
         Fatal("cannot slash miner twice for same deal")
     }
-    
+
     pledge, storage := CollateralForDeal(d)
-    
+
     // burn the pledge collateral
     self.BurnFunds(pledge)
-    
+
     // pay the client the storage collateral
     TransferFunds(d.ClientAddr, storage)
-    
+
     // make sure the miner can't be slashed twice for this deal
     self.ArbitratedDeals.Add(d.PieceRef)
 }
@@ -497,22 +534,22 @@ func DePledge(amt TokenAmount) {
     if msg.From != miner.Worker && msg.From != miner.Owner {
         Fatal("Not authorized to call DePledge")
     }
-    
+
     if miner.DePledgeTime > 0 {
         if miner.DePledgeTime > CurrentBlockHeight {
             Fatal("too early to withdraw collateral")
         }
-        
+
         TransferFunds(miner.Owner, miner.DePledgedCollateral)
         miner.DePledgeTime = 0
         miner.DePledgedCollateral = 0
         return
     }
-    
+
     if amt > miner.Collateral {
         Fatal("Not enough free collateral to withdraw that much")
     }
-    
+
     miner.Collateral -= amt
     miner.DePledgedCollateral = amt
     miner.DePledgeTime = CurrentBlockHeight + DePledgeCooldown
@@ -591,7 +628,7 @@ func UpdatePeerID(pid PeerID) {
     if msg.From != self.Worker {
         Fatal("only the mine worker may update the peer ID")
     }
-    
+
     self.PeerID = pid
 }
 ```
@@ -599,6 +636,3 @@ func UpdatePeerID(pid PeerID) {
 ## Payment Channel Broker Actor
 
 TODO
-
-
-

--- a/actors.md
+++ b/actors.md
@@ -2,11 +2,14 @@
 
 Any implementations of the Filecoin actors must be exactly byte for byte compatible with the go-filecoin actor implementations. The pseudocode below tries to capture the important logic, but capturing all the detail would require embedding exactly the code from go-filecoin, so for now, its simply informative pseudocode. The algorithms below are correct, and all implementations much match it (including go-filecoin), but details omitted from here should be looked for in the go-filecoin code.
 
-This spec decsribes a set of actors that operate within the [Filecoin State Machine](state-machine.md). All types are defined in [the basic type encoding spec](data-structures.md#basic-type-encodings).
+This spec describes a set of actors that operate within the [Filecoin State Machine](state-machine.md). All types are defined in [the basic type encoding spec](data-structures.md#basic-type-encodings).
 
 
+- [Init Actor](#init-actor)
 - [Storage Market Actor](#storage-market-actor)
 - [Storage Miner Actor](#storage-miner-actor)
+- [Payment Channel Broker Actor](#payment-channel-broker-actor)
+
 
 ## Init Actor
 The init actor is responsible for creating new actors on the filecoin network. This is a built-in actor and cannot be replicated. In the future, this actor will be responsible for loading new code into the system (for user programmable actors).
@@ -34,7 +37,6 @@ type InitActor struct {
 `Param` is the type representing any valid arugment that can be passed to a function.
 
 TODO: Find a better place for this definition.
-
 
 
 ```go

--- a/state-machine.md
+++ b/state-machine.md
@@ -15,7 +15,7 @@ Second, an `actor` may call a method on another actor during the invocation of o
 
 ### State Representation
 
-The `global state` is modeled as a map of actor addresses to actor structs. This map is implemented by an ipld HAMT (TODO: link to spec for our HAMT). Each actor's `state` is an ipld pointer to a graph that can be entirely defined by the actor.
+The `global state` is modeled as a map of actor `ID`s to actor structs. This map is implemented by an ipld HAMT (TODO: link to spec for our HAMT). Each actor's `state` is an ipld pointer to a graph that can be entirely defined by the actor.
 
 ### Execution (Calling a method on an Actor)
 
@@ -37,9 +37,8 @@ type VMContext interface {
 	// BlockHeight returns the height of the block this message was added to the chain in
 	BlockHeight() *types.BlockHeight
 
-	// CreateNewActor is used to create a new actor from the given code and constructor
-    // parameters (TODO: address should probably not be a parameter)
-	CreateNewActor(addr address.Address, code cid.Cid, initalizationParams interface{}) error
+	// CreateNewActor is used to create a new actor from the given code and constructor.
+	CreateNewActor(id BigInt, code cid.Cid, initalizationParams []Param) error
 }
 ```
 

--- a/state-machine.md
+++ b/state-machine.md
@@ -1,6 +1,6 @@
 # The Filecoin State Machine
 
-The majority of Filecoin's user facing functionality (payments, storage market, power table, etc) is managed through the Filecoin State Machine. The network generates a series of blocks, and agrees which 'chain' of blocks is the correct one. Each block contains a series of state transitions called `messages`, and a checkpoint of the current `global state` after the application of those `messages`. 
+The majority of Filecoin's user facing functionality (payments, storage market, power table, etc) is managed through the Filecoin State Machine. The network generates a series of blocks, and agrees which 'chain' of blocks is the correct one. Each block contains a series of state transitions called `messages`, and a checkpoint of the current `global state` after the application of those `messages`.
 
 The `global state` here consists of a set of `actors`, each with their own private `state`.
 
@@ -27,13 +27,13 @@ These functions are given, as input, an `ExecutionContext` containing useful inf
 type VMContext interface {
 	// Message is the message that kicked off the current invocation
 	Message() Message
-	
+
 	// Storage provides access to the VM storage layer
 	Storage() Storage
-	
+
 	// Send allows the current execution context to invoke methods on other actors in the system
 	Send(to address.Address, method string, value *types.AttoFIL, params []interface{}) ([][]byte, uint8, error)
-	
+
 	// BlockHeight returns the height of the block this message was added to the chain in
 	BlockHeight() *types.BlockHeight
 
@@ -49,7 +49,7 @@ If the execution completes successfully, changes to the state tree are saved. Ot
 func ApplyMessage(st StateTree, msg Message) MessageReceipt {
     st.Snapshot()
     fromActor := st.GetActor(msg.From)
-    
+
     totalCost := msg.Value + (msg.GasLimit * msg.GasPrice)
     if fromActor.Balance < totalCost {
         Fatal("not enough funds")
@@ -58,12 +58,12 @@ func ApplyMessage(st StateTree, msg Message) MessageReceipt {
 	if msg.Nonce() != fromActor.Nonce + 1 {
 		Fatal("invalid nonce")
 	}
-    
+
     st.DeductFunds(msg.From, totalCost)
     st.DepositFunds(msg.To, msg.Value)
-    
+
     vmctx := makeVMContext(st, msg)
-    
+
     ret, errcode := fromActor.Invoke(vmctx, msg.Method, msg.Params)
     if errcode != 0 {
         // revert all state changes since snapshot
@@ -73,10 +73,10 @@ func ApplyMessage(st StateTree, msg Message) MessageReceipt {
         // refund unused gas
         st.DepositFunds(msg.From, (msg.GasLimit - vmctx.GasUsed()) * msg.GasPrice)
     }
-    
+
     // reward miner gas fees
     st.DepositFunds(msg.To, msg.GasPrice * vmctx.GasUsed())
-    
+
     return MessageReceipt{
         ExitCode: errcode,
         Return: ret,
@@ -99,29 +99,28 @@ Actors are given acess to a `Storage` interface to fulfil their need for persist
 type Storage interface {
 	// Put writes the given object to the storage staging area and returns its CID
 	Put(interface{}) (Cid, error)
-    
+
 	// Get fetches the given object from storage (either staging, or local) and returns
 	// the serialized data.
 	Get(Cid) ([]byte, error)
-    
+
 	// Commit updates the actual stored state for the actor. This is a compare and swap
 	// operation, and will fail if 'old' is not equal to the current return value of `Head`.
 	// This functionality is used to prevent issues with re-entrancy
 	Commit(old Cid, new Cid) error
-    
+
 	// Head returns the CID of the current actor state
 	Head() Cid
 }
 ```
 
-Actors can store state as a single block or implement any persistent 
-data structure that can be built upon a content addressed block store. 
-Implementations may provide data structure implementations to simplify 
-development. The current interface only supports CBOR-IPLD, but this 
+Actors can store state as a single block or implement any persistent
+data structure that can be built upon a content addressed block store.
+Implementations may provide data structure implementations to simplify
+development. The current interface only supports CBOR-IPLD, but this
 should soon expand to allow other types of IPLD data structures (as long
 as the system has resolvers for them).
 
 The current state of a given actor can be accessed first by calling `Head` to retrieve the CID of the root of the actors state, then by using `Get` to retrieve the actual object being referenced.
 
 To store data, `Put` is used. Any number of objects may be `Put`, but only the object whose CID is committed, or objects that are linked to in some way by the committed object will be kept. All other objects are dropped after the method invocation returns. Objects stored via `Put` are first marshaled to CBOR-IPLD, and then stored, the returned CID is a 32 byte sha2-256 CBOR-IPLD content identifier.
-


### PR DESCRIPTION
Working on the init actor (we've only been talking about it for two years at this point). This will be the new way to create actors (answering questions for other PRs that needs to be able to create actors), it will also track and allocate actor IDs (though there may be some arguments for not tracking it here, i'll go through that later).

With this, we also remove the 'create actor' from the VM context, cleaning that logic up a bit. The weirdness now is that the init actor is a 'priveleged' actor, in that it can make calls that no other actor can make.