### PR TITLE
some clarifications to fees and fixes to collateral tracking

### DIFF
--- a/actors.md
+++ b/actors.md
@@ -721,11 +721,10 @@ func DePledge(amt TokenAmount) {
 		return
 	}
 
-	if amt > miner.Collateral {
+	if amt > vm.MyBalance() - miner.ActiveCollateral {
 		Fatal("Not enough free collateral to withdraw that much")
 	}
 
-	miner.Collateral -= amt
 	miner.DePledgedCollateral = amt
 	miner.DePledgeTime = CurrentBlockHeight + DePledgeCooldown
 }

--- a/faults.md
+++ b/faults.md
@@ -19,7 +19,7 @@ A fault is what happens when partcipants in the protocol are behaving incorrectl
   - **Reporting:** The miner submits their PoSt as usual, but includes the late submission fee.
   - **Check:** The chain checks first that the submission is within the `generation attack threshold`, and then checks that the fee provided matches the required fee for how many blocks late the submission is.
   - **Penalization:** The miner is penalized proportionally to the delay. Penalizations are enforced by a standard PoSt submission.
-    - *Economic penalization*: To determine the penalty amount, `CalculateLatePenalty(numLate)` is called. The miners power is not reduced after the fee submission.
+    - *Economic penalization*: To determine the penalty amount, `ComputeLateFee(minerPower, numLate)` is called.
     - *Power penalization*: The miners' power is not reduced. Note that the current view of the power table is computed with the lookback parameter.
       - *Why are we accounting the power table with a lookback parameter ?* If we do not use the lookback parameter then, we need to penalize late miners for the duration that they are late. This is tricky to do efficiently. For xample, if miners A, B and C each have 1/3 of the networks power, and C is late in submitting their proofs, then for that duration, A and B should each have effectively half of the networks power (and a 50% chance each of winning the block).
   - TODO: write on the spec exact parameters for PoSt Deadline and Gen Attack threshold


### PR DESCRIPTION
Should address #293 

Added stubs for the fee calculation functions (@decentralion if you could help with the real constructions for these, i'd really appreciate it).

Additionally, I removed the 'pledge' amount that was being used to track how many bytes a miner claims they have available. This isnt really useful, as we either have to force them to put collateral up for this (in which case they won't say how much storage they really have) or theres nothing backing it and people will just put random numbers, making the metric useless.

I've also removed the tracking of free collateral in the miner actor, and am just using the available balance in the account as the 'total collateral pool'. This should simplify a few things.