### PR TITLE
schemas: remove usage of 'UInt' in IPLD schemas

### DIFF
--- a/actors.md
+++ b/actors.md
@@ -32,7 +32,7 @@ The init actor is responsible for creating new actors on the filecoin network. T
 ```sh
 type InitActorState struct {
     addressMap {Address:ID}<Hamt>
-    nextId UInt
+    nextId Int
 }
 ```
 
@@ -420,7 +420,7 @@ func IsMiner(addr Address) bool {
 
 ```sh
 type StorageCollateralForSize struct {
-    size UInt
+    size Int
 } representation tuple
 ```
 
@@ -471,7 +471,7 @@ type StorageMinerActorState struct {
     arbitratedDeals {Cid:Null}
 
 	## Amount of power this miner has.
-    power UInt
+    power Int
 
     ## List of sectors that this miner was slashed for.
     slashedSet optional &SectorSet
@@ -1169,40 +1169,40 @@ type PaymentChannel struct {
 
 	toSend       TokenAmount
 
-	closingAt      UInt
-	minCloseHeight UInt
+	closingAt      Int
+	minCloseHeight Int
 
-	laneStates {UInt:LaneState}
+	laneStates {Int:LaneState}
 } representation tuple
 
 type SignedVoucher struct {
   TimeLock BlockHeight
   SecretPreimage Bytes
   Extra ModVerifyParams
-  Lane Uint
-  Nonce Uint
+  Lane Int
+  Nonce Int
   Merges []Merge
   Amount TokenAmount
-  MinCloseHeight Uint
+  MinCloseHeight Int
 
   Signature Signature
 }
 
 type ModVerifyParams struct {
   Actor Address
-  Method Uint
+  Method Int
   Data Bytes
 }
 
 type Merge struct {
-  Lane Uint
-  Nonce Uint
+  Lane Int
+  Nonce Int
 }
 
 type LaneState struct {
   Closed bool
   Redeemed TokenAmount
-  Nonce Uint
+  Nonce Int
 }
 
 type PaymentChannelMethod union {
@@ -1403,23 +1403,23 @@ The [init actor](#init-actor) is used to create new instances of the multisig.
 ```sh
 type MultisigActorState struct {
     signers [Address]
-    required UInt
-    nextTxId UInt
-    initialBalance UInt
-    startingBlock UInt
-    unlockDuration UInt
-    transactions {UInt:Transaction}
+    required Int
+    nextTxId Int
+    initialBalance Int
+    startingBlock Int
+    unlockDuration Int
+    transactions {Int:Transaction}
 }
 
 type Transaction struct {
-    txID UInt
+    txID Int
     to Address
     value TokenAmount
     method &ActorMethod
     approved [Address]
     completed Bool
     canceled Bool
-    retcode UInt
+    retcode Int
 }
 ```
 
@@ -1449,9 +1449,9 @@ type MultisigConstructor struct {
     ## The addresses that will be the signatories of this wallet.
     signers [Address]
     ## The number of signatories required to perform a transaction.
-    required UInt
+    required Int
     ## Unlock time (in blocks) of initial filecoin balance of this wallet. Unlocking is linear.
-    unlockDuration UInt
+    unlockDuration Int
 } representation tuple
 ```
 
@@ -1528,7 +1528,7 @@ Approve is called by a signer to approve a given transaction. If their approval 
 ```sh
 type Approve struct {
     ## The ID of the transaction to approve.
-    txid UInt
+    txid Int
 } representation tuple
 ```
 
@@ -1572,7 +1572,7 @@ func Approve(txid UInt) {
 
 ```sh
 type Cancel struct {
-    txid UInt
+    txid Int
 } representation tuple
 ```
 
@@ -1721,7 +1721,7 @@ func SwapSigner(old Address, new Address) {
 
 ```sh
 type ChangeRequirement struct {
-    requirement UInt
+    requirement Int
 } representation tuple
 ```
 

--- a/address.md
+++ b/address.md
@@ -51,7 +51,7 @@ type Address union {
 } representation byteprefix
 
 ## ID
-type AddressId UInt
+type AddressId Int
 
 ## Blake2b-160 Hash
 type AddressSecp256k1 Bytes

--- a/data-structures.md
+++ b/data-structures.md
@@ -50,10 +50,10 @@ type BlockHeader struct {
 	parents [&Block]
 
 	## ParentWeight is the aggregate chain weight of the parent set.
-	parentWeight UInt
+	parentWeight Int
 
 	## Height is the chain height of this block.
-	height UInt
+	height Int
 
 	## StateRoot is a cid pointer to the state tree after application of the
 	## transactions state transitions.
@@ -161,14 +161,14 @@ type UnsignedMessage struct {
 
 	## When receiving a message from a user account the nonce in the message must match the expected
 	## nonce in the from actor. This prevents replay attacks.
-	nonce UInt
+	nonce Int
 
-	value UInt
+	value Int
 
-	gasPrice UInt
-	gasLimit UInt
+	gasPrice Int
+	gasLimit Int
 
-	method Uint
+	method Int
 
 	## Serialized parameters to the method
 	params Bytes
@@ -197,9 +197,9 @@ type StateTree map {ID:Actor}<Hamt>
 
 ```sh
 type MessageReceipt struct {
-	exitCode UInt
+	exitCode Int
 	return Bytes
-	gasUsed UInt
+	gasUsed Int
 } representation tuple
 ```
 
@@ -214,10 +214,10 @@ type Actor struct {
 	head &ActorState
 
 	## Counter of the number of messages this actor has sent.
-	nonce UInt
+	nonce Int
 
 	## Current balance of filecoin of this actor.
-	balance UInt
+	balance Int
 }
 ```
 
@@ -243,7 +243,7 @@ FaultSets are used to denote which sectors failed at which block height.
 
 ```sh
 type FaultSet struct {
-	index    UInt
+	index    Int
 	bitField BitField
 }
 ```
@@ -260,7 +260,7 @@ For most objects referenced by Filecoin, a Content Identifier (CID for short) is
 ### Timestamp
 
 ```sh
-type Timestamp UInt
+type Timestamp Int
 ```
 
 ### PublicKey
@@ -275,7 +275,7 @@ type PublicKey Bytes
 
 BytesAmount is just a re-typed Integer.
 ```sh
-type BytesAmount UInt
+type BytesAmount Int
 ```
 
 ### PeerId
@@ -322,15 +322,15 @@ PoStProof is an opaque, dynamically-sized array of bytes.
 A type to represent an amount of filecoin tokens.
 
 ```sh
-type TokenAmount UInt
+type TokenAmount Int
 ```
 
 ### SectorID
 
-Uniquely identifies a miner's sector.
+Uniquely identifies a miner's sector. Within the 64-bit unsigned integer range.
 
 ```sh
-type SectorID uint64
+type SectorID int
 ```
 
 ## RLE+ Bitset Encoding
@@ -399,3 +399,4 @@ For Filecoin, byte arrays representing RLE+ bitstreams are encoded using [LSB 0]
 
 - The maximum size of an Object should be 1MB (2^20 bytes). Objects larger than this are invalid.
 - Hashes should use a blake2b-256 multihash.
+- Integers used throughout these data structures are assumed to be within the 32-bit unsigned integer range unless otherwise stated

--- a/network-protocols.md
+++ b/network-protocols.md
@@ -30,7 +30,7 @@ Whenever a node gets a new connection, it opens a new stream on that connection 
 ```sh
 type HelloMessage struct {
 	heaviestTipSet [&Block]
-	heaviestTipSetWeight UInt
+	heaviestTipSetWeight Int
 	genesisHash &Block
 }
 ```
@@ -300,7 +300,7 @@ type BlockSyncRequest struct {
     ## The TipSet being synced from
 	start [&Block]
     ## How many tipsets to sync
-	requestLength UInt
+	requestLength Int
     ## Query options
     options Options
 }
@@ -324,10 +324,10 @@ type BlockSyncResponse struct {
 type TipSetBundle struct {
   blocks [Blocks]
   secpMsgs [SignedMessage]
-  secpMsgIncludes [[UInt]]
+  secpMsgIncludes [[Int]]
 
   blsMsgs [Message]
-  blsMsgIncludes [[Uint]]
+  blsMsgIncludes [[Int]]
 }
 
 type Status enum {

--- a/retrieval-market.md
+++ b/retrieval-market.md
@@ -56,10 +56,10 @@ type Block struct {
 ## Represents all the metadata of a Cid.
 ## It does not contains  any actual content information.
 type CidPrefix struct {
-	version  UInt
-	codec    UInt
-	mhType   UInt
-	mhLength UInt
+	version  Int
+	codec    Int
+	mhType   Int
+	mhLength Int
 }
 ```
 


### PR DESCRIPTION
_(one of a few PRs to attempt to get the IPLD Schemas conforming to current spec)_

Specific typing restrictions are specified as adjuncts to schemas, for now as as descriptive documentation text but we will also soon have a method to also supply such information for codegen purposes, probably language-specific. IPLD only has an `Int` to offer via plain schemas.

I think I've added documentation where it's needed, including the note at the bottom of data-structures.md and the note about `SectorID` needing to allow up to uint64 range. More could be added if anyone thinks it's needed. Keep in mind that there's also going to need to be some codegen hinting metadata provided as adjunct (in some form) so we can revisit these when we get to that (soon) and be more specific so these schemas produce proper Go types (and hopefully other languages too).

Ref: https://github.com/ipld/specs/blob/master/design/history/exploration-reports/2019.07-int-ranges-as-adjuncts.md
Ref: https://github.com/ipld/specs/blob/data-model-motivation/data-model-layer/data-model.md#motivation