### PR TITLE
miner.ProvingSet.Count() -> .Size() as per elsewhere in the spec

### DIFF
--- a/actors.md
+++ b/actors.md
@@ -584,7 +584,7 @@ func SubmitPost(proofs []PoStProof, faults []FaultSet, recovered BitField, done 
 	// the last proving period.
 	oldPower := miner.Power
 
-	miner.Power = (miner.ProvingSet.Count() - allFaults.Count()) * miner.SectorSize
+	miner.Power = (miner.ProvingSet.Size() - allFaults.Count()) * miner.SectorSize
 	StorageMarket.UpdateStorage(miner.Power - oldPower)
 
 	miner.ProvingSet = miner.Sectors


### PR DESCRIPTION
## Why is this PR needed?

We use `ProvingSet.Size()` in two places and `ProvingSet.Count()` in one place. I'm very confident that the intended meaning of the two different expressions is identical; this PR standardizes the spec on the former.