### PR TITLE
(proposal) actor updates to support multiple sector sizes

### DIFF
--- a/actors.md
+++ b/actors.md
@@ -160,7 +160,7 @@ func CreateStorageMiner(pubkey PublicKey, pledge, sectorSize BytesAmount, pid Pe
 		Fatal("not enough funds to cover required collateral")
 	}
 
-	newminer := InitActor.Exec(MinerActorCodeCid, EncodeParams(pubkey, pledge, pid, sectorSize))
+	newminer := InitActor.Exec(MinerActorCodeCid, EncodeParams(pubkey, pledge, sectorSize, pid))
 
 	self.Miners.Add(newminer)
 

--- a/actors.md
+++ b/actors.md
@@ -405,9 +405,7 @@ func CommitSector(comm Commitment, proof *SealProof) SectorID {
 	}
 
 	// make sure the miner has enough collateral to add more storage
-	// currently, all sectors are the same size, and require the same collateral
-	// in the future, we may have differently sized sectors and need special handling
-	coll = CollateralForSector()
+	coll = CollateralForSector(miner.SectorSize)
 
 	if coll < miner.Collateral {
 		Fatal("not enough collateral")

--- a/actors.md
+++ b/actors.md
@@ -487,14 +487,14 @@ func SubmitPost(proofs []PoStProof, faults []FaultSet, recovered BitField, done 
 	permLostSet = AggregateBitfields(faults).Subtract(recovered)
 
 	// adjust collateral for 'done' sectors
-	miner.ActiveCollateral -= CollateralForSectors(miner.NextDoneSet)
-	miner.Collateral += CollateralForSectors(miner.NextDoneSet)
+	miner.ActiveCollateral -= CollateralForSectors(miner.SectorSize, miner.NextDoneSet)
+	miner.Collateral += CollateralForSectors(miner.SectorSize, miner.NextDoneSet)
 
 	// penalize collateral for lost sectors
-	miner.ActiveCollateral -= CollateralForSectors(permLostSet)
+	miner.ActiveCollateral -= CollateralForSectors(miner.SectorSize, permLostSet)
 
 	// burn funds for fees and collateral penalization
-	BurnFunds(miner, CollateralForSectors(permLostSet)+feesRequired)
+	BurnFunds(miner, CollateralForSectors(miner.SectorSize, permLostSet)+feesRequired)
 
 	// update sector sets and proving set
 	miner.Sectors.Subtract(done)

--- a/actors.md
+++ b/actors.md
@@ -124,8 +124,8 @@ The storage market actor is the central point for the Filecoin storage market. I
 type StorageMarketActor struct {
 	Miners AddressSet
 
-    // TODO: Determine correct unit of measure. Could be denominated in the
-    // smallest sector size supported by the network.
+	// TODO: Determine correct unit of measure. Could be denominated in the
+	// smallest sector size supported by the network.
 	TotalStorage BytesAmount
 }
 ```
@@ -148,9 +148,9 @@ Return: Address
 
 ```go
 func CreateStorageMiner(pubkey PublicKey, pledge, sectorSize BytesAmount, pid PeerID) Address {
-    if !SupportedSectorSize(sectorSize) {
-        Fatal("Unsupported sector size")
-    }
+	if !SupportedSectorSize(sectorSize) {
+		Fatal("Unsupported sector size")
+	}
 
 	if pledge < MinimumPledge(sectorSize) {
 		Fatal("Pledge too low")

--- a/actors.md
+++ b/actors.md
@@ -395,7 +395,7 @@ Return: SectorID
 ```go
 // NotYetSpeced: ValidatePoRep, EnsureSectorIsUnique, CollateralForSector, Commitment
 func CommitSector(comm Commitment, proof *SealProof) SectorID {
-	if !miner.ValidatePoRep(comm, miner.PublicKey, proof) {
+	if !miner.ValidatePoRep(miner.SectorSize, comm, miner.PublicKey, proof) {
 		Fatal("bad proof!")
 	}
 

--- a/actors.md
+++ b/actors.md
@@ -480,7 +480,7 @@ func SubmitPost(proofs []PoStProof, faults []FaultSet, recovered BitField, done 
 		Refund(msg.Value - feesRequired)
 	}
 
-	if !CheckPostProofs(proofs, faults) {
+	if !CheckPostProofs(miner.SectorSize, proofs, faults) {
 		Fatal("proofs invalid")
 	}
 

--- a/actors.md
+++ b/actors.md
@@ -728,6 +728,18 @@ func GetPeerID() PeerID {
 }
 ```
 
+### GetSectorSize
+
+Parameters: None
+
+Return: BytesAmount
+
+```go
+func GetSectorSize() BytesAmount {
+	return self.SectorSize
+}
+```
+
 ### UpdatePeerID
 
 Parameters:

--- a/actors.md
+++ b/actors.md
@@ -287,7 +287,7 @@ type StorageMiner struct {
 	// PledgeBytes is the amount of space being offered by this miner to the network
 	PledgeBytes BytesAmount
 
-	// SectorSize is the amount of space in the sectors committed to the network
+	// SectorSize is the amount of space in each sector committed to the network
 	// by this miner.
 	SectorSize BytesAmount
 

--- a/actors.md
+++ b/actors.md
@@ -124,7 +124,9 @@ The storage market actor is the central point for the Filecoin storage market. I
 type StorageMarketActor struct {
 	Miners AddressSet
 
-	TotalStorage Integer
+    // TODO: Determine correct unit of measure. Could be denominated in the
+    // smallest sector size supported by the network.
+	TotalStorage BytesAmount
 }
 ```
 
@@ -239,12 +241,12 @@ UpdateStorage is used to update the global power table.
 
 Parameters:
 
-- delta Integer
+- delta BytesAmount
 
 Return: None
 
 ```go
-func UpdateStorage(delta Integer) {
+func UpdateStorage(delta BytesAmount) {
 	if !self.Miners.Has(msg.From) {
 		Fatal("update storage must only be called by a miner actor")
 	}
@@ -257,10 +259,10 @@ func UpdateStorage(delta Integer) {
 
 Parameters: None
 
-Return: Integer
+Return: BytesAmount
 
 ```go
-func GetTotalStorage() Integer {
+func GetTotalStorage() BytesAmount {
 	return self.TotalStorage
 }
 ```
@@ -500,7 +502,7 @@ func SubmitPost(proofs []PoStProof, faults []FaultSet, recovered BitField, done 
 	// update miner power to the amount of data actually proved during
 	// the last proving period.
 	oldPower := miner.Power
-	miner.Power = SizeOf(Filter(miner.ProvingSet, faults))
+	miner.Power = SizeOf(Filter(miner.ProvingSet, faults)) * miner.SectorSize
 	StorageMarket.UpdateStorage(miner.Power - oldPower)
 
 	miner.ProvingSet = miner.Sectors
@@ -693,10 +695,10 @@ func GetWorkerAddr() Address {
 
 Parameters: None
 
-Return: Integer
+Return: BytesAmount
 
 ```go
-func GetPower() Integer {
+func GetPower() BytesAmount {
 	return self.Power
 }
 ```

--- a/mining.md
+++ b/mining.md
@@ -44,7 +44,7 @@ TODO: sectors need to be globally unique. This can be done either by having the 
 At the beginning of their proving period, miners collect the proving set (the set of all live sealed sectors on the chain at this point), and then call `ProveStorage`. This process will take the entire proving period to complete.
 
 ```go
-func ProveStorage(sectors []commR, startTime BlockHeight) (PoSTProof, []Fault) {
+func ProveStorage(sectorSize BytesAmount, sectors []commR, startTime BlockHeight) (PoSTProof, []Fault) {
 	var proofs []Proofs
 	var seeds []Seed
 	var faults []Fault
@@ -54,7 +54,7 @@ func ProveStorage(sectors []commR, startTime BlockHeight) (PoSTProof, []Fault) {
 		proofs = append(proofs, proof)
 		faults = append(faults, fault)
 	}
-	return GenPostSnark(sectors, seeds, proofs), faults
+	return GenPostSnark(sectorSize, sectors, seeds, proofs), faults
 }
 ```
 


### PR DESCRIPTION
## What's in this PR?

This PR proposes updates to the `StorageMarketActor` and `StorageMinerActor`s to support multiple sector sizes.

## Summary of Changes

1. `CreateStorageMiner` modified to accept a sector size. Sector size cannot be changed after miner actor has been created. Rationale: One sector size per storage miner implies one proving period per miner.
1. `StorageMarketActor.TotalStorage` tracked as `BytesAmount` instead of `Integer` (`UpdateStorage` and `GetTotalStorage` have been updated, too). Rationale: Miners will commit sectors of different sizes. A miner who commits a single, 10GB sector to the network must have the same power as a miner who has committed ten, 1GB sectors.
1. `CollateralForSector` now accepts a sector size.
1.  `ProvingPeriodDuration` and `GenerationAttackTime` now accept a sector size. Rationale: Small sectors take less time to prove than large sectors. To prevent generation attacks, the proving period for small sectors must be smaller than the proving period for large sectors.
1. `CheckPostProofs` and `ValidatePoRep` now accept a sector size. Rationale: Choice of verifying key will depend on sector size.

## Additional Talking Points

1. This proposal does add sector size to the ask. If a storage client wishes to make a deal with a miner offering sectors of a particular size, they can query the owner of the ask to obtain the miner actor's sector size.
1. This proposal represents `StorageMarketActor.TotalStorage` as `BytesAmount`. Power in the network should probably be tracked in some other unit, e.g. multiple-of-smallest-sector-available-to-network.