### PR TITLE
Simplify logic of mining rewards

### DIFF
--- a/src/systems/filecoin_blockchain/struct/block_producer/_index.md
+++ b/src/systems/filecoin_blockchain/struct/block_producer/_index.md
@@ -127,29 +127,26 @@ An eligible miner broadcasts the completed block to the network (via [block prop
 
 # Block Rewards
 
-Over the entire lifetime of the protocol, 1,400,000,000 FIL (`TotalIssuance`) will be given out to miners. The rate at which the funds are given out is set to halve every six years, smoothly (not a fixed jump like in Bitcoin). These funds are initially held by the network account actor, and are transferred to miners in blocks that they mine. The reward amount remains fixed for a period of 1 week (given our 30 second block time, this  is 20,160 blocks, the `AdjustmentPeriod`) and is then adjusted. Over time, the reward will eventually become zero as the fractional amount given out at each step shrinks the network account's balance to 0.
+Over the entire lifetime of the protocol, 1,400,000,000 FIL (`TotalIssuance`) will be given out to miners. The rate at which the funds are given out is set to halve every six years, smoothly (not a fixed jump like in Bitcoin). These funds are initially held by the network account actor, and are transferred to miners in blocks that they mine. Over time, the reward will eventually become close zero as the fractional amount given out at each step shrinks the network account's balance to 0.
 
 The equation for the current block reward is of the form:
 
 ```
-Reward = IV * (Decay ^ (BlockHeight / 20160))
+Reward = (IV * RemainingInNetworkActor) / TotalIssuance
 ```
 
-`IV` is the initial value, and is computed by taking:
+`IV` is the initial value, and is set to:
 
 ```
-IV = TotalIssuance * (1 - Decay)
+IV = 153856861913558700202 attoFIL // 153.85 FIL
 ```
 
-`Decay` is computed by:
-
-```
-Decay = e^(ln(0.5) / (HalvingPeriodBlocks / AdjustmentPeriod))
-```
-
+IV was derived from:
 ```
 // Given one block every 30 seconds, this is how many blocks are in six years
 HalvingPeriodBlocks = 6 * 365 * 24 * 60 * 2 = 6,307,200 blocks
+λ = ln(2) / HalvingPeriodBlocks
+IV = TotalIssuance * (1-e^(-λ)) // Converted to attoFIL (10e18)
 ```
 
 Note: Due to jitter in EC, and the gregorian calendar, there may be some error in the issuance schedule over time. This is expected to be small enough that it's not worth correcting for. Additionally, since the payout mechanism is transferring from the network account to the miner, there is no risk of minting *too much* FIL.


### PR DESCRIPTION
Below is an updated description.

----

It is the same model (exponential decay) but without `AdustmentPeriod` and with much simpler (and convergent) math.

Exponential distribution is defined as `dN/dt = -λN` but that formula is correct for continuos process.
In the case of a discrete process (our case), we have to work from the solution of the differential equation:
```
N(t) = N(0)*e^(-λ*t)
IV = N(0) - N(1)
IV = N(0) - N₀*e^(-λ)
IV = N(0) * (1-e^(-λ))
(1-e^(-λ)) = IV/N(0)  (eq. 1)
```
Then the reward is:
```
R(t) = N(t-1) - N(t)
R(t) = N(0) * e^(-λ*(t-1)) - N(0) * e^(-λ*(t))
R(t) = N(0) * e^(-λ*(t-1)) * (1 - e^(-λ)) // substitute eq. 1
R(t) = N(t-1) * IV / N(0)
N(t) = N(t-1) - R(t)
```
Where `N(t)` is NetworkActorBalance.

With the set IV, the schedule is within 3.94311e-12 FIL at 6 years.
The source of an observed error is limited precision of FIL unit (attoFIL) but is small enough that it should not matter.