### PR TITLE
replace pledge symbol with message value

### DIFF
--- a/actors.md
+++ b/actors.md
@@ -191,7 +191,12 @@ func CreateStorageMiner(worker Address, sectorSize BytesAmount, pid PeerID) Addr
 		Fatal("Unsupported sector size")
 	}
 
-	newminer := InitActor.Exec(MinerActorCodeCid, EncodeParams(pubkey, msg.Value, sectorSize, pid))
+	newminer := InitActor.Exec(MinerActorCodeCid, EncodeParams(pubkey, sectorSize, pid))
+
+	// Send the newly-created miner the FIL sent to the storage market actor by
+	// the miner's owner. The miner will draw collateral from this FIL when
+	// committing sectors to the network.
+	// vm.Send(newminer.Address, msg.Value, "", nil)
 
 	self.Miners.Add(newminer)
 

--- a/actors.md
+++ b/actors.md
@@ -191,7 +191,7 @@ func CreateStorageMiner(worker Address, sectorSize BytesAmount, pid PeerID) Addr
 		Fatal("Unsupported sector size")
 	}
 
-	newminer := InitActor.Exec(MinerActorCodeCid, EncodeParams(pubkey, pledge, sectorSize, pid))
+	newminer := InitActor.Exec(MinerActorCodeCid, EncodeParams(pubkey, msg.Value, sectorSize, pid))
 
 	self.Miners.Add(newminer)
 


### PR DESCRIPTION
## Why is this PR needed?

The `pledge` symbol is not defined in the enclosing function body.

## What's in this PR?

Replace `pledge` symbol with message value. The FIL in the message will be used to set the balance of the newly-created storage miner actor.