### PR TITLE
Add hints plugin to highlight non-spec paragraphs

### DIFF
--- a/INTRO.md
+++ b/INTRO.md
@@ -1,6 +1,8 @@
 # Filecoin Spec
 
+{% hint style='danger' %}
 This is the official Filecoin protocol specification. It is a work in progress. While reading, if you notice any discrepancies, or issues, please open an issue on the [specs repo](https://github.com/filecoin-project/specs).
+{% endhint %}
 
 This collection of pages specify the protocols comprising the Filecoin network. The goal of these specs is to provide sufficient detail that another implementation, written using only this document as reference, can be fully compatible with `go-filecoin` peers, but this is still a work in progress.
 

--- a/README.md
+++ b/README.md
@@ -14,17 +14,22 @@ discussions.
 
 You can also use gitbook tooling to view the spec locally.
 
-First, install `gitbook-cli` via npm and run:
+First, install `gitbook-cli` via npm then run the following to install all necessary plugins:
+```
+gitbook install
+```
+
+Now you can have gitbook serve it to you (with live-reload) via:
 ```
 gitbook serve
 ```
 
-Alternatively, you can use gitbook to print a pdf using:
+Alternatively, you can use gitbook to print a pdf (or epub, or mobi) using:
 ```
 gitbook pdf
 ```
 
-(Note: on macOS using the pdf printer may require some extra installation)
+(Note: on macOS using the pdf printer may require some extra installation, epub and mobi might require callibre to be installed, too)
 
 If you're just browsing on GitHub, start with [INTRO.md](INTRO.md) and the
 table of contents in [SUMMARY.md](SUMMARY.md). But really, we recommend using 

--- a/book.json
+++ b/book.json
@@ -3,5 +3,13 @@
 	"structure": {
 		"readme": "INTRO.md"
 	},
-	"plugins": ["-sharing"]
+	"plugins": ["-sharing", "hints"],
+	"pluginsConfig": {
+			"hints": {
+					"info": "fa fa-asterisk",
+					"tip": "fa fa-hand-o-right",
+					"danger": "fa fa-warning",
+					"working": "fa fa-wrench"
+			}
+	}
 }

--- a/data-structures.md
+++ b/data-structures.md
@@ -157,7 +157,10 @@ The state trie keeps track of all state in Filecoin. It is a map of addresses to
 
 ## HAMT
 
-TODO: link to spec for our CHAMP HAMT
+{% hint style='working' %}
+**TODO**: link to spec for our CHAMP HAMT
+{% endhint %}
+
 
 
 # Basic Type Encodings

--- a/mining.md
+++ b/mining.md
@@ -285,7 +285,9 @@ Each message should be applied on the resultant state of the previous message ex
 
 The miner merklizes the set of messages selected, and put the root in `MsgRoot`. They gather the receipts from each execution into a set, merklize them, and put that root in `ReceiptsRoot`. Finally, they set the `StateRoot` field with the resultant state.
 
+{% hint style='info' %}
 Note that the `ParentState` field from the expected consensus document is left out, this is to help minimize the size of the block header. The parent state for any given parent set should be computed by the client and cached locally.
+{% endhint %}
 
 Finally, the miner can generate a Unix Timestamp to add to their block, to show that the block generation was appropriately delayed.
 

--- a/operation.md
+++ b/operation.md
@@ -2,7 +2,10 @@
 
 Running a Filecoin `full node` requires running many different processes and protocols simultaneously. This section describes the set of things you need to do in order to run a fully validating Filecoin node.
 
-(TODO: elaborate on all this, obviously)
+
+{% hint style='working' %}
+**TODO**: elaborate on all this, obviously
+{% endhint %}
 
 ## Chain Validation
 

--- a/signatures.md
+++ b/signatures.md
@@ -162,8 +162,9 @@ Type SignedMessage Struct {
   - Go-filecoin - <https://github.com/filecoin-project/go-filecoin/blob/e95bde8ff289b0c88d748e92b1bcca99ecc403cb/crypto/secp256k1/secp256.go#L98>
 
 ### References
-
-TODO: this section should likely be removed, and the context it adds should be linked in some other way.
+{% hint style='working' %}
+**TODO**: this section should likely be removed, and the context it adds should be linked in some other way.
+{% endhint %}
 
 - Maybe Marshal/Unmarshal == NewSignedMessage/SignBytes?  
 

--- a/validation.md
+++ b/validation.md
@@ -21,4 +21,6 @@ Every block that comes in over the network must first be validated structurally.
 
 Once the block passes validation, it should be added to the local datastore, even in the case where we don't accept it right now. Future blocks from other miners may be mined on top of it and in that case we will want to have it around to avoid refetching. Blocks a certain distance from the current chain height may be dropped (exact number TBD, but blocks that havent been included after several days may be purged).
 
+{% hint style='tip' %}
 To make certain validation checks simpler, blocks should be indexed by height and by parent set. That way sets of blocks with a given height and common parents may be quickly queried. It may also be useful to compute and cache the resultant aggregate state of blocks in these sets, this saves extra state computation when checking which state root to start a block at when it has multiple parents.
+{% endhint %}


### PR DESCRIPTION
The spec is still riddled with notes, TODOs but also implementation details, neither of which should strictly be in a spec, but some of them still make sense to have. For example certain notes and hints to implementors or to point out some non-obvious things might be useful to state, however, as these are for implemenators to decide, they shouldn't strictly considered part of the spec.

To make it easier to distinguish between these, I've added the `hints` plugin to our gitbook setup and put some hints into the spec, I think we should aim for the following uses:

![Screenshot-20190509160846-1706x638](https://user-images.githubusercontent.com/40496/57461250-f6924800-7276-11e9-935f-20c829100d18.png)
**Danger**: the big red notes about meta-aspects or gaping holes. Example: in the entry page to highlight, that this spec is _not yet done_.  But also in later cases, to update documents to point out security issues we've learnt since writing the spec.

![Screenshot-20190509160948-1802x1082](https://user-images.githubusercontent.com/40496/57461279-00b44680-7277-11e9-879d-de195d0e07d4.png)
**Working**: the yellow with a wrench is appropriate for all aspects we are still working on or around the comments we've added to notice ourselves we need to improve this. For example, I'd add this around all "TODO"-items so it is more obvious, when scrolling through (and later also link to the corresponding tickets, so it is easier to pick up) 

![Screenshot-20190509161331-1686x622](https://user-images.githubusercontent.com/40496/57461298-0873eb00-7277-11e9-8714-19f976c36a72.png)
**Info**: the blue highlights some aspect you might otherwise wouldn't have noticed, but is still important to point out, and maybe some other information or implementation tip that follows from that

![Screenshot-20190509161408-1718x762](https://user-images.githubusercontent.com/40496/57461308-0f026280-7277-11e9-8988-70108916e8f2.png)
**Tip**: the bright green block is purely for implementation suggestions.

Neither of these hints is part of the _official_ spec (I'd add this comment to the style section, if that was already a separate document). The examples shown in the screenshots are also part of this PR.