### PR TITLE
Specify bit ordering for RLE+

### DIFF
--- a/data-structures.md
+++ b/data-structures.md
@@ -486,3 +486,8 @@ a long block.
 
 > **Note:** The encoding is unique, so no matter which algorithm for encoding is used, it should produce
 > the same encoding, given the same input.
+
+##### Bit Numbering
+
+For Filecoin, byte arrays representing RLE+ bitstreams are encoded using [LSB 0](https://en.wikipedia.org/wiki/Bit_numbering#LSB_0_bit_numbering) bit numbering.
+


### PR DESCRIPTION
## Summary
Specify little-endian/LSB 0 bit ordering for byte arrays representing RLE+ encodings.  This is needed for interoperability and storage.