### PR TITLE
incomplete: storageCollateral is actually pledgeCollateral

### DIFF
--- a/actors.md
+++ b/actors.md
@@ -217,7 +217,7 @@ type StorageMarketActorState struct {
 | `GetTotalStorage` | 5 |
 | `PowerLookup` | 6 |
 | `IsMiner` | 7 |
-| `StorageCollateralForSize` | 8 |
+| `PledgeCollateralForSize` | 8 |
 
 #### `Constructor`
 
@@ -413,13 +413,13 @@ func IsMiner(addr Address) bool {
 }
 ```
 
-#### `StorageCollateralForSize`
+#### `PledgeCollateralForSize`
 
 
 **Parameters**
 
 ```sh
-type StorageCollateralForSize struct {
+type PledgeCollateralForSize struct {
     size UInt
 } representation tuple
 ```
@@ -427,7 +427,7 @@ type StorageCollateralForSize struct {
 **Algorithm**
 
 ```go
-func StorageCollateralforSize(size UInt) TokenAmount {
+func PledgeCollateralforSize(size UInt) TokenAmount {
 	// TODO:
 }
 ```


### PR DESCRIPTION
Was implementing `SlashConsensusFault` and it was calling this method, but actually meaning for it to be PledgeCollateral. 

The references to this need to be updated, and there is one place where we actually care about storage collateral, but the way to calculate storage collateral should be done on the miner (since miners set their own storage collateral prices)