### PR TITLE
protocol does not define an enumeration of supported sector sizes

### DIFF
--- a/actors.md
+++ b/actors.md
@@ -159,7 +159,7 @@ type StorageMarketActor struct {
 	Miners AddressSet
 
 	// TODO: Determine correct unit of measure. Could be denominated in the
-	// smallest sector size supported by the network.
+	// smallest sector size for which verifying keys have been published.
 	TotalStorage BytesAmount
 }
 ```
@@ -180,17 +180,12 @@ type StorageMarketActor struct {
 Parameters:
 
 - worker Address
-- sectorSize BytesAmount
 - pid PeerID
 
 Return: Address
 
 ```go
 func CreateStorageMiner(worker Address, sectorSize BytesAmount, pid PeerID) Address {
-	if !SupportedSectorSize(sectorSize) {
-		Fatal("Unsupported sector size")
-	}
-
 	newminer := InitActor.Exec(MinerActorCodeCid, EncodeParams(pubkey, pledge, sectorSize, pid))
 
 	self.Miners.Add(newminer)

--- a/zigzap-porep.md
+++ b/zigzap-porep.md
@@ -40,7 +40,7 @@ First apply preprocessing as described in [Filecoin Client Data Processing](clie
 > Preprocessing adds two zero bits after every 254 bits of original data, yielding a sequence of 32-byte blocks, each of which contains two zeroes in the most-significant bits, when interpreted as a little-endian number. That is, for each block, 0x11000000 & block[31] == 0.
 
 ## Sector Padding
-After preprocessing, the data is padded with zero bytes so that the total length of the data is the sector size, __*SectorSize*__. __*SectorSize*__ must be one of a set of explicitly supported sizes and must be a power-of-two multiple of 32 bytes. The preprocessed and padded data is now considered to be an __*unsealed sector*__.
+After preprocessing, the data is padded with zero bytes so that the total length of the data is the sector size, __*SectorSize*__. __*SectorSize*__ must be one of a set of supported sector sizes (for which verifying keys have been published) and must be a power-of-two multiple of 32 bytes. The preprocessed and padded data is now considered to be an __*unsealed sector*__.
 
 ## Replication
 


### PR DESCRIPTION
We would like to roll out support for new sector sizes without requiring a change to the protocol.

A Filecoin node can verify seal and PoSt proofs for any sector size which they have verifying keys for. Adding support for a new sector size is as simple as distributing new verifying keys (for PoSt and seal) for that sector size.

The Filecoin node (i.e. not the protocol) should specify an enumeration of sector sizes for which Groth parameters and verifying keys are available. The protocol does not prevent an operator from creating a storage miner actor with a sector size for which no Groth parameters have been published - but they won't be able to generate proofs.