### PR TITLE
Add linear unlocking functionality for funds held in multisig actors

### DIFF
--- a/actors.md
+++ b/actors.md
@@ -1522,10 +1522,10 @@ func Propose(to Address, value TokenAmount, method String, params Bytes) UInt {
 	self.Transactions.Append(tx)
 
 	if self.Required == 1 {
-		if !self.canSpend(value) {
+		if !self.canSpend(tx.value) {
 			Fatal("transaction amount exceeds available")
 		}
-		tx.RetCode = vm.Send(tx.To, tx.Value, tx.Method, tx.Params) 
+		tx.RetCode = vm.Send(tx.To, tx.Value, tx.Method, tx.Params)
 		tx.Complete = true
 	}
 

--- a/actors.md
+++ b/actors.md
@@ -1574,7 +1574,7 @@ func Approve(txid UInt) {
 		if !self.canSpend(tx.Value) {
 			Fatal("transaction amount exceeds available")
 		}
-		tx.RetCode = Send(tx.To, tx.Value, tx.Method, tx.Params)
+		tx.RetCode = vm.Send(tx.To, tx.Value, tx.Method, tx.Params)
 		tx.Complete = true
 	}
 }

--- a/actors.md
+++ b/actors.md
@@ -1390,8 +1390,8 @@ type MultisigConstructor struct {
     signers [Address]
     ## The number of signatories required to perform a transaction.
     required UInt
-  	## Unlock time (in blocks) of initial filecoin balance of this wallet. Unlocking is linear.
-  	unlockDuration UInt
+    ## Unlock time (in blocks) of initial filecoin balance of this wallet. Unlocking is linear.
+    unlockDuration UInt
 } representation tuple
 ```
 
@@ -1401,9 +1401,9 @@ type MultisigConstructor struct {
 func Multisig(signers []Address, required UInt, unlockDuration UInt) {
 	self.Signers = signers
 	self.Required = required
-  self.initialBalance = msg.Value
-  self.unlockDuration = unlockDuration
-  self.startingBlock = VM.CurrentBlockHeight()
+	self.initialBalance = msg.Value
+	self.unlockDuration = unlockDuration
+	self.startingBlock = VM.CurrentBlockHeight()
 }
 ```
 
@@ -1448,9 +1448,9 @@ func Propose(to Address, value TokenAmount, method String, params Bytes) UInt {
 	self.Transactions.Append(tx)
 
 	if self.Required == 1 {
-    if !self.canSpend(value) {
-      Fatal("transaction amount exceeds available")
-    }
+		if !self.canSpend(value) {
+			Fatal("transaction amount exceeds available")
+		}
 		vm.Send(tx.To, tx.Value, tx.Method, tx.Params)
 		tx.Complete = true
 	}
@@ -1497,9 +1497,9 @@ func Approve(txid UInt) {
 	tx.Approved.Append(msg.From)
 
 	if len(tx.Approved) >= self.Required {
-    if !self.canSpend(tx.Value) {
-      Fatal("transaction amount exceeds available")
-    }
+		if !self.canSpend(tx.Value) {
+			Fatal("transaction amount exceeds available")
+		}
 		Send(tx.To, tx.Value, tx.Method, tx.Params)
 		tx.Complete = true
 	}
@@ -1715,10 +1715,10 @@ func BurnFunds(amt TokenAmount) {
 
 ```go
 func canSpend(amt TokenAmount) bool {
-  if self.unlockDuration == 0 {
-    return true
-  }
-  var MinAllowableBalance = (self.initialBalance / self.unlockDuration) * (VM.CurrentBlockHeight() - self.startingBlock)
-  return MinAllowableBalance >= (vm.MyBalance() - amt)
+	if self.unlockDuration == 0 {
+		return true
+	}
+	var MinAllowableBalance = (self.initialBalance / self.unlockDuration) * (VM.CurrentBlockHeight() - self.startingBlock)
+	return MinAllowableBalance >= (vm.MyBalance() - amt)
 }
 ```

--- a/actors.md
+++ b/actors.md
@@ -1571,14 +1571,10 @@ func Approve(txid UInt) {
 	tx.Approved.Append(msg.From)
 
 	if len(tx.Approved) >= self.Required {
-<<<<<<< HEAD
 		if !self.canSpend(tx.Value) {
 			Fatal("transaction amount exceeds available")
 		}
-		Send(tx.To, tx.Value, tx.Method, tx.Params)
-=======
 		tx.RetCode = Send(tx.To, tx.Value, tx.Method, tx.Params)
->>>>>>> master
 		tx.Complete = true
 	}
 }


### PR DESCRIPTION
This PR adds the ability to put a linear unlock on funds held in multisig actors by passing in a particular unlock period (in blocks from time of account creation -- each block estimated to be 30 seconds). This will be used for Filecoin investor account unlocking, however this could also be used for other use-cases wishing to keep funds locked until a certain block height. With this function the account holder(s) are able to transfer up to and including all funds that have unlocked at that point. Any attempt to transfer more than that will fail.

If the user wishes to not use this functionality at all they can just pass `0` to the initialization function for `unlockDuration`, then no unlock will be used and all funds will be spendable immediately.