### PR TITLE
add blocksync response code for bad request

### DIFF
--- a/network-protocols.md
+++ b/network-protocols.md
@@ -341,6 +341,8 @@ type Status enum {
     | GoAway 202
     ## Internal error occured.
     | InternalError 203
+    ## Request was bad
+    | BadRequest 204
 }
 ```
 


### PR DESCRIPTION
A bad request isnt an internal error, so i figured we should have a separate response code for it.