### PR TITLE
schemas: string keys for keyed unions

### DIFF
--- a/actors.md
+++ b/actors.md
@@ -1206,10 +1206,10 @@ type LaneState struct {
 }
 
 type PaymentChannelMethod union {
-  | PaymentChannelConstructor 0
-  | UpdateChannelState 1
-  | Close 2
-  | Collect 3
+  | PaymentChannelConstructor "0"
+  | UpdateChannelState "1"
+  | Close "2"
+  | Collect "3"
 } representation keyed
 ```
 

--- a/data-structures.md
+++ b/data-structures.md
@@ -149,8 +149,8 @@ type ElectionProof struct {
 
 ```sh
 type Message union {
-    | UnsignedMessage 0
-    | SignedMessage 1
+    | UnsignedMessage "0"
+    | SignedMessage "1"
 } representation keyed
 ```
 

--- a/network-protocols.md
+++ b/network-protocols.md
@@ -147,14 +147,14 @@ type DealState enum {
 
 ```sh
 type StorageDealResponse union {
-    | UnknownParams
-    | RejectedParams
-    | AcceptedParams
-    | StartedParams
-    | FailedParams
-    | StagedParams
-    | SealingParams
-    | CompleteParams
+    | UnknownParams "0"
+    | RejectedParams "1"
+    | AcceptedParams "2"
+    | StartedParams "3"
+    | FailedParams "4"
+    | StagedParams "5"
+    | SealingParams "6"
+    | CompleteParams "7"
 } representation keyed
 
 type UnknownParams struct {
@@ -266,9 +266,9 @@ type RetrievePieceRequest struct {
 ```sh
 type RetrievePieceResponse union {
     ## Success means that the piece can be retrieved from the miner.
-    | RetrievePieceResponseSuccess 0
+    | RetrievePieceResponseSuccess "0"
 	## Failure indicates that the piece can not be retrieved from the miner.
-    | RetrievePieceResponseFailure 1
+    | RetrievePieceResponseFailure "1"
 } representation keyed
 
 type RetrievePieceResponseSuccess struct {}

--- a/retrieval-market.md
+++ b/retrieval-market.md
@@ -34,9 +34,9 @@ type RetDealProposal struct {
 }
 
 type RetDealResponse union {
-    | AcceptedResponse 0
-    | RejectedResponse 1
-    | ErrorResponse 2
+    | AcceptedResponse "0"
+    | RejectedResponse "1"
+    | ErrorResponse "2"
 } representation keyed
 
 type AcceptedResponse struct {}


### PR DESCRIPTION
_(one of a few PRs to attempt to get the IPLD Schemas conforming to current spec)_

IPLD doesn't support non-string keys for maps which is how kinded unions are stored. Switch instead to string keys.

I'm not expecting this to be uncontroversial because an extra byte gets involved in the encoding here and I know that's an important consideration, but we're bumping up against the IPLD goal of providing a common data interface able to support multiple encoding formats and multiple programming languages. Integer map keys are comfortable from Go -> CBOR but become awkward as we move away from that pairing.

Ref: https://github.com/ipld/specs/blob/data-model-motivation/data-model-layer/data-model.md#motivation
Ref: https://github.com/ipld/specs/pull/184#issuecomment-530038905
Ref: https://github.com/ipld/specs/issues/58