### PR TITLE
CommitSector should accept a sector ID instead of producing a sector ID

### DIFF
--- a/actors.md
+++ b/actors.md
@@ -475,10 +475,10 @@ func CommitSector(sectorID SectorID, commD, commR, commRStar []byte, proof SealP
 	miner.Collateral -= coll
 	miner.ActiveCollateral += coll
 
-	miner.Sectors.Add(commR)
-	// TODO: sectors IDs might not be that useful. For now, this should just be the number of
-	// the sector within the set of sectors, but that can change as the miner experiences
-	// failures.
+    // Note: There must exist a unique index in the miner's sector set for each
+    // sector ID. The `faults`, `recovered`, and `done` parameters of the
+    // SubmitPoSt method express indices into this sector set.
+	miner.Sectors.Add((sectorID, commR, commD))
 
 	// if miner is not mining, start their proving period now
 	// Note: As written here, every miners first PoSt will only be over one sector.

--- a/actors.md
+++ b/actors.md
@@ -444,17 +444,18 @@ Note: this may be moved off chain soon, don't worry about testing it too heavily
 ### CommitSector
 
 Parameters:
+- sectorID SectorID
 - commD []byte
 - commR []byte
 - commRStar []byte
 - proof SealProof
 
-Return: SectorID
+Return: None
 
 
 ```go
 // NotYetSpeced: ValidatePoRep, EnsureSectorIsUnique, CollateralForSector, Commitment
-func CommitSector(comm Commitment, proof *SealProof) SectorID {
+func CommitSector(sectorID SectorID, commD, commR, commRStar []byte, proof SealProof) SectorID {
 	if !miner.ValidatePoRep(miner.SectorSize, comm, miner.PublicKey, proof) {
 		Fatal("bad proof!")
 	}
@@ -474,7 +475,7 @@ func CommitSector(comm Commitment, proof *SealProof) SectorID {
 	miner.Collateral -= coll
 	miner.ActiveCollateral += coll
 
-	sectorId = miner.Sectors.Add(commR)
+	miner.Sectors.Add(commR)
 	// TODO: sectors IDs might not be that useful. For now, this should just be the number of
 	// the sector within the set of sectors, but that can change as the miner experiences
 	// failures.
@@ -491,8 +492,6 @@ func CommitSector(comm Commitment, proof *SealProof) SectorID {
 		miner.ProvingSet = miner.Sectors
 		miner.ProvingPeriodEnd = chain.Now() + ProvingPeriodDuration(miner.SectorSize)
 	}
-
-	return sectorId
 }
 ```
 


### PR DESCRIPTION
## Why does this PR exist?

The spec [shows that sector id is an input to the seal operation](https://github.com/filecoin-project/specs/blob/master/proofs.md#seal). However, the current actors.md document shows that sector id is returned from the `CommitSector` method. The `CommitSector` method is called _after_ sealing has completed, so it cannot return the sector id. Rather, it needs to accept a sector id.

## What's in this PR?

This PR modifies `CommitSector` to accept a sector ID instead of returning a sector ID.

