### PR TITLE
bug(correctly terminate code blocks)

### DIFF
--- a/actors.md
+++ b/actors.md
@@ -484,7 +484,9 @@ type StorageMinerActorState struct {
 
     provingPeriodEnd BlockHeight
 }
+```
 
+```sh
 type MinerInfo struct {
 	## Account that owns this miner.
     ## - Income and returned collateral are paid to this address.
@@ -504,6 +506,7 @@ type MinerInfo struct {
     sectorSize BytesAmount
 
 }
+```
 
 #### Methods
 


### PR DESCRIPTION
## Why does this PR exist?

We aren't properly closing a code block, which means that some of the storage market actor stuff ends up incorrectly formatted. See screenshot.

## What's in this PR?

This PR closes the code blocks around pseudocode such that markdown headers render correctly.

<img width="583" alt="Screen Shot 2019-08-29 at 1 39 23 PM" src="https://user-images.githubusercontent.com/884507/63974876-952ef880-ca62-11e9-90c5-de6268c8fab1.png">
