### PR TITLE
bump up actor IDs by one so 0 is free for sending

### DIFF
--- a/actors.md
+++ b/actors.md
@@ -51,9 +51,9 @@ type InitActorState struct {
 
 | Name | Method ID |
 |--------|-------------|
-| `Constructor` | 0 |
-| `Exec` | 1 |
-| `GetIdForAddress` | 2 |
+| `Constructor` | 1 |
+| `Exec` | 2 |
+| `GetIdForAddress` | 3 |
 
 #### `Constructor`
 
@@ -179,8 +179,8 @@ type AccountActorState struct {
 
 | Name | Method ID |
 |--------|-------------|
-| `AccountConstructor` | 0 |
-| `GetAddress` | 1 |
+| `AccountConstructor` | 1 |
+| `GetAddress` | 2 |
 
 ```
 type AccountConstructor struct {
@@ -221,14 +221,14 @@ type StorageMarketActorState struct {
 
 | Name | Method ID |
 |--------|-------------|
-| `StorageMarketConstructor` | 0 |
-| `CreateStorageMiner` | 1 |
-| `SlashConsensusFault` | 2 |
-| `UpdateStorage` | 3 |
-| `GetTotalStorage` | 4 |
-| `PowerLookup` | 5 |
-| `IsMiner` | 6 |
-| `StorageCollateralForSize` | 7 |
+| `StorageMarketConstructor` | 1 |
+| `CreateStorageMiner` | 2 |
+| `SlashConsensusFault` | 3 |
+| `UpdateStorage` | 4 |
+| `GetTotalStorage` | 5 |
+| `PowerLookup` | 6 |
+| `IsMiner` | 7 |
+| `StorageCollateralForSize` | 8 |
 
 #### `Constructor`
 
@@ -514,22 +514,22 @@ type MinerInfo struct {
 
 | Name | Method ID |
 |--------|-------------|
-| `StorageMinerConstructor` | 0 |
-| `CommitSector` | 1 |
-| `SubmitPost` | 2 |
-| `SlashStorageFault` | 3 |
-| `GetCurrentProvingSet` | 4 |
-| `ArbitrateDeal` | 5 |
-| `DePledge` | 6 |
-| `GetOwner` | 7 |
-| `GetWorkerAddr` | 8 |
-| `GetPower` | 9 |
-| `GetPeerID` | 10 |
-| `GetSectorSize` | 11 |
-| `UpdatePeerID` | 12 |
-| `ChangeWorker` | 13 |
-| `IsSlashed` |  14 |
-| `IsLate` | 15 |
+| `StorageMinerConstructor` | 1 |
+| `CommitSector` | 2 |
+| `SubmitPost` | 3 |
+| `SlashStorageFault` | 4 |
+| `GetCurrentProvingSet` | 5 |
+| `ArbitrateDeal` | 6 |
+| `DePledge` | 7 |
+| `GetOwner` | 8 |
+| `GetWorkerAddr` | 9 |
+| `GetPower` | 10 |
+| `GetPeerID` | 11 |
+| `GetSectorSize` | 12 |
+| `UpdatePeerID` | 13 |
+| `ChangeWorker` | 14 |
+| `IsSlashed` |  15 |
+| `IsLate` | 16 |
 
 #### `Constructor`
 
@@ -1157,10 +1157,10 @@ type PaymentChannel struct {
 
 | Name | Method ID |
 |--------|-------------|
-| `PaymentChannelConstructor` | 0 |
-| `UpdateChannelState` | 1 |
-| `Close` | 2 |
-| `Collect` | 3 |
+| `Constructor` | 1 |
+| `UpdateChannelState` | 2 |
+| `Close` | 3 |
+| `Collect` | 4 |
 
 #### `Constructor`
 
@@ -1364,15 +1364,15 @@ type Transaction struct {
 
 | Name | Method ID |
 |--------|-------------|
-| `MultisigConstructor` | 0 |
-| `Propose` | 1 |
-| `Approve` | 2 |
-| `Cancel` | 3 |
-| `ClearCompleted` | 4 |
-| `AddSigner` | 5 |
-| `RemoveSigner` | 6 |
-| `SwapSigner` | 7 |
-| `ChangeRequirement` | 8 |
+| `MultisigConstructor` | 1 |
+| `Propose` | 2 |
+| `Approve` | 3 |
+| `Cancel` | 4 |
+| `ClearCompleted` | 5 |
+| `AddSigner` | 6 |
+| `RemoveSigner` | 7 |
+| `SwapSigner` | 8 |
+| `ChangeRequirement` | 9 |
 
 
 #### `Constructor`

--- a/state-machine.md
+++ b/state-machine.md
@@ -14,6 +14,12 @@ First, to call a method as an external participant of the system (aka, a normal 
 
 Second, an `actor` may call a method on another actor during the invocation of one of its methods.  However, the only time this may happen is as a result of some actor being invoked by an external users message (note: an actor called by a user may call another actor that then calls another actor, as many layers deep as the execution can afford to run for).
 
+### Sending Funds
+
+As all messages carry a method ID, the method ID '0' is reserved for simple
+transfers of funds. Funds specified by the value field are always transferred,
+but specifying a method ID of '0' ensures that no other side effects occur.
+
 ### State Representation
 
 The `global state` is modeled as a map of actor `ID`s to actor structs. This map is implemented by an ipld HAMT (TODO: link to spec for our HAMT) with the 'key' being the serialized ID address (every actor has an ID address that can be looked up via the `InitActor`), and the value is an [`Actor`](data-structures.md#actor) object with the actors information. Within each `Actor` object is a field called `state` that is an ipld pointer to a graph that can be entirely defined by the actor.


### PR DESCRIPTION
If we reserve 0 for constructors, then it becomes rather difficult to just send money to an actor. So now method ID 1 is reserved for constructors, ID 0 is kept empty for actors to receive funds on, and the rest are open.