### PR TITLE
Rename PieceConfirmation and TranslatedRef.

### DIFF
--- a/storage-market.md
+++ b/storage-market.md
@@ -71,7 +71,7 @@ This section describes the flow required to store a single piece with a single s
 #### Before Deal
 
 1. **Merkle Translation:** The client runs a 'Local Merkle Translation' to generate the storage market hash for the data.
-  - Storage miners reference data by its storage market hash, and not by its standard hash. This step is needed for the client to be able to trust their data was correctly included in the miners sector. See [Piece Confirmation](definitions.md#piece-confirmation)
+  - Storage miners reference data by its storage market hash, and not by its standard hash. This step is needed for the client to be able to trust their data was correctly included in the miners sector. See [Piece Inclusion Proof](definitions.md#piece-inclusion-proof)
 2. **Miner Selection:** The client looks at asks on the network, and then selects a storage miner to store their data with.
    - Note: this is currently a manual process.
 3. **Payment Channel Setup:** The client calls [`Payment.Setup`](#payments) with the piece and the funds they are going to pay the miner with. All payments between clients and storage providers use payment channels.
@@ -95,18 +95,18 @@ Note: The details of this protocol including formats, datastructures, and algori
 
 2. **Storage Deal Start**: Clients makes sure data is in a [sector](definitions.md#sector)
 
-    - **PieceConfirmation:** Once the miner seals the sector, they update the PieceConfirmation in the deal state, which the client then gets the next time they query that state.
-     - The PieceConfirmation proves that the piece in the deal is contained in a sector whose commitment is on chain. The 'Merkle Translation' hash from earlier is used here. See [piece inclusion proof for more details](proofs.md#piece-inclusion-proof)
-    -  Note: a client that is not interested in staying online to wait for PieceConfirmation can leave immediately, however, they run the risk that their files don't actually get stored (but if their data is not stored, the miner will not be able to claim payment for it).
-     - Note: In order to provide the piece confirmation, the miner needs to fill the sector. This may take some time. So there is a wait between the time the data is transferred to the miner, and when the piece confirmation becomes available.
+    - **PieceInclusionProof:** Once the miner seals the sector, they update the PieceInclusionProof in the deal state, which the client then gets the next time they query that state.
+     - The PieceInclusionProof proves that the piece in the deal is contained in a sector whose commitment is on chain. The 'Merkle Translation' hash from earlier is used here. See [piece inclusion proof for more details](proofs.md#piece-inclusion-proof)
+    -  Note: a client that is not interested in staying online to wait for PieceInclusionProof can leave immediately, however, they run the risk that their files don't actually get stored (but if their data is not stored, the miner will not be able to claim payment for it).
+     - Note: In order to provide the piece inclusion proof, the miner needs to fill the sector. This may take some time. So there is a wait between the time the data is transferred to the miner, and when the piece inclusion proof becomes available.
    - **Mining**: Miner posts `seal commitment` and associated proof on chain by calling `CommitSector` and starts running `proofs of spacetime`. See [storage mining cycle](mining.md#storage-mining-cycle) for more details.
 
-3. **Storage Deal Abort:** If the miner doesn't provide the PieceConfirmation, the client can invalidate the payment channel.
+3. **Storage Deal Abort:** If the miner doesn't provide the PieceInclusionProof, the client can invalidate the payment channel.
    - This is done by invoking the 'close' method on the channel on-chain. This process starts a timer that, on finishing, will release the funds to the client. 
    - If a client attempts to abort a deal that they have actually made with a miner, the miner can submit a payment channel update to force the channel to stay open for the length of the agreement.
 
 4. **Storage Deal Complete:** The client periodically queries the miner for the deals status until the deal is 'complete', at which point the client knows that the data is properly replicated.
-   - The client should store the returned 'PieceConfirmation' for later validation.
+   - The client should store the returned 'PieceInclusionProof' for later validation.
 
 TODO: 'complete' isnt really the right word here, as it implies that the deal is over.
 


### PR DESCRIPTION
This standardizes some terminology, renaming `PieceConfirmation` to `PieceInclusionProof` and `TranslatedRef` to `CommP`.