### PR TITLE
Storage market orders

### DIFF
--- a/src/glossary/_index.md
+++ b/src/glossary/_index.md
@@ -25,8 +25,7 @@ Actors are very similar to smart contracts in Ethereum.
 An address is an identifier that refers to an actor in the Filecoin state.
 
 ## Ask
-
-## Bid
+An ask contain the terms on which a miner is willing to provide services. Storage asks, for example, contain price and other terms under which a given miner is willing to sell its storage. The word comes from stock market usage of ask, shortened from asking price.
 
 ## Block
 

--- a/src/glossary/_index.md
+++ b/src/glossary/_index.md
@@ -25,7 +25,7 @@ Actors are very similar to smart contracts in Ethereum.
 An address is an identifier that refers to an actor in the Filecoin state.
 
 ## Ask
-An ask contain the terms on which a miner is willing to provide services. Storage asks, for example, contain price and other terms under which a given miner is willing to sell its storage. The word comes from stock market usage of ask, shortened from asking price.
+An ask contains the terms on which a miner is willing to provide services. Storage asks, for example, contain price and other terms under which a given miner is willing to sell its storage. The word comes from stock market usage of ask, shortened from asking price.
 
 ## Block
 

--- a/src/systems/filecoin_markets/order/_index.md
+++ b/src/systems/filecoin_markets/order/_index.md
@@ -1,14 +1,12 @@
 ---
 menuTitle: Orders
-statusIcon: 🛑
-title: Market Orders - Asks and Bids
+statusIcon: 🔁
+title: Market Orders - Asks and Proposals
 ---
 
-TODO:
-
-- Write asks
-- Write bids
-- Write how market orders propagate (gossipsub)
+There are two primary types of market orders:
+  - _Asks_ contain the terms on which a miner is willing to provide its services, and are propogated via gossipsub
+  - _Proposals_ contain the client's proposed deal details, and are sent directly to a selected miner
 
 {{< readfile file="order.id" code="true" lang="go" >}}
 
@@ -17,5 +15,5 @@ TODO:
 TODO:
 
 - write what parts of market orders are verifiable, and how
-  - eg: miner storage ask could carry the amount of storage available (which should be at mot (pledge - sectors sealed))
+  - eg: miner storage ask could carry the amount of storage available (which should be at most (pledge - sectors sealed))
   - eg: client storage bid price could be checked against available money in the StorageMarket

--- a/src/systems/filecoin_markets/order/_index.md
+++ b/src/systems/filecoin_markets/order/_index.md
@@ -4,9 +4,9 @@ statusIcon: ⚠️
 title: Market Orders - Asks and Proposals
 ---
 
-There are two primary types of market orders:
+There are two types of market orders:
   - _Asks_ contain the terms on which a miner is willing to provide its services, and are propogated via gossipsub
-  - _Proposals_ contain the client's proposed deal details, and are sent directly to a selected miner
+  - _Proposals_ contain the client's proposed deal details. Proposals are sent directly to a selected miner
 
 {{< readfile file="order.id" code="true" lang="go" >}}
 

--- a/src/systems/filecoin_markets/order/_index.md
+++ b/src/systems/filecoin_markets/order/_index.md
@@ -5,8 +5,13 @@ title: Market Orders - Asks and Proposals
 ---
 
 There are two types of market orders:
-  - _Asks_ contain the terms on which a miner is willing to provide its services, and are propogated via gossipsub
-  - _Proposals_ contain the client's proposed deal details. Proposals are sent directly to a selected miner
+  - _Asks_ contain the terms on which a miner is willing to provide its services, and are propogated via gossipsub.
+  - _Proposals_ contain the client's proposed deal details. Proposals are sent directly to a selected miner.
+
+A `StorageAsk` contains basic storage deal terms of price, collateral, and minimim piece size (size of the smallest piece it is willing to store under these terms). It also contains a `Timestamp` for its creation, and `Expiry` for when the miner will stop accepting new deals under these terms. If a miner wishes to override an ask, it can issue an new ask with a higher sequence number (`SeqNo`).
+
+TODO:
+- confirm/clarify `Expiry` is NOT the longest duration the miner is willing to store
 
 {{< readfile file="order.id" code="true" lang="go" >}}
 

--- a/src/systems/filecoin_markets/order/_index.md
+++ b/src/systems/filecoin_markets/order/_index.md
@@ -6,7 +6,7 @@ title: Market Orders - Asks
 
 _Asks_ contain the terms on which a miner is willing to provide its services. They are propogated via gossipsub.
 
-A `StorageAsk` contains basic storage deal terms of price, collateral, and minimum piece size (size of the smallest piece it is willing to store under these terms). It also contains a `Timestamp` for its creation in `ChainEpoch`, and a `MaxDuration` for the max duration in `ChainEpoch` that a miner is willing to store under these terms. If a miner wishes to override an ask, it can issue a new ask with a higher sequence number (`SeqNo`). Clients look at all the `StorageAsks` in a gossip network and decide which miner to contact to enter into a deal. The deal negotiation process happens off chain and the client submits a `StorageDealProposal` to the miner, as detailed in Storage Deals, after an agreement is reached. 
+A `StorageAsk` contains basic storage deal terms of price, collateral, and minimum piece size (size of the smallest piece it is willing to store under these terms). It also contains a `Timestamp` for its creation in `ChainEpoch`, a `MaxDuration` for the max duration in `ChainEpoch` that a miner is willing to store under these terms, and a `MinDuration`. If a miner wishes to override an ask, it can issue a new ask with a higher sequence number (`SeqNo`). Clients look at all the `StorageAsks` in a gossip network and decide which miner to contact to enter into a deal. The deal negotiation process happens off chain and the client submits a `StorageDealProposal` to the miner, as detailed in Storage Deals, after an agreement is reached. 
 
 
 TODO:

--- a/src/systems/filecoin_markets/order/_index.md
+++ b/src/systems/filecoin_markets/order/_index.md
@@ -1,17 +1,18 @@
 ---
 menuTitle: Orders
 statusIcon: ⚠️
-title: Market Orders - Asks and Proposals
+title: Market Orders - Asks
 ---
 
-There are two types of market orders:
-  - _Asks_ contain the terms on which a miner is willing to provide its services, and are propogated via gossipsub.
-  - _Proposals_ contain the client's proposed deal details. Proposals are sent directly to a selected miner.
+_Asks_ contain the terms on which a miner is willing to provide its services. They are propogated via gossipsub.
 
-A `StorageAsk` contains basic storage deal terms of price, collateral, and minimim piece size (size of the smallest piece it is willing to store under these terms). It also contains a `Timestamp` for its creation, and `Expiry` for when the miner will stop accepting new deals under these terms. If a miner wishes to override an ask, it can issue an new ask with a higher sequence number (`SeqNo`).
+A `StorageAsk` contains basic storage deal terms of price, collateral, and minimum piece size (size of the smallest piece it is willing to store under these terms). It also contains a `Timestamp` for its creation, and `Expiry` for when the miner will stop accepting new deals under these terms. If a miner wishes to override an ask, it can issue an new ask with a higher sequence number (`SeqNo`).
+
+Clients choose a `StorageAsk` and respond directly to that miner via a `StorageDealProposal`, detailed in Storage Deals.
 
 TODO:
 - confirm/clarify `Expiry` is NOT the longest duration the miner is willing to store
+- Retrieval asks
 
 {{< readfile file="order.id" code="true" lang="go" >}}
 

--- a/src/systems/filecoin_markets/order/_index.md
+++ b/src/systems/filecoin_markets/order/_index.md
@@ -1,6 +1,6 @@
 ---
 menuTitle: Orders
-statusIcon: 🔁
+statusIcon: ⚠️
 title: Market Orders - Asks and Proposals
 ---
 

--- a/src/systems/filecoin_markets/order/_index.md
+++ b/src/systems/filecoin_markets/order/_index.md
@@ -6,12 +6,11 @@ title: Market Orders - Asks
 
 _Asks_ contain the terms on which a miner is willing to provide its services. They are propogated via gossipsub.
 
-A `StorageAsk` contains basic storage deal terms of price, collateral, and minimum piece size (size of the smallest piece it is willing to store under these terms). It also contains a `Timestamp` for its creation, and `Expiry` for when the miner will stop accepting new deals under these terms. If a miner wishes to override an ask, it can issue an new ask with a higher sequence number (`SeqNo`).
+A `StorageAsk` contains basic storage deal terms of price, collateral, and minimum piece size (size of the smallest piece it is willing to store under these terms). It also contains a `Timestamp` for its creation in `ChainEpoch`, and a `MaxDuration` for the max duration in `ChainEpoch` that a miner is willing to store under these terms. If a miner wishes to override an ask, it can issue a new ask with a higher sequence number (`SeqNo`). Clients look at all the `StorageAsks` in a gossip network and decide which miner to contact to enter into a deal. The deal negotiation process happens off chain and the client submits a `StorageDealProposal` to the miner, as detailed in Storage Deals, after an agreement is reached. 
 
-Clients choose a `StorageAsk` and respond directly to that miner via a `StorageDealProposal`, detailed in Storage Deals.
 
 TODO:
-- confirm/clarify `Expiry` is NOT the longest duration the miner is willing to store
+
 - Retrieval asks
 
 {{< readfile file="order.id" code="true" lang="go" >}}

--- a/src/systems/filecoin_markets/order/order.id
+++ b/src/systems/filecoin_markets/order/order.id
@@ -1,5 +1,6 @@
 import util "github.com/filecoin-project/specs/util"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
+import block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
 
 type StorageAsk struct {
     Price         util.BigInt  // attoFIL per GiB per epoch
@@ -7,7 +8,7 @@ type StorageAsk struct {
 
     MinPieceSize  uint64
     Miner         addr.Address
-    Timestamp     uint64       // block.ChainEpoch
-    AskExpiry     uint64       // block.ChainEpoch
+    Timestamp     block.ChainEpoch
+    MaxDuration   block.ChainEpoch
     SeqNo         uint64
 }

--- a/src/systems/filecoin_markets/order/order.id
+++ b/src/systems/filecoin_markets/order/order.id
@@ -10,5 +10,16 @@ type StorageAsk struct {
 }
 
 type StorageDealProposal struct {
+	Data          cid.Cid
 
+	PricePerEpoch      types.BigInt // attoFIL per GiB
+	ProposalExpiration uint64
+	Duration           uint64
+
+	ProviderAddress address.Address
+	Client          address.Address
+	MinerID         peer.ID
 }
+
+
+

--- a/src/systems/filecoin_markets/order/order.id
+++ b/src/systems/filecoin_markets/order/order.id
@@ -10,5 +10,6 @@ type StorageAsk struct {
     Miner         addr.Address
     Timestamp     block.ChainEpoch
     MaxDuration   block.ChainEpoch
+    MinDuration   block.ChainEpoch
     SeqNo         uint64
 }

--- a/src/systems/filecoin_markets/order/order.id
+++ b/src/systems/filecoin_markets/order/order.id
@@ -3,7 +3,7 @@ import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address
 
 type StorageAsk struct {
     Price         util.BigInt  // attoFIL per GiB per epoch
-    Collateral    util.BigInt  // TODO define units
+    Collateral    util.BigInt  // attoFIL per GiB per epoch
 
     MinPieceSize  uint64
     Miner         addr.Address

--- a/src/systems/filecoin_markets/order/order.id
+++ b/src/systems/filecoin_markets/order/order.id
@@ -7,7 +7,7 @@ type StorageAsk struct {
 
     MinPieceSize  uint64
     Miner         addr.Address
-    Timestamp     uint64
-    AskExpiry     uint64
+    Timestamp     uint64       // block.ChainEpoch
+    AskExpiry     uint64       // block.ChainEpoch
     SeqNo         uint64
 }

--- a/src/systems/filecoin_markets/order/order.id
+++ b/src/systems/filecoin_markets/order/order.id
@@ -1,7 +1,14 @@
-type Ask struct {
-
+type StorageAsk struct {
+    Price         BigInt            // attoFIL per GiB per epoch
+    Collateral    BigInt            // TODO define units
+    
+    MinPieceSize  uint64
+    Miner         address.Address
+    Timestamp     uint64
+    Expiry        uint64
+    SeqNo         uint64
 }
 
-type Bid struct {
+type StorageDealProposal struct {
 
 }

--- a/src/systems/filecoin_markets/order/order.id
+++ b/src/systems/filecoin_markets/order/order.id
@@ -8,18 +8,3 @@ type StorageAsk struct {
     Expiry        uint64
     SeqNo         uint64
 }
-
-type StorageDealProposal struct {
-	Data          cid.Cid
-
-	PricePerEpoch      types.BigInt // attoFIL per GiB
-	ProposalExpiration uint64
-	Duration           uint64
-
-	ProviderAddress address.Address
-	Client          address.Address
-	MinerID         peer.ID
-}
-
-
-

--- a/src/systems/filecoin_markets/order/order.id
+++ b/src/systems/filecoin_markets/order/order.id
@@ -1,10 +1,13 @@
+import util "github.com/filecoin-project/specs/util"
+import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
+
 type StorageAsk struct {
-    Price         BigInt            // attoFIL per GiB per epoch
-    Collateral    BigInt            // TODO define units
-    
+    Price         util.BigInt  // attoFIL per GiB per epoch
+    Collateral    util.BigInt  // TODO define units
+
     MinPieceSize  uint64
-    Miner         address.Address
+    Miner         addr.Address
     Timestamp     uint64
-    Expiry        uint64
+    AskExpiry     uint64
     SeqNo         uint64
 }


### PR DESCRIPTION
- Change Ask to StorageAsk, because RetrievalAsks are likely.
- Defines StorageAsk based on what is in https://github.com/filecoin-project/lotus/blob/master/chain/types/ask.go + recent discussion with @whyrusleeping @anorth
- Remove Bid, replace with reference to StorageDealProposal already defined in 2.7.2.6

Reviewers, please look especially at:
- Collateral units
- Confirm/clarify `Expiry` is when the ask terms expire (similar to a sale or special promotion), and is NOT the longest duration the miner is willing to store. This means there is no way for clients to determine how long miner is willing to store data before sending a `StorageDealProposal`, and can only know this via deal rejection.

Questions:
- We should probably also standardize deal response error codes.