### PR TITLE
miner should validate commP

### DIFF
--- a/storage-market.md
+++ b/storage-market.md
@@ -87,6 +87,7 @@ Note: The details of this protocol including formats, datastructures, and algori
   - If the miner accepts, the client now sends the data to the miner
   - Once the miner receives the data:
     - They validate that the data matches the storage market hash claimed by the client
+		- They validate that `commP` supplied in deal payments is correct
     - They stage it into a sector and set the deal state to `Staged`
 
 


### PR DESCRIPTION
### Problem

A malicious client can create a deal proposal containing payment information with a bogus commP. If the miner waits until the sector is sealed to check commP, the client can cancel payments and still have the miner store their data.

### Solution

Miners should confirm that the `commP` supplied in payment conditions is correct as soon as they receive the piece data.