### PR TITLE
Proofs interfaces

### DIFF
--- a/src/libraries/filcrypto/filproofs/algorithms.go
+++ b/src/libraries/filcrypto/filproofs/algorithms.go
@@ -662,7 +662,7 @@ func ComputeUnsealedSectorCIDFromPieceInfos(sectorSize UInt, pieceInfos []PieceI
 	if rootSize != sectorSize {
 		return unsealedCID, errors.New("Wrong sector size.")
 	}
-	// TODO: Enforce maximum padding allowable padding.
+
 	return UnsealedSectorCID(AsBytes_PieceCID(rootPieceInfo.PieceCID())), nil
 }
 

--- a/src/libraries/filcrypto/filproofs/algorithms.go
+++ b/src/libraries/filcrypto/filproofs/algorithms.go
@@ -9,6 +9,7 @@ import "encoding/binary"
 
 import util "github.com/filecoin-project/specs/util"
 import file "github.com/filecoin-project/specs/systems/filecoin_files/file"
+import piece "github.com/filecoin-project/specs/systems/filecoin_files/piece"
 import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 import sectorIndex "github.com/filecoin-project/specs/systems/filecoin_mining/sector_index"
 
@@ -16,7 +17,7 @@ type SHA256Hash Bytes32
 type PedersenHash Bytes32
 type Bytes32 []byte
 type UInt = util.UInt
-type PieceInfo = sector.PieceInfo
+type PieceInfo = *sector.PieceInfo_I
 type Label Bytes32
 type Commitment = sector.Commitment
 
@@ -655,15 +656,13 @@ func (sdr *StackedDRG_I) VerifySeal(sv sector.SealVerifyInfo) bool {
 }
 
 func ComputeUnsealedSectorCIDFromPieceInfos(sectorSize UInt, pieceInfos []PieceInfo) (unsealedCID sector.UnsealedSectorCID, err error) {
-
 	rootPieceInfo := computeRootPieceInfo(pieceInfos)
 	rootSize := rootPieceInfo.Size()
 	if rootSize != sectorSize {
 		return unsealedCID, errors.New("Wrong sector size.")
 	}
 	// TODO: Enforce maximum padding allowable padding.
-	return rootPieceInfo.CommP(), nil
-
+	return UnsealedSectorCID(AsBytes_PieceCID(rootPieceInfo.PieceCID())), nil
 }
 
 // commD := rootPieceInfo.CommP()
@@ -743,8 +742,8 @@ func zeroPadding(size UInt) PieceInfo {
 func joinPieceInfos(left PieceInfo, right PieceInfo) PieceInfo {
 	util.Assert(left.Size() == right.Size())
 	return &sector.PieceInfo_I{
-		Size_:  left.Size() + right.Size(),
-		CommP_: UnsealedSectorCID(BinaryHash_SHA256Hash(AsBytes_UnsealedSectorCID(left.CommP()), AsBytes_UnsealedSectorCID(right.CommP()))), // FIXME: make this whole function generic?
+		Size_:     left.Size() + right.Size(),
+		PieceCID_: piece.PieceCID(BinaryHash_SHA256Hash(AsBytes_PieceCID(left.PieceCID()), AsBytes_PieceCID(right.PieceCID()))), // FIXME: make this whole function generic?
 	}
 }
 
@@ -963,13 +962,19 @@ func AsBytes_T(t util.T) []byte {
 }
 
 func AsBytes_UnsealedSectorCID(cid sector.UnsealedSectorCID) []byte {
-	panic("Unimplemented for T")
+	panic("Unimplemented for UnsealedSectorCID")
 
 	return []byte{}
 }
 
 func AsBytes_SealedSectorCID(CID sector.SealedSectorCID) []byte {
-	panic("Unimplemented for T")
+	panic("Unimplemented for SealedSectorCID")
+
+	return []byte{}
+}
+
+func AsBytes_PieceCID(CID piece.PieceCID) []byte {
+	panic("Unimplemented for PieceCID")
 
 	return []byte{}
 }

--- a/src/libraries/filcrypto/filproofs/algorithms.go
+++ b/src/libraries/filcrypto/filproofs/algorithms.go
@@ -658,6 +658,7 @@ func (sdr *StackedDRG_I) VerifySeal(sv sector.SealVerifyInfo) bool {
 func ComputeUnsealedSectorCIDFromPieceInfos(sectorSize UInt, pieceInfos []PieceInfo) (unsealedCID sector.UnsealedSectorCID, err error) {
 	rootPieceInfo := computeRootPieceInfo(pieceInfos)
 	rootSize := rootPieceInfo.Size()
+
 	if rootSize != sectorSize {
 		return unsealedCID, errors.New("Wrong sector size.")
 	}

--- a/src/libraries/filcrypto/filproofs/algorithms.go
+++ b/src/libraries/filcrypto/filproofs/algorithms.go
@@ -1,6 +1,7 @@
 package filproofs
 
 import "bytes"
+import "errors"
 import "math"
 import "math/rand"
 import big "math/big"
@@ -653,19 +654,21 @@ func (sdr *StackedDRG_I) VerifySeal(sv sector.SealVerifyInfo) bool {
 	return sdr.VerifyOfflineCircuitProof(commD, commR, sealSeeds, challenges, sealProof)
 }
 
-// TODO:
-//func ComputeDataCommitment()
-// sectorSize := sealCfg.SectorSize()
-//
-// rootPieceInfo := sdr.ComputeRootPieceInfo(pieceInfos)
-// rootSize := rootPieceInfo.Size()
-// if rootSize != sectorSize {
-// 	return false
-// }
+func ComputeUnsealedSectorCIDFromPieceInfos(sectorSize UInt, pieceInfos []PieceInfo) (unsealedCID sector.UnsealedSectorCID, err error) {
+
+	rootPieceInfo := computeRootPieceInfo(pieceInfos)
+	rootSize := rootPieceInfo.Size()
+	if rootSize != sectorSize {
+		return unsealedCID, errors.New("Wrong sector size.")
+	}
+	// TODO: Enforce maximum padding allowable padding.
+	return rootPieceInfo.CommP(), nil
+
+}
 
 // commD := rootPieceInfo.CommP()
 
-func (sdr *StackedDRG_I) ComputeRootPieceInfo(pieceInfos []PieceInfo) PieceInfo {
+func computeRootPieceInfo(pieceInfos []PieceInfo) PieceInfo {
 	// Construct root PieceInfo by (shift-reduce) parsing the constituent PieceInfo array.
 	// Later pieces must always be joined with equal-sized predecessors to create a new root twice their size.
 	// So if a piece is larger than the current root (top of stack), add padding until it is not.

--- a/src/systems/filecoin_markets/storage_market/storage_market_actor.go
+++ b/src/systems/filecoin_markets/storage_market/storage_market_actor.go
@@ -8,6 +8,8 @@ import msg "github.com/filecoin-project/specs/systems/filecoin_vm/message"
 import vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
 import ipld "github.com/filecoin-project/specs/libraries/ipld"
 import util "github.com/filecoin-project/specs/util"
+import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
+import piece "github.com/filecoin-project/specs/systems/filecoin_files/piece"
 
 ////////////////////////////////////////////////////////////////////////////////
 // Boilerplate
@@ -310,6 +312,26 @@ func (a *StorageMarketActorCode_I) GetLastDealExpirationFromDealIDs(rt Runtime, 
 	Release(rt, h, st)
 
 	return lastDealExpiration
+}
+
+func (a *StorageMarketActorCode_I) GetUnsealedCIDForDealIDs(rt Runtime, dealIDs []deal.DealID) sector.UnsealedSectorCID {
+	pieceCIDs := make([]piece.PieceCID, len(dealIDs))
+	pieceSizes := make([]piece.PieceSize, len(dealIDs))
+
+	h, st := a.State(rt)
+	for index, deal := range st.Deals() {
+		proposal := deal.Proposal()
+
+		pieceCIDs[index] = proposal.PieceCID()
+		pieceSizes[index] = proposal.PieceSize()
+	}
+
+	// call proof to compute UnsealedSectorCID
+	var commD sector.UnsealedSectorCID
+
+	Release(rt, h, st)
+
+	return commD
 }
 
 func (a *StorageMarketActorCode_I) InvokeMethod(rt Runtime, method actor.MethodNum, params actor.MethodParams) InvocOutput {

--- a/src/systems/filecoin_markets/storage_market/storage_market_actor.go
+++ b/src/systems/filecoin_markets/storage_market/storage_market_actor.go
@@ -12,6 +12,10 @@ import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 import proving "github.com/filecoin-project/specs/systems/filecoin_mining/storage_proving"
 import exitcode "github.com/filecoin-project/specs/systems/filecoin_vm/runtime/exitcode"
 
+const (
+	MethodGetUnsealedCIDForDealIDs = actor.MethodNum(3)
+)
+
 ////////////////////////////////////////////////////////////////////////////////
 // Boilerplate
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/systems/filecoin_markets/storage_market/storage_market_actor.go
+++ b/src/systems/filecoin_markets/storage_market/storage_market_actor.go
@@ -20,8 +20,6 @@ type Runtime = vmr.Runtime
 type Bytes = util.Bytes
 type State = StorageMarketActorState
 
-const MAX_ALLOWABLE_PADDING_DENOMINATOR = 64
-
 func (a *StorageMarketActorCode_I) State(rt Runtime) (vmr.ActorStateHandle, State) {
 	h := rt.AcquireState()
 	stateCID := h.Take()
@@ -333,13 +331,6 @@ func (a *StorageMarketActorCode_I) GetUnsealedCIDForDealIDs(rt Runtime, sectorSi
 	}
 
 	Release(rt, h, st)
-
-	maxAllowablePadding := sectorSize / MAX_ALLOWABLE_PADDING_DENOMINATOR
-	minTotalPiece := sectorSize - maxAllowablePadding
-
-	if totalPieceSize < minTotalPiece {
-		return rt.ErrorReturn(exitcode.InvalidSectorPacking)
-	}
 
 	SPS := new(proving.StorageProvingSubsystem_I)
 	ret := SPS.ComputeUnsealedSectorCID(sectorSize, pieceInfos)

--- a/src/systems/filecoin_markets/storage_market/storage_market_actor.id
+++ b/src/systems/filecoin_markets/storage_market/storage_market_actor.id
@@ -77,5 +77,5 @@ type StorageMarketActorCode struct {
     // TODO: StorageDeals should be renewable
     // UpdateStorageDeal(newStorageDeals [deal.StorageDeal])
 
-    GetUnsealedCIDForDealIDs(rt Runtime, dealIDs [deal.DealID]) sector.UnsealedSectorCID
+    GetPieceInfosForDealIDs(rt Runtime, dealIDs [deal.DealID]) [sector.PieceInfo]
 }

--- a/src/systems/filecoin_markets/storage_market/storage_market_actor.id
+++ b/src/systems/filecoin_markets/storage_market/storage_market_actor.id
@@ -2,6 +2,7 @@ import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 import block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import deal "github.com/filecoin-project/specs/systems/filecoin_markets/deal"
+import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 
 type StorageParticipantBalance struct {
     Locked     actor.TokenAmount
@@ -75,4 +76,6 @@ type StorageMarketActorCode struct {
 
     // TODO: StorageDeals should be renewable
     // UpdateStorageDeal(newStorageDeals [deal.StorageDeal])
+
+    GetUnsealedCIDForDealIDs(rt Runtime, dealIDs [deal.DealID]) sector.UnsealedSectorCID
 }

--- a/src/systems/filecoin_mining/sector/sealing.go
+++ b/src/systems/filecoin_mining/sector/sealing.go
@@ -16,3 +16,7 @@ var SealSeedHash = SHA256
 // 	h := SealSeedHash(buf)
 // 	return SealSeed(h)
 // }
+
+func PieceInfosFromBytes([]byte) []*PieceInfo_I {
+	panic("TODO")
+}

--- a/src/systems/filecoin_mining/sector/sealing.id
+++ b/src/systems/filecoin_mining/sector/sealing.id
@@ -116,8 +116,8 @@ type SealAlgorithm enum {
 type SealOutputArtifacts struct {}
 
 // TODO: PieceInfo is the name used by proofs for this struct, but there also exists a piece.PieceInfo type, which is different.
-// We should probably rename one of them, since this is quite confusing.
+// We should probably rename one of them, since this is quite confusing. Or, if we can put `PieceCID` into pieces.PieceInfo, we can just use that.
 type PieceInfo struct {
     Size      UVarint  // Size in nodes. For BLS12-381 (capacity 254 bits), must be >= 16. (16 * 8 = 128)
-    PieceCID  piece.PieceCID  // FIXME: create a distinct type for piece commitments.
+    PieceCID  piece.PieceCID
 }

--- a/src/systems/filecoin_mining/sector/sealing.id
+++ b/src/systems/filecoin_mining/sector/sealing.id
@@ -1,4 +1,5 @@
 import file "github.com/filecoin-project/specs/systems/filecoin_files/file"
+import piece "github.com/filecoin-project/specs/systems/filecoin_files/piece"
 import deal "github.com/filecoin-project/specs/systems/filecoin_markets/deal"
 import block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
 
@@ -114,7 +115,9 @@ type SealAlgorithm enum {
 // TODO
 type SealOutputArtifacts struct {}
 
+// TODO: PieceInfo is the name used by proofs for this struct, but there also exists a piece.PieceInfo type, which is different.
+// We should probably rename one of them, since this is quite confusing.
 type PieceInfo struct {
-    Size   UInt  // Size in nodes. For BLS12-381 (capacity 254 bits), must be >= 16. (16 * 8 = 128)
-    CommP  UnsealedSectorCID  // FIXME: create a distinct type for piece commitments.
+    Size      UVarint  // Size in nodes. For BLS12-381 (capacity 254 bits), must be >= 16. (16 * 8 = 128)
+    PieceCID  piece.PieceCID  // FIXME: create a distinct type for piece commitments.
 }

--- a/src/systems/filecoin_mining/sector/sealing.id
+++ b/src/systems/filecoin_mining/sector/sealing.id
@@ -26,7 +26,7 @@ type SealVerifyInfo struct {
     SealCfg
     Randomness             SealRandomness
     InteractiveRandomness  InteractiveSealRandomness
-    PieceInfos             [PieceInfo]
+    UnsealedCID            UnsealedSectorCID  // CommD
 }
 
 // OnChainSealVerifyInfo is the structure of information that must be sent with
@@ -116,5 +116,5 @@ type SealOutputArtifacts struct {}
 
 type PieceInfo struct {
     Size   UInt  // Size in nodes. For BLS12-381 (capacity 254 bits), must be >= 16. (16 * 8 = 128)
-    CommP  UnsealedSectorCID
+    CommP  UnsealedSectorCID  // FIXME: create a distinct type for piece commitments.
 }

--- a/src/systems/filecoin_mining/sector/sealing.id
+++ b/src/systems/filecoin_mining/sector/sealing.id
@@ -120,4 +120,7 @@ type SealOutputArtifacts struct {}
 type PieceInfo struct {
     Size      UVarint  // Size in nodes. For BLS12-381 (capacity 254 bits), must be >= 16. (16 * 8 = 128)
     PieceCID  piece.PieceCID
+
+    // Data returns the serialized representation of the PieceInfo.
+    Data()    Bytes
 }

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor.go
@@ -574,7 +574,8 @@ func (a *StorageMinerActorCode_I) DeclareFaults(rt Runtime, faultSet sector.Comp
 	return rt.SuccessReturn()
 }
 
-func (st *StorageMinerActorState_I) _isSealVerificationCorrect(rt Runtime, onChainInfo sector.OnChainSealVerifyInfo) bool {
+func (a *StorageMinerActorCode_I) _isSealVerificationCorrect(rt Runtime, onChainInfo sector.OnChainSealVerifyInfo) bool {
+	h, st := a.State(rt)
 	sectorSize := st.Info().SectorSize()
 	dealIDs := onChainInfo.DealIDs()
 	params := make([]actor.MethodParam, 1+len(dealIDs))
@@ -614,6 +615,9 @@ func (st *StorageMinerActorState_I) _isSealVerificationCorrect(rt Runtime, onCha
 		InteractiveRandomness_: sector.InteractiveSealRandomness(rt.Randomness(onChainInfo.InteractiveEpoch(), 0)),
 		UnsealedCID_:           unsealedCID,
 	}
+
+	Release(rt, h, st) // if no modifications made; or
+
 	sdr := filproofs.SDRParams(&sealCfg, nil)
 	return sdr.VerifySeal(&svInfo)
 }

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor.go
@@ -597,9 +597,13 @@ func (st *StorageMinerActorState_I) _isSealVerificationCorrect(rt Runtime, onCha
 		Value_:  rt.ValueSupplied(), // TODO: figure out where tx fee should come from
 	})
 
+	if receipt.ExitCode() == exitcode.InvalidSectorPacking {
+		return false
+	}
+
 	ret := receipt.ReturnValue()
 
-	// TODO: Is this actually the right way to turn these raw bytes into an UnsealedSectorCID?
+	// This assumes the raw bytes have been passed unmodified through the VM.
 	var unsealedCID sector.UnsealedSectorCID = sector.UnsealedSectorCID(ret)
 
 	new(proving.StorageProvingSubsystem_I).VerifySeal(&sector.SealVerifyInfo_I{

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor.go
@@ -580,7 +580,7 @@ func (st *StorageMinerActorState_I) _isSealVerificationCorrect(rt Runtime, onCha
 	params := make([]actor.MethodParam, 1+len(dealIDs))
 	// TODO: serialize method param as {sectorSize,  DealIDs...}.
 
-	receipt := rt.SendAllowingErrors(&msg.InvocInput_I{
+	receipt := rt.SendCatchingErrors(&msg.InvocInput_I{
 		To_:     addr.StorageMarketActorAddr,
 		Method_: storage_market.MethodGetUnsealedCIDForDealIDs,
 		Params_: params,

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor.go
@@ -586,15 +586,6 @@ func (a *StorageMinerActorCode_I) DeclareFaults(rt Runtime, faultSet sector.Comp
 }
 
 func (st *StorageMinerActorState_I) _isSealVerificationCorrect(rt Runtime, onChainInfo sector.OnChainSealVerifyInfo) bool {
-	// TODO: verify seal @nicola
-	// TODO: st.verifySeal(sectorID SectorID, comm sector.OnChainSealVerifyInfo, proof SealProof)
-
-	// verifySeal will also generate CommD on the fly from CommP and PieceSize
-
-	// var pieceInfos []sector.PieceInfo // = make([]sector.PieceInfo, 0)
-
-	// FIXME: Actually get commD  from the storage market actor, in exchange for onChainInfo.DealIDs().
-
 	// TODO: serialize method param
 	sectorSize := st.Info().SectorSize()
 	params := make([]actor.MethodParam, sectorSize, len(onChainInfo.DealIDs()))
@@ -608,7 +599,7 @@ func (st *StorageMinerActorState_I) _isSealVerificationCorrect(rt Runtime, onCha
 
 	ret := receipt.ReturnValue()
 
-	// TODO: Is this actually the right way to turn these raw bytes ito an UnsealedSectorCID?
+	// TODO: Is this actually the right way to turn these raw bytes into an UnsealedSectorCID?
 	var unsealedCID sector.UnsealedSectorCID = sector.UnsealedSectorCID(ret)
 
 	new(proving.StorageProvingSubsystem_I).VerifySeal(&sector.SealVerifyInfo_I{

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor.go
@@ -591,10 +591,21 @@ func (st *StorageMinerActorState_I) _isSealVerificationCorrect(rt Runtime, onCha
 
 	// verifySeal will also generate CommD on the fly from CommP and PieceSize
 
-	var pieceInfos []sector.PieceInfo // = make([]sector.PieceInfo, 0)
+	// var pieceInfos []sector.PieceInfo // = make([]sector.PieceInfo, 0)
 
 	// FIXME: Actually get commD  from the storage market actor, in exchange for onChainInfo.DealIDs().
-	_ = pieceInfos
+
+	// TODO: serialize method param
+	params := make([]actor.MethodParam, len(onChainInfo.DealIDs()))
+
+	rt.Send(&msg.InvocInput_I{
+		To_:     addr.StorageMarketActorAddr,
+		Method_: actor.MethodSend, // TODO: need to define and register MethodNum for SMA
+		Params_: params,
+		Value_:  rt.ValueSupplied(), // TODO: figure out where tx fee should come from
+	}).ReturnValue()
+
+	// TODO: deserialize result from rt.Send into unsealedCID
 	var unsealedCID sector.UnsealedSectorCID
 
 	new(proving.StorageProvingSubsystem_I).VerifySeal(&sector.SealVerifyInfo_I{

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor.go
@@ -1,29 +1,18 @@
 package storage_mining
 
-import (
-	actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
-	addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
-
-	block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
-
-	ipld "github.com/filecoin-project/specs/libraries/ipld"
-
-	msg "github.com/filecoin-project/specs/systems/filecoin_vm/message"
-
-	poster "github.com/filecoin-project/specs/systems/filecoin_mining/storage_proving/poster"
-
-	power "github.com/filecoin-project/specs/systems/filecoin_blockchain/storage_power_consensus"
-
-	proving "github.com/filecoin-project/specs/systems/filecoin_mining/storage_proving"
-
-	sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
-
-	util "github.com/filecoin-project/specs/util"
-
-	vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
-
-	exitcode "github.com/filecoin-project/specs/systems/filecoin_vm/runtime/exitcode"
-)
+import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
+import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
+import block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
+import ipld "github.com/filecoin-project/specs/libraries/ipld"
+import msg "github.com/filecoin-project/specs/systems/filecoin_vm/message"
+import poster "github.com/filecoin-project/specs/systems/filecoin_mining/storage_proving/poster"
+import power "github.com/filecoin-project/specs/systems/filecoin_blockchain/storage_power_consensus"
+import proving "github.com/filecoin-project/specs/systems/filecoin_mining/storage_proving"
+import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
+import storage_market "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market"
+import util "github.com/filecoin-project/specs/util"
+import vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
+import exitcode "github.com/filecoin-project/specs/systems/filecoin_vm/runtime/exitcode"
 
 ////////////////////////////////////////////////////////////////////////////////
 // Boilerplate
@@ -593,7 +582,7 @@ func (st *StorageMinerActorState_I) _isSealVerificationCorrect(rt Runtime, onCha
 
 	receipt := rt.SendAllowingErrors(&msg.InvocInput_I{
 		To_:     addr.StorageMarketActorAddr,
-		Method_: actor.MethodGetUnsealedCIDForDealIDs,
+		Method_: storage_market.MethodGetUnsealedCIDForDealIDs,
 		Params_: params,
 	})
 

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor.go
@@ -591,11 +591,10 @@ func (st *StorageMinerActorState_I) _isSealVerificationCorrect(rt Runtime, onCha
 	params := make([]actor.MethodParam, 1+len(dealIDs))
 	// TODO: serialize method param as {sectorSize,  DealIDs...}.
 
-	receipt := rt.Send(&msg.InvocInput_I{
+	receipt := rt.SendAllowingErrors(&msg.InvocInput_I{
 		To_:     addr.StorageMarketActorAddr,
 		Method_: actor.MethodGetUnsealedCIDForDealIDs,
 		Params_: params,
-		Value_:  rt.ValueSupplied(), // TODO: figure out where tx fee should come from
 	})
 
 	if receipt.ExitCode() == exitcode.InvalidSectorPacking {

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor.go
@@ -586,9 +586,10 @@ func (a *StorageMinerActorCode_I) DeclareFaults(rt Runtime, faultSet sector.Comp
 }
 
 func (st *StorageMinerActorState_I) _isSealVerificationCorrect(rt Runtime, onChainInfo sector.OnChainSealVerifyInfo) bool {
-	// TODO: serialize method param
 	sectorSize := st.Info().SectorSize()
-	params := make([]actor.MethodParam, sectorSize, len(onChainInfo.DealIDs()))
+	dealIDs := onChainInfo.DealIDs()
+	params := make([]actor.MethodParam, 1+len(dealIDs))
+	// TODO: serialize method param as {sectorSize,  DealIDs...}.
 
 	receipt := rt.Send(&msg.InvocInput_I{
 		To_:     addr.StorageMarketActorAddr,

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor.go
@@ -599,12 +599,14 @@ func (st *StorageMinerActorState_I) _isSealVerificationCorrect(rt Runtime, onCha
 	sectorSize := st.Info().SectorSize()
 	params := make([]actor.MethodParam, sectorSize, len(onChainInfo.DealIDs()))
 
-	ret := rt.Send(&msg.InvocInput_I{
+	receipt := rt.Send(&msg.InvocInput_I{
 		To_:     addr.StorageMarketActorAddr,
-		Method_: actor.MethodSend, // TODO: need to define and register MethodNum for SMA
+		Method_: actor.MethodGetUnsealedCIDForDealIDs,
 		Params_: params,
 		Value_:  rt.ValueSupplied(), // TODO: figure out where tx fee should come from
-	}).ReturnValue()
+	})
+
+	ret := receipt.ReturnValue()
 
 	// TODO: Is this actually the right way to turn these raw bytes ito an UnsealedSectorCID?
 	var unsealedCID sector.UnsealedSectorCID = sector.UnsealedSectorCID(ret)

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor.go
@@ -593,12 +593,9 @@ func (st *StorageMinerActorState_I) _isSealVerificationCorrect(rt Runtime, onCha
 
 	var pieceInfos []sector.PieceInfo // = make([]sector.PieceInfo, 0)
 
-	for dealId := range onChainInfo.DealIDs() {
-		// FIXME: Actually get the deal info from the storage market actor and use it to create a sector.PieceInfo.
-		_ = dealId
-
-		pieceInfos = append(pieceInfos, nil)
-	}
+	// FIXME: Actually get commD  from the storage market actor, in exchange for onChainInfo.DealIDs().
+	_ = pieceInfos
+	var unsealedCID sector.UnsealedSectorCID
 
 	new(proving.StorageProvingSubsystem_I).VerifySeal(&sector.SealVerifyInfo_I{
 		SectorID_: &sector.SectorID_I{
@@ -618,7 +615,7 @@ func (st *StorageMinerActorState_I) _isSealVerificationCorrect(rt Runtime, onCha
 		//Randomness_:
 		// TODO: get InteractiveRandomness sector.SealRandomness using onChainInfo.InteractiveEpoch
 		//InteractiveRandomness_:
-		PieceInfos_: pieceInfos,
+		UnsealedCID_: unsealedCID,
 	})
 	return false // TODO: finish
 }

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor.go
@@ -597,8 +597,17 @@ func (a *StorageMinerActorCode_I) _isSealVerificationCorrect(rt Runtime, onChain
 
 	ret := receipt.ReturnValue()
 
-	// This assumes the raw bytes have been passed unmodified through the VM.
-	var unsealedCID sector.UnsealedSectorCID = sector.UnsealedSectorCID(ret)
+	pieceInfos := sector.PieceInfosFromBytes(ret)
+
+	// Unless we enforce a minimum padding amount, this totalPieceSize calculation can be removed.
+	// Leaving for now until that decision is entirely finalized.
+	var totalPieceSize util.UInt
+	for _, pieceInfo := range pieceInfos {
+		pieceSize := (*pieceInfo).Size()
+		totalPieceSize += pieceSize
+	}
+
+	unsealedCID, _ := filproofs.ComputeUnsealedSectorCIDFromPieceInfos(sectorSize, pieceInfos)
 
 	sealCfg := sector.SealCfg_I{
 		SectorSize_:     sectorSize,

--- a/src/systems/filecoin_mining/storage_proving/storage_proving_subsystem.go
+++ b/src/systems/filecoin_mining/storage_proving/storage_proving_subsystem.go
@@ -2,6 +2,7 @@ package storage_proving
 
 import filproofs "github.com/filecoin-project/specs/libraries/filcrypto/filproofs"
 import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
+import util "github.com/filecoin-project/specs/util"
 
 func (sps *StorageProvingSubsystem_I) VerifySeal(sv sector.SealVerifyInfo) StorageProvingSubsystem_VerifySeal_FunRet {
 	sdr := filproofs.SDRParams(sv.SealCfg(), nil)
@@ -9,4 +10,15 @@ func (sps *StorageProvingSubsystem_I) VerifySeal(sv sector.SealVerifyInfo) Stora
 	result := sdr.VerifySeal(sv)
 
 	return StorageProvingSubsystem_VerifySeal_FunRet_Make_ok(StorageProvingSubsystem_VerifySeal_FunRet_ok(result)) //,
+}
+
+func (sps *StorageProvingSubsystem_I) ComputeUnsealedSectorCID(sectorSize util.UInt, pieceInfos []sector.PieceInfo) StorageProvingSubsystem_ComputeUnsealedSectorCID_FunRet {
+	unsealedCID, err := filproofs.ComputeUnsealedSectorCIDFromPieceInfos(sectorSize, pieceInfos)
+
+	if err != nil {
+		return StorageProvingSubsystem_ComputeUnsealedSectorCID_FunRet_Make_err(StorageProvingSubsystem_ComputeUnsealedSectorCID_FunRet_err(err))
+	} else {
+		return StorageProvingSubsystem_ComputeUnsealedSectorCID_FunRet_Make_unsealedSectorCID(
+			StorageProvingSubsystem_ComputeUnsealedSectorCID_FunRet_unsealedSectorCID(unsealedCID))
+	}
 }

--- a/src/systems/filecoin_mining/storage_proving/storage_proving_subsystem.go
+++ b/src/systems/filecoin_mining/storage_proving/storage_proving_subsystem.go
@@ -12,7 +12,7 @@ func (sps *StorageProvingSubsystem_I) VerifySeal(sv sector.SealVerifyInfo) Stora
 	return StorageProvingSubsystem_VerifySeal_FunRet_Make_ok(StorageProvingSubsystem_VerifySeal_FunRet_ok(result)) //,
 }
 
-func (sps *StorageProvingSubsystem_I) ComputeUnsealedSectorCID(sectorSize util.UInt, pieceInfos []sector.PieceInfo) StorageProvingSubsystem_ComputeUnsealedSectorCID_FunRet {
+func (sps *StorageProvingSubsystem_I) ComputeUnsealedSectorCID(sectorSize util.UInt, pieceInfos []*sector.PieceInfo_I) StorageProvingSubsystem_ComputeUnsealedSectorCID_FunRet {
 	unsealedCID, err := filproofs.ComputeUnsealedSectorCIDFromPieceInfos(sectorSize, pieceInfos)
 
 	if err != nil {

--- a/src/systems/filecoin_mining/storage_proving/storage_proving_subsystem.id
+++ b/src/systems/filecoin_mining/storage_proving/storage_proving_subsystem.id
@@ -8,6 +8,7 @@ type StorageProvingSubsystem struct {
     PostGenerator  poster.PostGenerator
 
     VerifySeal(sv sector.SealVerifyInfo, pieceInfos [sector.PieceInfo]) union {ok bool, err error}
+    ComputeUnsealedSectorCID(sectorSize UInt, pieceInfos [sector.PieceInfo]) union {unsealedSectorCID sector.UnsealedSectorCID, err error}
 
     ValidateBlock(block block.Block)
 

--- a/src/systems/filecoin_vm/actor/actor.go
+++ b/src/systems/filecoin_vm/actor/actor.go
@@ -6,8 +6,6 @@ const (
 	MethodSend        = MethodNum(0)
 	MethodConstructor = MethodNum(1)
 	MethodCron        = MethodNum(2)
-
-	MethodGetUnsealedCIDForDealIDs = MethodNum(99)
 )
 
 func (st *ActorState_I) CID() ipld.CID {

--- a/src/systems/filecoin_vm/actor/actor.go
+++ b/src/systems/filecoin_vm/actor/actor.go
@@ -6,6 +6,8 @@ const (
 	MethodSend        = MethodNum(0)
 	MethodConstructor = MethodNum(1)
 	MethodCron        = MethodNum(2)
+
+	MethodGetUnsealedCIDForDealIDs = MethodNum(99)
 )
 
 func (st *ActorState_I) CID() ipld.CID {

--- a/src/systems/filecoin_vm/runtime/exitcode/vm_exitcodes.go
+++ b/src/systems/filecoin_vm/runtime/exitcode/vm_exitcodes.go
@@ -53,6 +53,10 @@ var (
 	MethodSubcallError = SystemErrorCode(10)
 )
 
+var (
+	InvalidSectorPacking = UserDefinedError(1)
+)
+
 func OK() ExitCode {
 	return ExitCode_Make_Success(&ExitCode_Success_I{})
 }


### PR DESCRIPTION
- [x] Provide `filproofs` method to compute commD from `PieceInfo`s.
- [x] Call from `storage_miner_actor` into `storage_market_actor` to get commD from deal IDs.
- [x] Call from `storage_market_actor` into `filproofs` via `StorageProvingSubsystem` to get `commD` from PieceInfos.
- [x] Get randomness and interactive randomness from epochs in `storage_mining_actor`.
- [x] Pass `comm_d`, randomness, etc. to verify seal proof in `storage_mining_actor`.
- [x] Disallow sectors with to much padding (by refusing to compute commD for pieces that total insufficient bytes).

