### PR TITLE
clock: updated code and implementation

### DIFF
--- a/src/systems/filecoin_blockchain/blockchain.id
+++ b/src/systems/filecoin_blockchain/blockchain.id
@@ -14,7 +14,7 @@ type SyncState union {
 }
 
 type BlockchainSubsystem struct @(mutable) {
-    Clock              &clock.Clock
+    Clock              &clock.UTCClock
 
     LatestEpoch()      block.ChainEpoch
     BestChain()        block.Chain

--- a/src/systems/filecoin_nodes/clock/_index.md
+++ b/src/systems/filecoin_nodes/clock/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Clock
-statusIcon: ⚠️
+statusIcon: ✅
 ---
 
 {{< readfile file="clock_subsystem.id" code="true" lang="go" >}}

--- a/src/systems/filecoin_nodes/clock/clock_subsystem.go
+++ b/src/systems/filecoin_nodes/clock/clock_subsystem.go
@@ -2,34 +2,50 @@ package clock
 
 import "time"
 
-func (_ *Clock_I) NowUTC() Time {
-	return Time(time.Now().Unix())
+// UTCMaxDrift is how large the allowable drift is in Filecoin's use of UTC time.
+var UTCMaxDrift = time.Second
+
+// UTCSyncPeriod notes how often to sync the UTC clock with an authoritative
+// source, such as NTP, or a very precise hardware clock.
+var UTCSyncPeriod = time.Hour
+
+// EpochDuration is a constant that represents the UTC time duration
+// of a blockchain epoch.
+var EpochDuration = time.Second * 15
+
+// ISOFormat is the ISO timestamp format we use, in Go time package notation.
+var ISOFormat = "2006-01-02T15:04:05.999999999Z"
+
+func (_ *UTCClock_I) NowUTC() Time {
+	return Time(time.Now().Format(ISOFormat))
 }
 
-func (_ *Clock_I) NowUTCNano() Time {
-	return Time(time.Now().UnixNano())
+func (_ *UTCClock_I) NowUTCUnix() UnixTime {
+	return UnixTime(time.Now().Unix())
 }
 
-// given some starting epoch and time since, what epoch should this be?
-func (self *Clock_I) epochAfterTime(start ChainEpoch, t Time) ChainEpoch {
-	panic("")
-	// return start + t/epochDuration
+func (_ *UTCClock_I) NowUTCUnixNano() UnixTimeNano {
+	return UnixTimeNano(time.Now().UnixNano())
 }
 
-func (self *Clock_I) EpochAfterGenesis() ChainEpoch {
-	panic("")
-	// return self.epochAfterTime(0 + self.NowUTCNano() - self.genesisTime)
-}
+// EpochAtTime returns the ChainEpoch corresponding to t.
+// It first subtracts GenesisTime, then divides by EpochDuration
+// and returns the resulting number of epochs.
+func (c *ChainEpochClock_I) EpochAtTime(t Time) ChainEpoch {
+	g1 := c.GenesisTime()
+	g2, err := time.Parse(ISOFormat, string(g1))
+	if err != nil {
+		// an implementation should probably not panic here
+		// this is for simplicity of the spec
+		panic(err)
+	}
 
-func (self *Clock_I) currentEpochStart() Time {
-	panic("")
-	// return EpochAfterGenesis() * self.epochDuration + genesisTime
-}
+	t2, err := time.Parse(ISOFormat, string(t))
+	if err != nil {
+		panic(err)
+	}
 
-func (self *Clock_I) CurrentEpochState() ChainEpoch {
-	panic("")
-	// if self.NowUTCNano()-self.currentEpochStart() > self.cutoffAt_ {
-	// 	return ChainEpochState.PastCutoff
-	// }
-	// return ChainEpochState.Active
+	difference := t2.Sub(g2)
+	epochs := difference / EpochDuration
+	return ChainEpoch(epochs)
 }

--- a/src/systems/filecoin_nodes/clock/clock_subsystem.id
+++ b/src/systems/filecoin_nodes/clock/clock_subsystem.id
@@ -1,22 +1,23 @@
 type Time string  // ISO nano timestamp
-type UnixTime int  // unix timestamp
-type Round int  // Blockchain round
-type ChainEpoch UVarint
-type ChainEpochState union {
-    InEpoch     int
-    PastCutoff  int
+type UnixTime int64  // unix timestamp
+type UnixTimeNano int64  // unix timestamp in nanoseconds
+
+// UTCClock is a normal, system clock reporting UTC time.
+// It should be kept in sync, with drift less than 1 second.
+type UTCClock struct {
+    NowUTC()          Time
+    NowUTCUnix()      UnixTime
+    NowUTCUnixNano()  UnixTimeNano
 }
 
-type Clock struct {
-    NowUTC()       Time
-    NowUTCNano()   UnixTime
+// ChainEpoch represents a round of a blockchain protocol.
+type ChainEpoch UVarint
 
-    genesisTime    UnixTime
-    epochDuration  UnixTime  @(cached)
-    cutoffAt       UnixTime  @(cached)
-    epochAfterTime(start ChainEpoch, t UnixTime) ChainEpoch
-    currentEpochStart() UnixTime
+// ChainEpochClock is a clock that represents epochs of the protocol.
+type ChainEpochClock struct {
+    // GenesisTime is the time of the first block. EpochClock counts
+    // up from there.
+    GenesisTime          Time
 
-    EpochAfterGenesis()  ChainEpochState
-    CurrentEpochState()  ChainEpochState
+    EpochAtTime(t Time)  ChainEpoch
 }

--- a/src/systems/filecoin_nodes/node_types/filecoin_node.id
+++ b/src/systems/filecoin_nodes/node_types/filecoin_node.id
@@ -8,5 +8,5 @@ type FilecoinNode struct {
 
     Repository  repo.Repository
     FileStore   filestore.FileStore
-    Clock       clock.Clock
+    Clock       clock.UTCClock
 }


### PR DESCRIPTION
This PR cleans up the clock interface:
- use UTCClock to be clear what kind of clock it is (wall clock was ok, but less clear)
- split ChainEpochClock into a separate object.