### PR TITLE
Add network name to init actor

### DIFF
--- a/actors.md
+++ b/actors.md
@@ -52,6 +52,7 @@ The init actor is responsible for creating new actors on the filecoin network. T
 type InitActorState struct {
     addressMap {Address:ID}<Hamt>
     nextId UInt
+    network String
 }
 
 type InitActorMethod union {
@@ -67,11 +68,18 @@ type InitActorMethod union {
 
 ```sh
 type InitConstructor struct {
+    network String
 }
 
 ```
 
 **Algorithm**
+
+```go
+func InitActor(network String) {
+    self.network = network
+}
+```
 
 #### `Exec`
 

--- a/actors.md
+++ b/actors.md
@@ -62,17 +62,6 @@ type InitActorMethod union {
 } representation keyed
 ```
 
-#### `Constructor`
-
-**Parameters**
-
-```sh
-type InitConstructor struct {
-    network String
-}
-
-```
-
 **Algorithm**
 
 ```go


### PR DESCRIPTION
### What is this?

Give the `InitActor` a `network` property passed in through the constructor.

### Why do we need this?

__short answer:__ It gives us the ability to schedule network upgrades at different block heights on different networks.

__long answer:__ In order to support durable networks (pre- and post- release), we will need to have a mechanism for upgrading the protocol. We don't need to get into details about what that means here, but there are a few features of protocol upgrades that should hold regardless of the mechanism or type of upgrade:

1. All participants in a network must switch to the new protocol at the same block height.
2. The calendar time of a protocol upgrade is indeterminate, so participants must prepare for the upgrade ahead of time and the switch must happen without human intervention.
3. Multiple Filecoin networks will need to exist prior to main net and after main net for testing and development.
4. Test networks should upgrade earlier than the main network and their chain heights will vary significantly.

The first and second point suggest that protocol upgrade code and the mechanism for upgrading belong in source code. To ensure the network upgrades seamlessly, the timing of the upgrade should live in source code as well so that preparing for an upgrade is as simple as patching the protocol engine.

This strategy causes problems for multiple networks, however. We would really like a test network and the main network to run the same code, but we require that the networks upgrade at different block heights. The simplest solution is to create a upgrade table in source code that describes when to upgrade on all networks. This works, but a node will need a way to determine on which network it is running. Hence this PR.

### Why should it live in InitActor?

We've described above why we need a key to determine the network and why it can't live in source code. We could simply keep the network name in configuration disk. But that would require the operator of every node on a network to configure it correctly. This is alright for main net (which can be the default), but gets a little messy elsewhere.

Your network is really determined by your genesis block, since only nodes with the same genesis can sync. It makes sense the network should live in the genesis block. This way, the network name is determined when genesis is created, and all nodes will inherit the name simply by syncing to the network's chain. Adding the network name to InitActor state is the most straightforward way to add the name to the genesis block. Exactly how the value is accessed can be left to the implementation.