### PR TITLE
Fix message type

### DIFF
--- a/data-structures.md
+++ b/data-structures.md
@@ -105,6 +105,8 @@ type UnsignedMessage struct {
 	gasLimit UInt
 
 	method Uint
+	
+	## Serialized parameters to the method
 	params Bytes
 } representation tuple
 ```

--- a/data-structures.md
+++ b/data-structures.md
@@ -104,7 +104,8 @@ type UnsignedMessage struct {
 	gasPrice UInt
 	gasLimit UInt
 
-	method &ActorMethod
+	method Uint
+	params Bytes
 } representation tuple
 ```
 

--- a/state-machine.md
+++ b/state-machine.md
@@ -30,7 +30,7 @@ This second route for creating an actor is allowed to avoid the necessity of an 
 
 ### Execution (Calling a method on an Actor)
 
-Message execution currently relies entirely on 'built-in' code, with a common external interface. The method and actor to call it on are specified in the `Method` and `To` fields of a message, respectively. Method parameters are encoded and put into the `Params` field of a message. The encoding is a cbor array of each of the types individually encoded. The individual encodings for each type are as follows.
+Message execution currently relies entirely on 'built-in' code, with a common external interface. The method and actor to call it on are specified in the `Method` and `To` fields of a message, respectively. Method parameters are encoded and put into the `Params` field of a message. The encoding is technically actor dependent, but for all built-in Filecoin actors it is the dag-cbor ipld encoding of the parameters struct for each method defined in [the actors doc](actors.md). The individual encodings for each type are as follows.
 
 These functions are given, as input, an `ExecutionContext` containing useful information for their execution.
 

--- a/state-machine.md
+++ b/state-machine.md
@@ -30,7 +30,7 @@ This second route for creating an actor is allowed to avoid the necessity of an 
 
 ### Execution (Calling a method on an Actor)
 
-Message execution currently relies entirely on 'built-in' code, with a common external interface. The method and actor to call it on are specified in the `Method` and `To` fields of a message, respectively. Method parameters are encoded and put into the `Params` field of a message. The encoding is technically actor dependent, but for all built-in Filecoin actors it is the dag-cbor ipld encoding of the parameters struct for each method defined in [the actors doc](actors.md). The individual encodings for each type are as follows.
+Message execution currently relies entirely on 'built-in' code, with a common external interface. The method and actor to call it on are specified in the `Method` and `To` fields of a message, respectively. Method parameters are encoded and put into the `Params` field of a message. The encoding is technically actor dependent, but for all built-in Filecoin actors it is the dag-cbor ipld encoding of the parameters struct for each method defined in [the actors doc](actors.md).
 
 These functions are given, as input, an `ExecutionContext` containing useful information for their execution.
 


### PR DESCRIPTION
@dignifiedquire this snuck past my review. The message type will have a integer field to denote the message, and opaque bytes as the parameters. These bytes are passed into the VM, and the actor gets to decide how they are decoded. Any encoding we use for the built-in actors is merely convention (similar to the conventions defined by solidity around method calls).