### PR TITLE
unseal requires ticket in order to compute replica id

### DIFF
--- a/proofs.md
+++ b/proofs.md
@@ -105,6 +105,7 @@ Unseal
   outputPath    string,   // path to which unsealed bytes will be written (regular file, ramdisk, etc.)
   proverID      [31]byte, // uniquely identifies miner
   sectorID      [31]byte, // uniquely identifies sector
+  ticket        [32]byte, // ticket to which miner committed when sealing began
   startOffset   uint64,   // zero-based byte offset in original, unsealed sector-file
   numBytes      uint64,   // number of bytes to unseal (corresponds to contents of unsealed sector-file)
  ) err Error |


### PR DESCRIPTION
As per the [ZigZag spec](https://github.com/filecoin-project/specs/blob/master/zigzag-porep.md#replication), replica id is created like so:

```
ReplicaID := Hash(ProverID || SectorID || ticket)
```

Decoding a sealed sector requires the replica id, and unsealing requires decoding. Thus, this PR.