### PR TITLE
Make NextdoneSet a BitField

### DIFF
--- a/actors.md
+++ b/actors.md
@@ -467,7 +467,7 @@ type StorageMinerActorState struct {
 	## Sectors reported during the last PoSt submission as being 'done'. The collateral
     ## for them is still being held until the next PoSt submission in case early sector
     ## removal penalization is needed.
-    nextDoneSet SectorSet
+    nextDoneSet BitField
 
 	## Deals this miner has been slashed for since the last post submission.
     arbitratedDeals CidSet


### PR DESCRIPTION
### Problem

`NextDoneSet` is currently a `SectorSet`.
`SubmitPoSt`'s `done` parameter is a `BitField`.
In `SubmitPoSt`, we set `miner.NextDoneSet = done`.

### Solution

`NextDoneSet` should be a `BitField` like `done`.