### PR TITLE
Sync up storage deal response with implementation

### DIFF
--- a/network-protocols.md
+++ b/network-protocols.md
@@ -173,17 +173,30 @@ type AcceptedParams RejectedParams
 type FailedParams RejectedParams
 type StagedParams RejectedParams
 
+type ProofInfo struct {
+    sectorID uint64
+
+    ## Various commitments (can be empty depending on Deal State)
+    commD Bytes
+    commR Bytes
+    commRStar Bytes
+
+    ## A reference to the message that was sent to submit the sector containing this data to the chain.
+    commitmentMessage &Message
+
+    ## The proof needed to convince the client that the miner has sealed the data into a sector.
+    ## Note: the miner doesnt necessarily have to have committed the sector at this point
+    ## they just need to have staged it into a sector, and be committed to putting it at
+    ## that place in the sector.
+    pieceInclusionProof PieceInclusionProof
+}
+
 type SealingParams struct {
-	## The proof needed to convince the client that the miner has sealed the data into a sector.
-	## Note: the miner doesnt necessarily have to have committed the sector at this point
-	## they just need to have staged it into a sector, and be committed to putting it at
-	## that place in the sector.
-	pieceInclusionProof PieceInclusionProof
+    proofInfo ProofInfo
 }
 
 type CompleteParams struct {
-	## A reference to the message that was sent to submit the sector containing this data to the chain.
-	sectorCommitMessage &Message
+    proofInfo ProofInfo
 }
 ```
 


### PR DESCRIPTION
## Summary
The network protocols document has fallen out of sync with implementation, and there are more changes on the way.  This PR includes the existing `ProofInfo` structure and upcoming changes from filecoin-project/go-filecoin#3197.

## Note
This should be merged after filecoin-project/go-filecoin#3197 lands, as there may still be some changes in the PR feedback cycle.