### PR TITLE
CommitSector takes FaultSet, not FailureSet

### DIFF
--- a/actors.md
+++ b/actors.md
@@ -499,7 +499,7 @@ func CommitSector(comm Commitment, proof *SealProof) SectorID {
 
 Parameters:
 - proofs []PoStProof
-- faults []FailureSet
+- faults []FaultSet
 - recovered SectorSet
 - done SectorSet
 


### PR DESCRIPTION
FailureSet isn't a specified type, but FaultSet is.