### PR TITLE
docs(standardize indentation to 4 spaces throughout actors.md)

### DIFF
--- a/actors.md
+++ b/actors.md
@@ -75,56 +75,56 @@ type Exec struct {
 
 ```go
 func Exec(code Cid, params ActorMethod) Address {
-	// Get the actor ID for this actor.
-	actorID = self.NextID
-	self.NextID++
+    // Get the actor ID for this actor.
+    actorID = self.NextID
+    self.NextID++
 
-	// Make sure that only the actors defined in the spec can be launched.
-	if !IsBuiltinActor(code) {
-		Fatal("cannot launch actor instance that is not a builtin actor")
-	}
+    // Make sure that only the actors defined in the spec can be launched.
+    if !IsBuiltinActor(code) {
+        Fatal("cannot launch actor instance that is not a builtin actor")
+    }
 
-	// Ensure that singeltons can be only launched once.
-	// TODO: do we want to enforce this? If so how should actors be marked as such?
-	if IsSingletonActor(code) {
-		Fatal("cannot launch another actor of this type")
-	}
+    // Ensure that singeltons can be only launched once.
+    // TODO: do we want to enforce this? If so how should actors be marked as such?
+    if IsSingletonActor(code) {
+        Fatal("cannot launch another actor of this type")
+    }
 
-	// This generates a unique address for this actor that is stable across message
-	// reordering
-	// TODO: where do `creator` and `nonce` come from?
-	addr := VM.ComputeActorAddress(creator, nonce)
+    // This generates a unique address for this actor that is stable across message
+    // reordering
+    // TODO: where do `creator` and `nonce` come from?
+    addr := VM.ComputeActorAddress(creator, nonce)
 
-	// Set up the actor itself
-	actor := Actor{
-		Code:    code,
-		Balance: msg.Value,
-		Head:    nil,
-		Nonce:   0,
-	}
+    // Set up the actor itself
+    actor := Actor{
+        Code:    code,
+        Balance: msg.Value,
+        Head:    nil,
+        Nonce:   0,
+    }
 
-	// The call to the actors constructor will set up the initial state
-	// from the given parameters, setting `actor.Head` to a new value when successfull.
-	// TODO: can constructors fail?
-	actor.Constructor(params)
+    // The call to the actors constructor will set up the initial state
+    // from the given parameters, setting `actor.Head` to a new value when successfull.
+    // TODO: can constructors fail?
+    actor.Constructor(params)
 
-	VM.GlobalState.Set(actorID, actor)
+    VM.GlobalState.Set(actorID, actor)
 
-	// Store the mapping of address to actor ID.
-	self.AddressMap[addr] = actorID
+    // Store the mapping of address to actor ID.
+    self.AddressMap[addr] = actorID
 
-	return addr
+    return addr
 }
 
 func IsSingletonActor(code Cid) bool {
-	return code == StorageMarketActor || code == InitActor
+    return code == StorageMarketActor || code == InitActor
 }
 ```
 
 ```go
 // TODO: find a better home for this logic
 func (VM VM) ComputeActorAddress(creator Address, nonce Integer) Address {
-	return NewActorAddress(bytes.Concat(creator.Bytes(), nonce.BigEndianBytes()))
+    return NewActorAddress(bytes.Concat(creator.Bytes(), nonce.BigEndianBytes()))
 }
 ```
 
@@ -144,11 +144,11 @@ type GetIdForAddress struct {
 
 ```go
 func GetIdForAddress(addr Address) UInt {
-	id := self.AddressMap[addr]
-	if id == nil {
-		Fault("unknown address")
-	}
-	return id
+    id := self.AddressMap[addr]
+    if id == nil {
+        Fault("unknown address")
+    }
+    return id
 }
 ```
 
@@ -189,7 +189,7 @@ type GetAddress struct {
 
 ```go
 func GetAddress() Address {
-	return self.address
+    return self.address
 }
 ```
 
@@ -245,15 +245,15 @@ type CreateStorageMiner struct {
 
 ```go
 func CreateStorageMiner(worker Address, owner Address, sectorSize BytesAmount, pid PeerID) Address {
-	if !SupportedSectorSize(sectorSize) {
-		Fatal("Unsupported sector size")
-	}
+    if !SupportedSectorSize(sectorSize) {
+        Fatal("Unsupported sector size")
+    }
 
-	newminer := InitActor.Exec(MinerActorCodeCid, EncodeParams(worker, owner, pledge, sectorSize, pid))
+    newminer := InitActor.Exec(MinerActorCodeCid, EncodeParams(worker, owner, pledge, sectorSize, pid))
 
-	self.Miners.Add(newminer)
+    self.Miners.Add(newminer)
 
-	return newminer
+    return newminer
 }
 ```
 
@@ -272,59 +272,59 @@ type SlashConsensusFault struct {
 
 ```go
 func shouldSlash(block1, block2 BlockHeader) bool {
-	// First slashing condition, blocks have the same ticket round
-	if sameTicketRound(block1, block2) {
-		return true
-	}
+    // First slashing condition, blocks have the same ticket round
+    if sameTicketRound(block1, block2) {
+        return true
+    }
 
-	// Second slashing condition, miner ignored own block when mining
-	// Case A: block2 could have been in block1's parent set but is not
-	block1ParentTipSet := parentOf(block1)
-	if !block1Parent.contains(block2) &&
-		block1ParentTipSet.Height == block2.Height &&
-		block1ParentTipSet.ParentCids == block2.ParentCids {
-		return true
-	}
+    // Second slashing condition, miner ignored own block when mining
+    // Case A: block2 could have been in block1's parent set but is not
+    block1ParentTipSet := parentOf(block1)
+    if !block1Parent.contains(block2) &&
+        block1ParentTipSet.Height == block2.Height &&
+        block1ParentTipSet.ParentCids == block2.ParentCids {
+        return true
+    }
 
-	// Case B: block1 could have been in block2's parent set but is not
-	block2ParentTipSet := parentOf(block2)
-	if !block2Parent.contains(block1) &&
-		block2ParentTipSet.Height == block1.Height &&
-		block2ParentTipSet.ParentCids == block1.ParentCids {
-		return true
-	}
+    // Case B: block1 could have been in block2's parent set but is not
+    block2ParentTipSet := parentOf(block2)
+    if !block2Parent.contains(block1) &&
+        block2ParentTipSet.Height == block1.Height &&
+        block2ParentTipSet.ParentCids == block1.ParentCids {
+        return true
+    }
 
-	return false
+    return false
 }
 
 func SlashConsensusFault(block1, block2 BlockHeader) {
-	if !ValidateSignature(block1.Signature) || !ValidSignature(block2.Signature) {
-		Fatal("invalid blocks")
-	}
+    if !ValidateSignature(block1.Signature) || !ValidSignature(block2.Signature) {
+        Fatal("invalid blocks")
+    }
 
-	if AuthorOf(block1) != AuthorOf(block2) {
-		Fatal("blocks must be from the same miner")
-	}
+    if AuthorOf(block1) != AuthorOf(block2) {
+        Fatal("blocks must be from the same miner")
+    }
 
-	// see the "Consensus Faults" section of the faults spec (faults.md)
-	// for details on these slashing conditions.
-	if !shouldSlash(block1, block2) {
-		Fatal("blocks do not prove a slashable offense")
-	}
+    // see the "Consensus Faults" section of the faults spec (faults.md)
+    // for details on these slashing conditions.
+    if !shouldSlash(block1, block2) {
+        Fatal("blocks do not prove a slashable offense")
+    }
 
-	miner := AuthorOf(block1)
+    miner := AuthorOf(block1)
 
-	// TODO: Some of the slashed collateral should be paid to the slasher
+    // TODO: Some of the slashed collateral should be paid to the slasher
 
-	// Burn all of the miners collateral
-	miner.BurnCollateral()
+    // Burn all of the miners collateral
+    miner.BurnCollateral()
 
-	// Remove the miner from the list of network miners
-	self.Miners.Remove(miner)
-	self.UpdateStorage(-1 * miner.Power)
+    // Remove the miner from the list of network miners
+    self.Miners.Remove(miner)
+    self.UpdateStorage(-1 * miner.Power)
 
-	// Now delete the miner (maybe this is a bit harsh, but i'm okay with it for now)
-	miner.SelfDestruct()
+    // Now delete the miner (maybe this is a bit harsh, but i'm okay with it for now)
+    miner.SelfDestruct()
 }
 ```
 
@@ -345,11 +345,11 @@ type UpdateStorage struct {
 
 ```go
 func UpdateStorage(delta BytesAmount) {
-	if !self.Miners.Has(msg.From) {
-		Fatal("update storage must only be called by a miner actor")
-	}
+    if !self.Miners.Has(msg.From) {
+        Fatal("update storage must only be called by a miner actor")
+    }
 
-	self.TotalStorage += delta
+    self.TotalStorage += delta
 }
 ```
 
@@ -367,7 +367,7 @@ type GetTotalStorage struct {
 
 ```go
 func GetTotalStorage() BytesAmount {
-	return self.TotalStorage
+    return self.TotalStorage
 }
 ```
 
@@ -385,13 +385,13 @@ type PowerLookup struct {
 
 ```go
 func PowerLookup(miner Address) BytesAmount {
-	if !self.Miners.Has(miner) {
-		Fatal("miner not registered with storage market")
-	}
+    if !self.Miners.Has(miner) {
+        Fatal("miner not registered with storage market")
+    }
 
-	mact := LoadMinerActor(miner)
+    mact := LoadMinerActor(miner)
 
-	return mact.GetPower()
+    return mact.GetPower()
 }
 ```
 
@@ -409,7 +409,7 @@ type IsMiner struct {
 
 ```go
 func IsMiner(addr Address) bool {
-	return self.Miners.Has(miner)
+    return self.Miners.Has(miner)
 }
 ```
 
@@ -428,7 +428,7 @@ type StorageCollateralForSize struct {
 
 ```go
 func StorageCollateralforSize(size UInt) TokenAmount {
-	// TODO:
+    // TODO:
 }
 ```
 
@@ -445,14 +445,14 @@ type StorageMinerActorState struct {
     ## Collateral that is waiting to be withdrawn.
     dePledgedCollateral TokenAmount
 
-	## Time at which the depledged collateral may be withdrawn.
+    ## Time at which the depledged collateral may be withdrawn.
     dePledgeTime BlockHeight
 
-	## All sectors this miner has committed.
+    ## All sectors this miner has committed.
     sectors &SectorSet
 
-	## Sectors this miner is currently mining. It is only updated
-	## when a PoSt is submitted (not as each new sector commitment is added).
+    ## Sectors this miner is currently mining. It is only updated
+    ## when a PoSt is submitted (not as each new sector commitment is added).
     provingSet &SectorSet
 
     ## Faulty sectors reported since last SubmitPost, up to the current proving period's challenge time.
@@ -462,15 +462,15 @@ type StorageMinerActorState struct {
     ## is submitted. These become the currentFaultSet when a PoSt is submitted.
     nextFaultSet BitField
 
-	## Sectors reported during the last PoSt submission as being 'done'. The collateral
+    ## Sectors reported during the last PoSt submission as being 'done'. The collateral
     ## for them is still being held until the next PoSt submission in case early sector
     ## removal penalization is needed.
     nextDoneSet BitField
 
-	## Deals this miner has been slashed for since the last post submission.
+    ## Deals this miner has been slashed for since the last post submission.
     arbitratedDeals {Cid:Null}
 
-	## Amount of power this miner has.
+    ## Amount of power this miner has.
     power UInt
 
     ## List of sectors that this miner was slashed for.
@@ -486,15 +486,15 @@ type StorageMinerActorState struct {
 }
 
 type MinerInfo struct {
-	## Account that owns this miner.
+    ## Account that owns this miner.
     ## - Income and returned collateral are paid to this address.
     ## - This address is also allowed to change the worker address for the miner.
     owner Address
 
-	## Worker account for this miner.
-	## This will be the key that is used to sign blocks created by this miner, and
-	## sign messages sent on behalf of this miner to commit sectors, submit PoSts, and
-	## other day to day miner activities.
+    ## Worker account for this miner.
+    ## This will be the key that is used to sign blocks created by this miner, and
+    ## sign messages sent on behalf of this miner to commit sectors, submit PoSts, and
+    ## other day to day miner activities.
     worker Address
 
     ## Libp2p identity that should be used when connecting to this miner.
@@ -548,13 +548,13 @@ type StorageMinerConstructor struct {
 
 ```go
 func StorageMinerActor(worker Address, owner Address, sectorSize BytesAmount, pid PeerID) {
-	self.info.owner = message.From
-	self.info.worker = worker
-	self.info.peerID = pid
-	self.info.sectorSize = sectorSize
+    self.info.owner = message.From
+    self.info.worker = worker
+    self.info.peerID = pid
+    self.info.sectorSize = sectorSize
 
-	self.sectors = EmptySectorSet()
-	self.provingSet = EmptySectorSet()
+    self.sectors = EmptySectorSet()
+    self.provingSet = EmptySectorSet()
 }
 ```
 
@@ -580,50 +580,50 @@ TODO: ValidatePoRep, EnsureSectorIsUnique, CollateralForSector, Commitment
 
 ```go
 func CommitSector(sectorID SectorID, commD, commR, commRStar []byte, proof SealProof) SectorID {
-	if !self.ValidatePoRep(self.info.sectorSize, comm, self.info.worker, proof) {
-		Fatal("bad proof!")
-	}
+    if !self.ValidatePoRep(self.info.sectorSize, comm, self.info.worker, proof) {
+        Fatal("bad proof!")
+    }
 
-	// make sure the miner isnt trying to submit a pre-existing sector
-	if !self.EnsureSectorIsUnique(comm) {
-		Fatal("sector already committed!")
-	}
+    // make sure the miner isnt trying to submit a pre-existing sector
+    if !self.EnsureSectorIsUnique(comm) {
+        Fatal("sector already committed!")
+    }
 
-	// Power of the miner after adding this sector
-	futurePower = self.power + self.info.sectorSize
-	collateralRequired = CollateralForPower(futurePower)
+    // Power of the miner after adding this sector
+    futurePower = self.power + self.info.sectorSize
+    collateralRequired = CollateralForPower(futurePower)
 
-	if collateralRequired > vm.MyBalance() {
-		Fatal("not enough collateral")
-	}
+    if collateralRequired > vm.MyBalance() {
+        Fatal("not enough collateral")
+    }
 
-	// Note: There must exist a unique index in the miner's sector set for each
-	// sector ID. The `faults`, `recovered`, and `done` parameters of the
-	// SubmitPoSt method express indices into this sector set.
-	miner.Sectors.Add(sectorID, commR, commD)
+    // Note: There must exist a unique index in the miner's sector set for each
+    // sector ID. The `faults`, `recovered`, and `done` parameters of the
+    // SubmitPoSt method express indices into this sector set.
+    miner.Sectors.Add(sectorID, commR, commD)
 
-	// if miner is not mining, start their proving period now
-	// Note: As written here, every miners first PoSt will only be over one sector.
-	// We could set up a 'grace period' for starting mining that would allow miners
-	// to submit several sectors for their first proving period. Alternatively, we
-	// could simply make the 'CommitSector' call take multiple sectors at a time.
-	//
-	// Note: Proving period is a function of sector size; small sectors take less
-	// time to prove than large sectors do. Sector size is selected when pledging.
-	if miner.ProvingSet.Size() == 0 {
-		miner.ProvingSet = miner.Sectors
-		miner.ProvingPeriodEnd = chain.Now() + ProvingPeriodDuration(miner.SectorSize)
-	}
+    // if miner is not mining, start their proving period now
+    // Note: As written here, every miners first PoSt will only be over one sector.
+    // We could set up a 'grace period' for starting mining that would allow miners
+    // to submit several sectors for their first proving period. Alternatively, we
+    // could simply make the 'CommitSector' call take multiple sectors at a time.
+    //
+    // Note: Proving period is a function of sector size; small sectors take less
+    // time to prove than large sectors do. Sector size is selected when pledging.
+    if miner.ProvingSet.Size() == 0 {
+        miner.ProvingSet = miner.Sectors
+        miner.ProvingPeriodEnd = chain.Now() + ProvingPeriodDuration(miner.SectorSize)
+    }
 }
 
 func CollateralForPower(power BytesAmount) TokenAmount {
-	availableFil = FakeGlobalMethods.GetAvailableFil()
-	totalNetworkPower = StorageMinerActor.GetTotalStorage()
-	numMiners = StorageMarket.GetMinerCount()
-	powerCollateral = availableFil * NetworkConstants.POWER_COLLATERAL_PROPORTION * power / totalNetworkPower
-	perCapitaCollateral = availableFil * NetworkConstants.PER_CAPITA_COLLATERAL_PROPORTION / numMiners
-	collateralRequired = math.Ceil(minerPowerCollateral + minerPerCapitaCollateral)
-	return collateralRequired
+    availableFil = FakeGlobalMethods.GetAvailableFil()
+    totalNetworkPower = StorageMinerActor.GetTotalStorage()
+    numMiners = StorageMarket.GetMinerCount()
+    powerCollateral = availableFil * NetworkConstants.POWER_COLLATERAL_PROPORTION * power / totalNetworkPower
+    perCapitaCollateral = availableFil * NetworkConstants.PER_CAPITA_COLLATERAL_PROPORTION / numMiners
+    collateralRequired = math.Ceil(minerPowerCollateral + minerPerCapitaCollateral)
+    return collateralRequired
 }
 ```
 
@@ -642,45 +642,45 @@ type SubmitPost struct {
 
 ```go
 func SubmitPost(proofs PoStProof, doneSet Bitfield) {
-	if msg.From != self.Worker {
-		Fatal("not authorized to submit post for miner")
-	}
+    if msg.From != self.Worker {
+        Fatal("not authorized to submit post for miner")
+    }
 
-	feesRequired := 0
+    feesRequired := 0
     nextProvingPeriodEnd := self.ProvingPeriodEnd + ProvingPeriodDuration(self.SectorSize)
 
     // TODO: rework fault handling, for now anything later than 2 proving periods is invalid
     if chain.now() > nextProvingPeriodEnd {
         Fatal("PoSt submited too late")
-	} else if chain.Now() > self.ProvingPeriodEnd {
-		feesRequired += ComputeLateFee(self.power, chain.Now() - self.provingPeriodEnd)
-	}
+    } else if chain.Now() > self.ProvingPeriodEnd {
+        feesRequired += ComputeLateFee(self.power, chain.Now() - self.provingPeriodEnd)
+    }
 
-	feesRequired += ComputeTemporarySectorFailureFee(self.sectorSize, self.currentFaultSet)
+    feesRequired += ComputeTemporarySectorFailureFee(self.sectorSize, self.currentFaultSet)
 
-	if msg.Value < feesRequired {
-		Fatal("not enough funds to pay post submission fees")
-	}
+    if msg.Value < feesRequired {
+        Fatal("not enough funds to pay post submission fees")
+    }
 
-	// we want to ensure that the miner can submit more fees than required, just in case
-	if msg.Value > feesRequired {
-		TransferFunds(msg.From, msg.Value-feesRequired)
-	}
+    // we want to ensure that the miner can submit more fees than required, just in case
+    if msg.Value > feesRequired {
+        TransferFunds(msg.From, msg.Value-feesRequired)
+    }
 
     var seed
     if chain.Now() < self.ProvingPeriodEnd {
-      // good case, submitted in time
-      seed = GetRandFromBlock(self.ProvingPeriodEnd - POST_CHALLENGE_TIME)
+        // good case, submitted in time
+        seed = GetRandFromBlock(self.ProvingPeriodEnd - POST_CHALLENGE_TIME)
     } else {
-      // bad case, submitted late, need to take new proving period end as reference
-      seed = GetRandFromBlock(nextPovingPeriodEnd - POST_CHALLENGE_TIME)
+        // bad case, submitted late, need to take new proving period end as reference
+        seed = GetRandFromBlock(nextPovingPeriodEnd - POST_CHALLENGE_TIME)
     }
 
     faultSet := self.currentFaultSet
 
-	if !VerifyPoSt(self.SectorSize, self.provingSet, seed, proof, faultSet) {
-		Fatal("proof invalid")
-	}
+    if !VerifyPoSt(self.SectorSize, self.provingSet, seed, proof, faultSet) {
+        Fatal("proof invalid")
+    }
 
     // The next fault set becomes the current one
     self.currentFaultSet = self.nextFaultSet
@@ -688,35 +688,35 @@ func SubmitPost(proofs PoStProof, doneSet Bitfield) {
 
     // TODO: penalize for faults
 
-	// Remove doneSet from the current sectors
-	self.Sectors.Subtract(doneSet)
+    // Remove doneSet from the current sectors
+    self.Sectors.Subtract(doneSet)
 
-	// Update miner power to the amount of data actually proved during the last proving period.
-	oldPower := self.Power
+    // Update miner power to the amount of data actually proved during the last proving period.
+    oldPower := self.Power
 
-	self.Power = (self.ProvingSet.Size() - faultSet.Count()) * self.SectorSize
-	StorageMarket.UpdateStorage(self.Power - oldPower)
+    self.Power = (self.ProvingSet.Size() - faultSet.Count()) * self.SectorSize
+    StorageMarket.UpdateStorage(self.Power - oldPower)
 
-	self.ProvingSet = self.Sectors
+    self.ProvingSet = self.Sectors
 
-	// Updating proving period given a fixed schedule, independent of late submissions.
-	self.ProvingPeriodEnd = nextProvingPeriodEnd
+    // Updating proving period given a fixed schedule, independent of late submissions.
+    self.ProvingPeriodEnd = nextProvingPeriodEnd
 
-	// update next done set
-	self.NextDoneSet = done
-	self.ArbitratedDeals.Clear()
+    // update next done set
+    self.NextDoneSet = done
+    self.ArbitratedDeals.Clear()
 }
 
 func ProvingPeriodDuration(sectorSize uint64) Integer {
-	return 24 * 60 * 60 * 2 // number of blocks in one day
+    return 24 * 60 * 60 * 2 // number of blocks in one day
 }
 
 func ComputeLateFee(power Integer, blocksLate Integer) TokenAmount {
-	return 4 // TODO: real collateral calculation, obviously
+    return 4 // TODO: real collateral calculation, obviously
 }
 
 func ComputeTemporarySectorFailureFee(sectorSize BytesAmount, numSectors Integer) TokenAmount {
-	return 4 // TODO: something tells me that 4 might not work in all situations. probably should find a better way to compute this
+    return 4 // TODO: something tells me that 4 might not work in all situations. probably should find a better way to compute this
 }
 ```
 
@@ -734,37 +734,37 @@ type SlashStorageFault struct {
 
 ```go
 func SlashStorageFault() {
-	// You can only be slashed once for missing your PoSt.
-	if self.SlashedAt > 0 {
-		Fatal("miner already slashed")
-	}
+    // You can only be slashed once for missing your PoSt.
+    if self.SlashedAt > 0 {
+        Fatal("miner already slashed")
+    }
 
-	// Only if the miner is actually late, they can be slashed.
-	if chain.Now() <= self.ProvingPeriodEnd+GenerationAttackTime(self.SectorSize) {
-		Fatal("miner is not yet tardy")
-	}
+    // Only if the miner is actually late, they can be slashed.
+    if chain.Now() <= self.ProvingPeriodEnd+GenerationAttackTime(self.SectorSize) {
+        Fatal("miner is not yet tardy")
+    }
 
-	// Only a miner who is expected to prove, can be slashed.
-	if self.ProvingSet.Size() == 0 {
-		Fatal("miner is inactive")
-	}
+    // Only a miner who is expected to prove, can be slashed.
+    if self.ProvingSet.Size() == 0 {
+        Fatal("miner is inactive")
+    }
 
-	// Strip the miner of their power.
-	StorageMarketActor.UpdateStorage(-1 * self.Power)
-	self.Power = 0
+    // Strip the miner of their power.
+    StorageMarketActor.UpdateStorage(-1 * self.Power)
+    self.Power = 0
 
-	self.slashedSet = self.ProvingSet
-	// remove proving set from our sectors
-	self.sectors.Substract(self.slashedSet)
+    self.slashedSet = self.ProvingSet
+    // remove proving set from our sectors
+    self.sectors.Substract(self.slashedSet)
 
-	// clear proving set
-	self.ProvingSet = nil
+    // clear proving set
+    self.ProvingSet = nil
 
-	self.owedStorageCollateral = StorageMarketActor.StorageCollateralForSize(
-		self.slashedSet.Size() * self.SectorSize,
-	)
+    self.owedStorageCollateral = StorageMarketActor.StorageCollateralForSize(
+        self.slashedSet.Size() * self.SectorSize,
+    )
 
-	self.SlashedAt = CurrentBlockHeight
+    self.SlashedAt = CurrentBlockHeight
 }
 ```
 
@@ -781,7 +781,7 @@ type GetCurrentProvingSet struct {
 
 ```go
 func GetCurrentProvingSet() [][]byte {
-	return self.ProvingSet
+    return self.ProvingSet
 }
 ```
 
@@ -805,44 +805,44 @@ type ArbitrateDeal struct {
 
 ```go
 func AbitrateDeal(deal Deal) {
-	if !VM.ValidateSignature(deal, self.Worker) {
-		Fatal("invalid signature on deal")
-	}
+    if !VM.ValidateSignature(deal, self.Worker) {
+        Fatal("invalid signature on deal")
+    }
 
-	if VM.CurrentBlockHeight() < deal.StartTime {
-		Fatal("Deal not yet started")
-	}
+    if VM.CurrentBlockHeight() < deal.StartTime {
+        Fatal("Deal not yet started")
+    }
 
-	if deal.Expiry < VM.CurrentBlockHeight() {
-		Fatal("Deal is expired")
-	}
+    if deal.Expiry < VM.CurrentBlockHeight() {
+        Fatal("Deal is expired")
+    }
 
-	if !self.NextDoneSet.Has(deal.pieceInclusionProof.sectorID) {
-		Fatal("Deal agreement not broken, or arbitration too late")
-	}
+    if !self.NextDoneSet.Has(deal.pieceInclusionProof.sectorID) {
+        Fatal("Deal agreement not broken, or arbitration too late")
+    }
 
-	if self.ArbitratedDeals.Has(deal.commP) {
-		Fatal("cannot slash miner twice for same deal")
-	}
+    if self.ArbitratedDeals.Has(deal.commP) {
+        Fatal("cannot slash miner twice for same deal")
+    }
 
-	if !deal.pieceInclusionProof.Verify(deal.commP, deal.size) {
-		Fatal("invalid piece inclusion proof or size")
-	}
+    if !deal.pieceInclusionProof.Verify(deal.commP, deal.size) {
+        Fatal("invalid piece inclusion proof or size")
+    }
 
-	storageCollateral := StorageMarketActor.StorageCollateralForSize(deal.size)
+    storageCollateral := StorageMarketActor.StorageCollateralForSize(deal.size)
 
-	if self.owedStorageCollateral < storageCollateral {
-		Fatal("math is hard, and we didnt do it right")
-	}
+    if self.owedStorageCollateral < storageCollateral {
+        Fatal("math is hard, and we didnt do it right")
+    }
 
-	// pay the client the storage collateral
-	VM.TransferFunds(storageCollateral, deal.client)
+    // pay the client the storage collateral
+    VM.TransferFunds(storageCollateral, deal.client)
 
-	// keep track of how much we have payed out
-	self.owedStorageCollateral -= storageCollateral
+    // keep track of how much we have payed out
+    self.owedStorageCollateral -= storageCollateral
 
-	// make sure the miner can't be slashed twice for this deal
-	self.ArbitratedDeals.Add(deal.commP)
+    // make sure the miner can't be slashed twice for this deal
+    self.ArbitratedDeals.Add(deal.commP)
 }
 ```
 
@@ -864,29 +864,29 @@ type DePledge struct {
 
 ```go
 func DePledge(amt TokenAmount) {
-	if msg.From != self.info.Worker && msg.From != self.info.owner {
-		Fatal("Not authorized to call DePledge")
-	}
+    if msg.From != self.info.Worker && msg.From != self.info.owner {
+        Fatal("Not authorized to call DePledge")
+    }
 
-	if self.DePledgeTime > 0 {
-		if self.DePledgeTime > VM.CurrentBlockHeight() {
-			Fatal("too early to withdraw collateral")
-		}
+    if self.DePledgeTime > 0 {
+        if self.DePledgeTime > VM.CurrentBlockHeight() {
+            Fatal("too early to withdraw collateral")
+        }
 
-		TransferFunds(self.info.owner, self.DePledgedCollateral)
-		self.DePledgeTime = 0
-		self.DePledgedCollateral = 0
-		return
-	}
+        TransferFunds(self.info.owner, self.DePledgedCollateral)
+        self.DePledgeTime = 0
+        self.DePledgedCollateral = 0
+        return
+    }
 
-	collateralRequired = CollateralForPower(self.power)
+    collateralRequired = CollateralForPower(self.power)
 
-	if amt+collateralRequired > vm.MyBalance() {
-		Fatal("Not enough free collateral to withdraw that much")
-	}
+    if amt+collateralRequired > vm.MyBalance() {
+        Fatal("Not enough free collateral to withdraw that much")
+    }
 
-	self.DePledgedCollateral = amt
-	self.DePledgeTime = CurrentBlockHeight + DePledgeCooldown
+    self.DePledgedCollateral = amt
+    self.DePledgeTime = CurrentBlockHeight + DePledgeCooldown
 }
 ```
 
@@ -902,7 +902,7 @@ type GetOwner struct {
 
 ```go
 func GetOwner() Address {
-	return self.info.owner
+    return self.info.owner
 }
 ```
 
@@ -919,7 +919,7 @@ type GetWorkerAddr struct {
 
 ```go
 func GetWorkerAddr() Address {
-	return self.info.worker
+    return self.info.worker
 }
 ```
 
@@ -936,7 +936,7 @@ type GetPower struct {
 
 ```go
 func GetPower() BytesAmount {
-	return self.power
+    return self.power
 }
 ```
 
@@ -953,7 +953,7 @@ type GetPeerID struct {
 
 ```go
 func GetPeerID() PeerID {
-	return self.info.peerID
+    return self.info.peerID
 }
 ```
 
@@ -970,7 +970,7 @@ type GetSectorSize struct {
 
 ```go
 func GetSectorSize() BytesAmount {
-	return self.info.sectorSize
+    return self.info.sectorSize
 }
 ```
 
@@ -988,11 +988,11 @@ type UpdatePeerID struct {
 
 ```go
 func UpdatePeerID(pid PeerID) {
-	if msg.From != self.info.worker {
-		Fatal("only the mine worker may update the peer ID")
-	}
+    if msg.From != self.info.worker {
+        Fatal("only the mine worker may update the peer ID")
+    }
 
-	self.info.peerID = pid
+    self.info.peerID = pid
 }
 ```
 
@@ -1012,11 +1012,11 @@ type ChangeWorker struct {
 
 ```go
 func ChangeWorker(addr Address) {
-	if msg.From != self.info.owner {
-		Fatal("only the owner can change the worker address")
-	}
+    if msg.From != self.info.owner {
+        Fatal("only the owner can change the worker address")
+    }
 
-	self.info.worker = addr
+    self.info.worker = addr
 }
 ```
 
@@ -1161,15 +1161,15 @@ The payment channel actor manages the on-chain state of a point to point payment
 
 ```sh
 type PaymentChannel struct {
-	from Address
-	to   Address
+    from Address
+    to   Address
 
-	toSend       TokenAmount
+    toSend       TokenAmount
 
-	closingAt      UInt
-	minCloseHeight UInt
+    closingAt      UInt
+    minCloseHeight UInt
 
-	laneStates {UInt:LaneState}
+    laneStates {UInt:LaneState}
 } representation tuple
 
 type SignedVoucher struct {
@@ -1253,79 +1253,79 @@ type UpdateChannelState struct {
 
 ```go
 func UpdateChannelState(sv SignedVoucher, secret []byte, proof []byte) {
-	if !self.validateSignature(sv) {
-		Fatal("Signature Invalid")
-	}
+    if !self.validateSignature(sv) {
+        Fatal("Signature Invalid")
+    }
 
-	if chain.Now() < sv.TimeLock {
-		Fatal("cannot use this voucher yet!")
-	}
+    if chain.Now() < sv.TimeLock {
+        Fatal("cannot use this voucher yet!")
+    }
 
-	if sv.SecretPreimage != nil {
-		if Hash(secret) != sv.SecretPreimage {
-			Fatal("Incorrect secret!")
-		}
-	}
+    if sv.SecretPreimage != nil {
+        if Hash(secret) != sv.SecretPreimage {
+            Fatal("Incorrect secret!")
+        }
+    }
 
-	if sv.Extra != nil {
-		ret := vmctx.Send(sv.Extra.Actor, sv.Extra.Method, sv.Extra.Data, proof)
-		if ret != 0 {
-			Fatal("spend voucher verification failed")
-		}
-	}
+    if sv.Extra != nil {
+        ret := vmctx.Send(sv.Extra.Actor, sv.Extra.Method, sv.Extra.Data, proof)
+        if ret != 0 {
+            Fatal("spend voucher verification failed")
+        }
+    }
 
-	ls := self.LaneStates[sv.Lane]
-	if ls.Closed {
-		Fatal("cannot redeem a voucher on a closed lane")
-	}
+    ls := self.LaneStates[sv.Lane]
+    if ls.Closed {
+        Fatal("cannot redeem a voucher on a closed lane")
+    }
 
-	if ls.Nonce > sv.Nonce {
-		Fatal("voucher has an outdated nonce, cannot redeem")
-	}
+    if ls.Nonce > sv.Nonce {
+        Fatal("voucher has an outdated nonce, cannot redeem")
+    }
 
-	var mergeValue TokenAmount
-	for _, merge := range sv.Merges {
-		if merge.Lane == sv.Lane {
-			Fatal("voucher cannot merge its own lane")
-		}
+    var mergeValue TokenAmount
+    for _, merge := range sv.Merges {
+        if merge.Lane == sv.Lane {
+            Fatal("voucher cannot merge its own lane")
+        }
 
-		ols := self.LaneStates[merge.Lane]
-		if ols.Nonce >= merge.Nonce {
-			Fatal("merge in voucher has outdated nonce, cannot redeem")
-		}
+        ols := self.LaneStates[merge.Lane]
+        if ols.Nonce >= merge.Nonce {
+            Fatal("merge in voucher has outdated nonce, cannot redeem")
+        }
 
-		mergeValue += ols.Redeemed
-		ols.Nonce = merge.Nonce
-	}
+        mergeValue += ols.Redeemed
+        ols.Nonce = merge.Nonce
+    }
 
-	ls.Nonce = sv.Nonce
-	balanceDelta = sv.Amount - (mergeValue + ls.Redeemed)
-	ls.Redeemed = sv.Amount
+    ls.Nonce = sv.Nonce
+    balanceDelta = sv.Amount - (mergeValue + ls.Redeemed)
+    ls.Redeemed = sv.Amount
 
-	newSendBalance = self.ToSend + balanceDelta
-	if newSendBalance < 0 {
-		// TODO: is this impossible?
-		Fatal("voucher would leave channel balance negative")
-	}
+    newSendBalance = self.ToSend + balanceDelta
+    if newSendBalance < 0 {
+        // TODO: is this impossible?
+        Fatal("voucher would leave channel balance negative")
+    }
 
-	if newSendBalance > self.Balance {
-		Fatal("not enough funds in channel to cover voucher")
-	}
+    if newSendBalance > self.Balance {
+        Fatal("not enough funds in channel to cover voucher")
+    }
 
-	self.ToSend = newSendBalance
+    self.ToSend = newSendBalance
 
-	if sv.MinCloseHeight != 0 {
-		if self.ClosingAt != 0 && self.ClosingAt < sv.MinCloseHeight {
-			self.ClosingAt = sv.MinCloseHeight
-		}
-		if self.MinCloseHeight < sv.MinCloseHeight {
-			self.MinCloseHeight = sv.MinCloseHeight
-		}
-	}
+    if sv.MinCloseHeight != 0 {
+        if self.ClosingAt != 0 && self.ClosingAt < sv.MinCloseHeight {
+            self.ClosingAt = sv.MinCloseHeight
+        }
+        if self.MinCloseHeight < sv.MinCloseHeight {
+            self.MinCloseHeight = sv.MinCloseHeight
+        }
+    }
 }
 
 func Hash(b []byte) []byte {
-	return blake2b.Sum(b)
+    return blake2b.Sum(b)
 }
 ```
 
@@ -1344,17 +1344,17 @@ type Close struct {
 const ChannelClosingDelay = 6 * 60 * 2 // six hours
 
 func Close() {
-	if msg.From != self.From && msg.From != self.To {
-		Fatal("not authorized to close channel")
-	}
-	if self.ClosingAt != 0 {
-		Fatal("Channel already closing")
-	}
+    if msg.From != self.From && msg.From != self.To {
+        Fatal("not authorized to close channel")
+    }
+    if self.ClosingAt != 0 {
+        Fatal("Channel already closing")
+    }
 
-	self.ClosingAt = chain.Now() + ChannelClosingDelay
-	if self.ClosingAt < self.MinCloseHeight {
-		self.ClosingAt = self.MinCloseHeight
-	}
+    self.ClosingAt = chain.Now() + ChannelClosingDelay
+    if self.ClosingAt < self.MinCloseHeight {
+        self.ClosingAt = self.MinCloseHeight
+    }
 }
 ```
 
@@ -1371,17 +1371,17 @@ type Collect struct {
 
 ```go
 func Collect() {
-	if self.ClosingAt == 0 {
-		Fatal("payment channel not closing or closed")
-	}
+    if self.ClosingAt == 0 {
+        Fatal("payment channel not closing or closed")
+    }
 
-	if chain.Now() < self.ClosingAt {
-		Fatal("Payment channel not yet closed")
-	}
+    if chain.Now() < self.ClosingAt {
+        Fatal("Payment channel not yet closed")
+    }
 
-	TransferFunds(self.From, self.Balance-self.ToSend)
-	TransferFunds(self.To, self.ToSend)
-  self.ToSend = 0
+    TransferFunds(self.From, self.Balance-self.ToSend)
+    TransferFunds(self.To, self.ToSend)
+    self.ToSend = 0
 }
 ```
 
@@ -1456,11 +1456,11 @@ type MultisigConstructor struct {
 
 ```go
 func Multisig(signers []Address, required UInt, unlockDuration UInt) {
-	self.Signers = signers
-	self.Required = required
-	self.initialBalance = msg.Value
-	self.unlockDuration = unlockDuration
-	self.startingBlock = VM.CurrentBlockHeight()
+    self.Signers = signers
+    self.Required = required
+    self.initialBalance = msg.Value
+    self.unlockDuration = unlockDuration
+    self.startingBlock = VM.CurrentBlockHeight()
 }
 ```
 
@@ -1486,33 +1486,33 @@ type Propose struct {
 
 ```go
 func Propose(to Address, value TokenAmount, method String, params Bytes) UInt {
-	if !isSigner(msg.From) {
-		Fatal("not authorized")
-	}
+    if !isSigner(msg.From) {
+        Fatal("not authorized")
+    }
 
-	txid := self.NextTxID
-	self.NextTxID++
+    txid := self.NextTxID
+    self.NextTxID++
 
-	tx := Transaction{
-		TxID:     txid,
-		To:       to,
-		Value:    value,
-		Method:   method,
-		Params:   params,
-		Approved: []Address{msg.From},
-	}
+    tx := Transaction{
+        TxID:     txid,
+        To:       to,
+        Value:    value,
+        Method:   method,
+        Params:   params,
+        Approved: []Address{msg.From},
+    }
 
-	self.Transactions.Append(tx)
+    self.Transactions.Append(tx)
 
-	if self.Required == 1 {
-		if !self.canSpend(tx.value) {
-			Fatal("transaction amount exceeds available")
-		}
-		tx.RetCode = vm.Send(tx.To, tx.Value, tx.Method, tx.Params)
-		tx.Complete = true
-	}
+    if self.Required == 1 {
+        if !self.canSpend(tx.value) {
+            Fatal("transaction amount exceeds available")
+        }
+        tx.RetCode = vm.Send(tx.To, tx.Value, tx.Method, tx.Params)
+        tx.Complete = true
+    }
 
-	return txid
+    return txid
 }
 ```
 
@@ -1533,33 +1533,33 @@ type Approve struct {
 
 ```go
 func Approve(txid UInt) {
-	if !self.isSigner(msg.From) {
-		Fatal("not authorized")
-	}
+    if !self.isSigner(msg.From) {
+        Fatal("not authorized")
+    }
 
-	tx := self.getTransaction(txid)
-	if tx.Complete {
-		Fatal("transaction already completed")
-	}
-	if tx.Canceled {
-		Fatal("transaction canceled")
-	}
+    tx := self.getTransaction(txid)
+    if tx.Complete {
+        Fatal("transaction already completed")
+    }
+    if tx.Canceled {
+        Fatal("transaction canceled")
+    }
 
-	for _, signer := range tx.Approved {
-		if signer == msg.From {
-			Fatal("already signed this message")
-		}
-	}
+    for _, signer := range tx.Approved {
+        if signer == msg.From {
+            Fatal("already signed this message")
+        }
+    }
 
-	tx.Approved.Append(msg.From)
+    tx.Approved.Append(msg.From)
 
-	if len(tx.Approved) >= self.Required {
-		if !self.canSpend(tx.Value) {
-			Fatal("transaction amount exceeds available")
-		}
-		tx.RetCode = vm.Send(tx.To, tx.Value, tx.Method, tx.Params)
-		tx.Complete = true
-	}
+    if len(tx.Approved) >= self.Required {
+        if !self.canSpend(tx.Value) {
+            Fatal("transaction amount exceeds available")
+        }
+        tx.RetCode = vm.Send(tx.To, tx.Value, tx.Method, tx.Params)
+        tx.Complete = true
+    }
 }
 ```
 
@@ -1577,24 +1577,24 @@ type Cancel struct {
 
 ```go
 func Cancel(txid UInt) {
-	if !self.isSigner(msg.From) {
-		Fatal("not authorized")
-	}
+    if !self.isSigner(msg.From) {
+        Fatal("not authorized")
+    }
 
-	tx := self.getTransaction(txid)
-	if tx.Complete {
-		Fatal("cannot cancel completed transaction")
-	}
-	if tx.Canceled {
-		Fatal("transaction already canceled")
-	}
+    tx := self.getTransaction(txid)
+    if tx.Complete {
+        Fatal("cannot cancel completed transaction")
+    }
+    if tx.Canceled {
+        Fatal("transaction already canceled")
+    }
 
-	proposer := tx.Approved[0]
-	if proposer != msg.From && isSigner(proposer) {
-		Fatal("cannot cancel another signers transaction")
-	}
+    proposer := tx.Approved[0]
+    if proposer != msg.From && isSigner(proposer) {
+        Fatal("cannot cancel another signers transaction")
+    }
 
-	tx.Canceled = true
+    tx.Canceled = true
 }
 ```
 
@@ -1611,15 +1611,15 @@ type ClearCompleted struct {
 
 ```go
 func ClearCompleted() {
-	if !self.isSigner(msg.From) {
-		Fatal("not authorized")
-	}
+    if !self.isSigner(msg.From) {
+        Fatal("not authorized")
+    }
 
-	for tx := range self.Transactions {
-		if tx.Completed || tx.Canceled {
-			self.Transactions.Remove(tx)
-		}
-	}
+    for tx := range self.Transactions {
+        if tx.Completed || tx.Canceled {
+            self.Transactions.Remove(tx)
+        }
+    }
 }
 ```
 
@@ -1638,17 +1638,17 @@ type AddSigner struct {
 
 ```go
 func AddSigner(signer Address, increaseReq bool) {
-	if msg.From != self.Address {
-		Fatal("add signer must be called by wallet itself")
-	}
-	if self.isSigner(signer) {
-		Fatal("new address is already a signer")
-	}
-	if increaseReq {
-		self.Required = self.Required + 1
-	}
+    if msg.From != self.Address {
+        Fatal("add signer must be called by wallet itself")
+    }
+    if self.isSigner(signer) {
+        Fatal("new address is already a signer")
+    }
+    if increaseReq {
+        self.Required = self.Required + 1
+    }
 
-	self.Signers.Append(signer)
+    self.Signers.Append(signer)
 }
 ```
 
@@ -1667,18 +1667,18 @@ type RemoveSigner struct {
 
 ```go
 func RemoveSigner(signer Address, decreaseReq bool) {
-	if msg.From != self.Address {
-		Fatal("remove signer must be called by wallet itself")
-	}
-	if !self.isSigner(signer) {
-		Fatal("given address was not a signer")
-	}
-	if decreaseReq || len(self.Signers)-1 < self.Required {
-		// Reduce Required outherwise the wallet is locked out
-		self.Required = self.Required - 1
-	}
+    if msg.From != self.Address {
+        Fatal("remove signer must be called by wallet itself")
+    }
+    if !self.isSigner(signer) {
+        Fatal("given address was not a signer")
+    }
+    if decreaseReq || len(self.Signers)-1 < self.Required {
+        // Reduce Required outherwise the wallet is locked out
+        self.Required = self.Required - 1
+    }
 
-	self.Signers.Remove(signer)
+    self.Signers.Remove(signer)
 }
 ```
 
@@ -1697,18 +1697,18 @@ type SwapSigner struct {
 
 ```go
 func SwapSigner(old Address, new Address) {
-	if msg.From != self.Address {
-		Fatal("swap signer must be called by wallet itself")
-	}
-	if !self.isSigner(old) {
-		Fatal("given old address was not a signer")
-	}
-	if self.isSigner(new) {
-		Fatal("given new address was already a signer")
-	}
+    if msg.From != self.Address {
+        Fatal("swap signer must be called by wallet itself")
+    }
+    if !self.isSigner(old) {
+        Fatal("given old address was not a signer")
+    }
+    if self.isSigner(new) {
+        Fatal("given new address was already a signer")
+    }
 
-	self.Signers.Remove(old)
-	self.Signers.Append(new)
+    self.Signers.Remove(old)
+    self.Signers.Append(new)
 }
 ```
 
@@ -1726,17 +1726,17 @@ type ChangeRequirement struct {
 
 ```go
 func ChangeRequirement(req UInt) {
-	if msg.From != self.Address {
-		Fatal("change requirement must be called by wallet itself")
-	}
-	if req < 1 {
-		Fatal("requirement must be at least 1")
-	}
-	if req > len(self.Signers) {
-		Fatal("requirement must be less than number of signers")
-	}
+    if msg.From != self.Address {
+        Fatal("change requirement must be called by wallet itself")
+    }
+    if req < 1 {
+        Fatal("requirement must be at least 1")
+    }
+    if req > len(self.Signers) {
+        Fatal("requirement must be less than number of signers")
+    }
 
-	self.Required = req
+    self.Required = req
 }
 ```
 
@@ -1746,48 +1746,48 @@ The various helper methods called above are defined here.
 
 ```go
 func isSigner(a Address) bool {
-	for signer := range self.Signers {
-		if a == signer {
-			return true
-		}
-	}
-	return false
+    for signer := range self.Signers {
+        if a == signer {
+            return true
+        }
+    }
+    return false
 }
 ```
 
 ```go
 func getTransaction(txid UInt) Transaction {
-	tx, ok := self.Transactions[txid]
-	if !ok {
-		Fatal("no such transaction")
-	}
+    tx, ok := self.Transactions[txid]
+    if !ok {
+        Fatal("no such transaction")
+    }
 
-	return tx
+    return tx
 }
 ```
 
 ```go
 func AggregateBitfields(faults []FaultSet) Bitfield {
-	var out Bitfield
-	for _, f := range faults {
-		out = out.Union(f.bitField)
-	}
-	return out
+    var out Bitfield
+    for _, f := range faults {
+        out = out.Union(f.bitField)
+    }
+    return out
 }
 ```
 
 ```go
 func BurnFunds(amt TokenAmount) {
-	TransferFunds(BurntFundsAddress, amt)
+    TransferFunds(BurntFundsAddress, amt)
 }
 ```
 
 ```go
 func canSpend(amt TokenAmount) bool {
-	if self.unlockDuration == 0 {
-		return true
-	}
-	var MinAllowableBalance = (self.initialBalance / self.unlockDuration) * (VM.CurrentBlockHeight() - self.startingBlock)
-	return MinAllowableBalance >= (vm.MyBalance() - amt)
+    if self.unlockDuration == 0 {
+        return true
+    }
+    var MinAllowableBalance = (self.initialBalance / self.unlockDuration) * (VM.CurrentBlockHeight() - self.startingBlock)
+    return MinAllowableBalance >= (vm.MyBalance() - amt)
 }
 ```


### PR DESCRIPTION
## Why does this PR exist?

The formatting in actors.md is all sorts of bad. We sometimes use two spaces to indent, sometimes four, and sometimes a tab. See inline image for an example.

## What's in this PR?

This PR replaces all tabs with four spaces, and replaces two space-indents with four.

<img width="421" alt="Screen Shot 2019-08-29 at 1 24 27 PM" src="https://user-images.githubusercontent.com/884507/63973849-7c254800-ca60-11e9-9e29-07f8aac4bc01.png">