### PR TITLE
add PoStProof description and note size of arrays

### DIFF
--- a/data-structures.md
+++ b/data-structures.md
@@ -207,7 +207,11 @@ BlockHeader is a serialized `Block`.
 
 #### `SealProof`
 
-SealProof is an array of bytes.
+SealProof is a 384-element array of bytes.
+
+#### `PoStProof`
+
+PoStProof is a 192-element array of bytes.
 
 #### `TokenAmount`
 


### PR DESCRIPTION
## What's in this PR?

- adds `PoStProof` and `SealProof` to data structures section of spec