### PR TITLE
Check Pledge Collateral Requirement at PoSt Submission and Pledge Slashing

### DIFF
--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor.id
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor.id
@@ -30,7 +30,9 @@ type StoragePowerActorState struct {
     _lockPledgeCollateral(rt Runtime, address addr.Address, amount actor.TokenAmount)
     _unlockPledgeCollateral(rt Runtime, address addr.Address, amount actor.TokenAmount)
     _getPledgeCollateralReq(rt Runtime, newPower block.StoragePower) actor.TokenAmount
-    _sampleMinersToSurprise(rt Runtime, challengeCount int, randomness util.Randomness) [addr.Address]
+     _sampleMinersToSurprise(rt Runtime, challengeCount int, randomness util.Randomness) [addr.Address]
+    _shouldChallenge(rt Runtime, networkPower block.StoragePower) bool
+    _safeGetPowerEntry(rt Runtime, minerID addr.Address) PowerTableEntry
 }
 
 type StoragePowerActorCode struct {
@@ -54,7 +56,12 @@ type StoragePowerActorCode struct {
     EnsurePledgeCollateralSatisfied(rt Runtime) bool
 
     ProcessPowerReport(rt Runtime, report PowerReport)
-    SlashPledgeForStorageFaults(rt Runtime, faultType sector.StorageFaultType)
+    SlashPledgeForStorageFaults(
+        rt             Runtime
+        affectedPower  block.StoragePower
+        faultType      sector.StorageFaultType
+    )
+
     ReportConsensusFault(
         // slasherAddr  addr.Address TODO: fromActor
         rt         Runtime

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor.id
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor.id
@@ -54,7 +54,7 @@ type StoragePowerActorCode struct {
     // PowerTable Operations
     GetTotalPower(rt Runtime) block.StoragePower
 
-    EnsurePledgeCollateralSatisfied(rt Runtime) bool
+    EnsurePledgeCollateralSatisfied(rt Runtime)
 
     ProcessPowerReport(rt Runtime, report PowerReport)
     SlashPledgeForStorageFault(

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor.id
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor.id
@@ -29,7 +29,7 @@ type StoragePowerActorState struct {
     _lockPledgeCollateral(rt Runtime, address addr.Address, amount actor.TokenAmount)
     _unlockPledgeCollateral(rt Runtime, address addr.Address, amount actor.TokenAmount)
     _getPledgeCollateralReq(rt Runtime, newPower block.StoragePower) actor.TokenAmount
-     _sampleMinersToSurprise(rt Runtime, challengeCount int, randomness util.Randomness) [addr.Address]
+    _sampleMinersToSurprise(rt Runtime, challengeCount int, randomness util.Randomness) [addr.Address]
     _shouldChallenge(rt Runtime, networkPower block.StoragePower) bool
 
     _safeGetPowerEntry(rt Runtime, minerID addr.Address) PowerTableEntry

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor.id
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor.id
@@ -54,7 +54,7 @@ type StoragePowerActorCode struct {
     EnsurePledgeCollateralSatisfied(rt Runtime) bool
 
     ProcessPowerReport(rt Runtime, report PowerReport)
-    ProcessFaultReport(rt Runtime, report sector.FaultReport)
+    SlashPledgeForStorageFaults(rt Runtime, faultType sector.StorageFaultType)
     ReportConsensusFault(
         // slasherAddr  addr.Address TODO: fromActor
         rt         Runtime

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor.id
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor.id
@@ -34,6 +34,11 @@ type StoragePowerActorState struct {
 
     _safeGetPowerEntry(rt Runtime, minerID addr.Address) PowerTableEntry
     _ensurePledgeCollateralSatisfied(rt Runtime) bool
+    _getAffectedPledge(
+        rt             Runtime
+        minerID        addr.Address
+        affectedPower  block.StoragePower
+    ) actor.TokenAmount
 }
 
 type StoragePowerActorCode struct {

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor.id
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor.id
@@ -31,7 +31,9 @@ type StoragePowerActorState struct {
     _getPledgeCollateralReq(rt Runtime, newPower block.StoragePower) actor.TokenAmount
      _sampleMinersToSurprise(rt Runtime, challengeCount int, randomness util.Randomness) [addr.Address]
     _shouldChallenge(rt Runtime, networkPower block.StoragePower) bool
+
     _safeGetPowerEntry(rt Runtime, minerID addr.Address) PowerTableEntry
+    _ensurePledgeCollateralSatisfied(rt Runtime) bool
 }
 
 type StoragePowerActorCode struct {

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor.id
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor.id
@@ -19,12 +19,11 @@ type PowerReport struct {
 // type PowerTableHAMT {actor.ActorID: PowerTableEntry}
 type PowerTableHAMT {addr.Address: PowerTableEntry}  // TODO: convert address to ActorID
 
-// TODO: What does graceful removal look like?
-
 type StoragePowerActorState struct {
     // PowerTable is a mapping from MinerActorID to PowerTableEntry
-    PowerTable  PowerTableHAMT
-    EC          ExpectedConsensus
+    PowerTable               PowerTableHAMT
+    EC                       ExpectedConsensus
+    PledgeCollateralSlashed  actor.TokenAmount
 
     _slashPledgeCollateral(rt Runtime, address addr.Address, amount actor.TokenAmount)
     _lockPledgeCollateral(rt Runtime, address addr.Address, amount actor.TokenAmount)
@@ -56,7 +55,7 @@ type StoragePowerActorCode struct {
     EnsurePledgeCollateralSatisfied(rt Runtime) bool
 
     ProcessPowerReport(rt Runtime, report PowerReport)
-    SlashPledgeForStorageFaults(
+    SlashPledgeForStorageFault(
         rt             Runtime
         affectedPower  block.StoragePower
         faultType      sector.StorageFaultType

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor.id
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor.id
@@ -21,11 +21,10 @@ type PowerTableHAMT {addr.Address: PowerTableEntry}  // TODO: convert address to
 
 type StoragePowerActorState struct {
     // PowerTable is a mapping from MinerActorID to PowerTableEntry
-    PowerTable               PowerTableHAMT
-    EC                       ExpectedConsensus
-    PledgeCollateralSlashed  actor.TokenAmount
+    PowerTable  PowerTableHAMT
+    EC          ExpectedConsensus
 
-    _slashPledgeCollateral(rt Runtime, address addr.Address, amount actor.TokenAmount)
+    _slashPledgeCollateral(rt Runtime, address addr.Address, amount actor.TokenAmount) actor.TokenAmount
     _lockPledgeCollateral(rt Runtime, address addr.Address, amount actor.TokenAmount)
     _unlockPledgeCollateral(rt Runtime, address addr.Address, amount actor.TokenAmount)
     _getPledgeCollateralReq(rt Runtime, newPower block.StoragePower) actor.TokenAmount

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor.md
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor.md
@@ -6,9 +6,13 @@ title: Storage Power Actor
 
 {{< readfile file="storage_power_actor.id" code="true" lang="go" >}}
 
-# `StoragePowerActor` implementation
+# `StoragePowerActorState` implementation
 
-{{< readfile file="storage_power_actor.go" code="true" lang="go" >}}
+{{< readfile file="storage_power_actor_state.go" code="true" lang="go" >}}
+
+# `StoragePowerActorCode` implementation
+
+{{< readfile file="storage_power_actor_code.go" code="true" lang="go" >}}
 
 
 {{<label power_table>}}

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_code.go
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_code.go
@@ -15,9 +15,9 @@ import (
 )
 
 const (
-	MethodProcessPowerReport          = actor.MethodPlaceholder
-	MethodSlashPledgeForStorageFaults = actor.MethodPlaceholder
-	EnsurePledgeCollateralSatisfied   = actor.MethodPlaceholder
+	MethodProcessPowerReport         = actor.MethodPlaceholder
+	MethodSlashPledgeForStorageFault = actor.MethodPlaceholder
+	EnsurePledgeCollateralSatisfied  = actor.MethodPlaceholder
 )
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_code.go
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_code.go
@@ -15,9 +15,9 @@ import (
 )
 
 const (
-	MethodProcessPowerReport        = actor.MethodPlaceholder
-	MethodProcessFaultReport        = actor.MethodPlaceholder
-	EnsurePledgeCollateralSatisfied = actor.MethodPlaceholder
+	MethodProcessPowerReport          = actor.MethodPlaceholder
+	MethodSlashPledgeForStorageFaults = actor.MethodPlaceholder
+	EnsurePledgeCollateralSatisfied   = actor.MethodPlaceholder
 )
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -202,17 +202,17 @@ func (a *StoragePowerActorCode_I) EnsurePledgeCollateralSatisfied(rt Runtime) In
 
 // @param fault report
 // slash pledge collateral for Declared, Detected and Terminated faults
-func (a *StoragePowerActorCode_I) ProcessFaultReport(rt Runtime, report sector.FaultReport) {
+func (a *StoragePowerActorCode_I) SlashPledgeForStorageFaults(rt Runtime, faultType sector.StorageFaultType) {
 
-	var msgSender addr.Address // TODO replace this
+	// var msgSender addr.Address // TODO replace this
 
 	h, st := a.State(rt)
 
-	declaredFaultSlash := report.GetDeclaredFaultSlash()
-	detectedFaultSlash := report.GetDetectedFaultSlash()
-	terminatedFaultSlash := report.GetTerminatedFaultSlash()
+	// declaredFaultSlash := report.GetDeclaredFaultSlash()
+	// detectedFaultSlash := report.GetDetectedFaultSlash()
+	// terminatedFaultSlash := report.GetTerminatedFaultSlash()
 
-	st._slashPledgeCollateral(rt, msgSender, (declaredFaultSlash + detectedFaultSlash + terminatedFaultSlash))
+	// st._slashPledgeCollateral(rt, msgSender, (declaredFaultSlash + detectedFaultSlash + terminatedFaultSlash))
 
 	UpdateRelease(rt, h, st)
 }

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_code.go
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_code.go
@@ -66,13 +66,8 @@ func DeserializeState(x Bytes) State {
 func (a *StoragePowerActorCode_I) AddBalance(rt Runtime) {
 
 	msgValue := rt.ValueReceived()
-
-	// TODO: this should be enforced somewhere else
-	if msgValue < 0 {
-		rt.Abort("negative message value.")
-	}
-
 	minerID := rt.ImmediateCaller()
+	panic("TODO: fix minerID usage")
 
 	h, st := a.State(rt)
 
@@ -91,21 +86,22 @@ func (a *StoragePowerActorCode_I) AddBalance(rt Runtime) {
 func (a *StoragePowerActorCode_I) WithdrawBalance(rt Runtime, amount actor.TokenAmount) {
 
 	if amount < 0 {
-		rt.Abort("negative amount.")
+		rt.Abort("spa.WithdrawBalance: negative amount.")
 	}
 
 	minerID := rt.ImmediateCaller()
+	panic("TODO: fix minerID usage and assert caller is miner worker")
 
 	h, st := a.State(rt)
 
 	ret := st._ensurePledgeCollateralSatisfied(rt)
 	if !ret {
-		rt.Abort("insufficient pledge collateral.")
+		rt.Abort("spa.WithdrawBalance: insufficient pledge collateral.")
 	}
 
 	currEntry := st._safeGetPowerEntry(rt, minerID)
 	if currEntry.AvailableBalance() < amount {
-		rt.Abort("insufficient available balance.")
+		rt.Abort("spa.WithdrawBalance: insufficient available balance.")
 	}
 
 	currEntry.Impl().AvailableBalance_ = currEntry.AvailableBalance() - amount
@@ -154,14 +150,16 @@ func (a *StoragePowerActorCode_I) CreateStorageMiner(
 func (a *StoragePowerActorCode_I) RemoveStorageMiner(rt Runtime, address addr.Address) {
 
 	minerID := rt.ImmediateCaller()
+	panic("TODO: use address and verify address is the caller")
+	panic(minerID)
 
 	h, st := a.State(rt)
 
-	if (st.PowerTable()[minerID].ActivePower() + st.PowerTable()[minerID].InactivePower()) > 0 {
+	if (st.PowerTable()[address].ActivePower() + st.PowerTable()[address].InactivePower()) > 0 {
 		rt.Abort("power still remains.")
 	}
 
-	delete(st.PowerTable(), minerID)
+	delete(st.PowerTable(), address)
 
 	UpdateRelease(rt, h, st)
 }

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_code.go
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_code.go
@@ -200,21 +200,17 @@ func (a *StoragePowerActorCode_I) SlashPledgeForStorageFault(rt Runtime, affecte
 
 	h, st := a.State(rt)
 
-	// TODO: revisit this calculation
-	powerEntry := st._safeGetPowerEntry(rt, minerID)
-	totalPower := powerEntry.ActivePower() + powerEntry.InactivePower()
-	pledgeRequired := st._getPledgeCollateralReq(rt, totalPower)
-	pledgeAffected := actor.TokenAmount(uint64(pledgeRequired) * uint64(affectedPower) / uint64(totalPower))
+	affectedPledge := st._getAffectedPledge(rt, minerID, affectedPower)
 
 	switch faultType {
 	case sector.DeclaredFault:
-		amountToSlash := actor.TokenAmount(DeclaredFaultSlashPercent * uint64(pledgeAffected) / 100)
+		amountToSlash := actor.TokenAmount(DeclaredFaultSlashPercent * uint64(affectedPledge) / 100)
 		st._slashPledgeCollateral(rt, minerID, amountToSlash)
 	case sector.DetectedFault:
-		amountToSlash := actor.TokenAmount(DetectedFaultSlashPercent * uint64(pledgeAffected) / 100)
+		amountToSlash := actor.TokenAmount(DetectedFaultSlashPercent * uint64(affectedPledge) / 100)
 		st._slashPledgeCollateral(rt, minerID, amountToSlash)
 	case sector.TerminatedFault:
-		amountToSlash := actor.TokenAmount(TerminatedFaultSlashPercent * uint64(pledgeAffected) / 100)
+		amountToSlash := actor.TokenAmount(TerminatedFaultSlashPercent * uint64(affectedPledge) / 100)
 		st._slashPledgeCollateral(rt, minerID, amountToSlash)
 	}
 

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_code.go
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_code.go
@@ -114,7 +114,7 @@ func (a *StoragePowerActorCode_I) WithdrawBalance(rt Runtime, amount actor.Token
 	UpdateRelease(rt, h, st)
 
 	// send funds to miner
-	rt.SendPropagatingErrors(&msg.InvocInput_I{
+	rt.SendPropagatingErrors(&vmr.InvocInput_I{
 		To_:    minerID,
 		Value_: amount,
 	})
@@ -218,7 +218,7 @@ func (a *StoragePowerActorCode_I) SlashPledgeForStorageFault(rt Runtime, affecte
 	amountToSlash := st.PledgeCollateralSlashed()
 	UpdateRelease(rt, h, st)
 
-	rt.SendPropagatingErrors(&msg.InvocInput_I{
+	rt.SendPropagatingErrors(&vmr.InvocInput_I{
 		To_:    addr.BurntFundsActorAddr,
 		Value_: amountToSlash,
 	})

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_state.go
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_state.go
@@ -37,7 +37,6 @@ func (st *StoragePowerActorState_I) _slashPledgeCollateral(rt Runtime, address a
 	panic(amountToSlash)
 	st.Impl().PowerTable_[minerID] = currEntry
 
-	// TODO: commit state change
 }
 
 // TODO: batch process this if possible

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_state.go
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_state.go
@@ -58,6 +58,7 @@ func (st *StoragePowerActorState_I) _unlockPledgeCollateral(rt Runtime, address 
 	}
 
 	minerID := rt.ImmediateCaller()
+	panic("TODO: fix minerID usage and assert caller is miner worker")
 
 	currEntry := st._safeGetPowerEntry(rt, minerID)
 	if currEntry.Impl().LockedPledgeCollateral() < amount {

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_state.go
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_state.go
@@ -18,10 +18,7 @@ func (st *StoragePowerActorState_I) _slashPledgeCollateral(rt Runtime, address a
 	// TODO: convert address to MinerActorID
 	var minerID addr.Address
 
-	currEntry, found := st.PowerTable()[minerID]
-	if !found {
-		rt.Abort("minerID not found.")
-	}
+	currEntry := st._safeGetPowerEntry(rt, minerID)
 
 	amountToSlash := amount
 
@@ -50,10 +47,7 @@ func (st *StoragePowerActorState_I) _lockPledgeCollateral(rt Runtime, address ad
 	// TODO: convert address to MinerActorID
 	var minerID addr.Address
 
-	currEntry, found := st.PowerTable()[minerID]
-	if !found {
-		rt.Abort("minerID not found.")
-	}
+	currEntry := st._safeGetPowerEntry(rt, minerID)
 
 	if currEntry.Impl().AvailableBalance() < amount {
 		rt.Abort("insufficient available balance.")
@@ -73,11 +67,7 @@ func (st *StoragePowerActorState_I) _unlockPledgeCollateral(rt Runtime, address 
 	// TODO: convert address to MinerActorID
 	var minerID addr.Address
 
-	currEntry, found := st.PowerTable()[minerID]
-	if !found {
-		rt.Abort("minerID not found.")
-	}
-
+	currEntry := st._safeGetPowerEntry(rt, minerID)
 	if currEntry.Impl().LockedPledgeCollateral() < amount {
 		rt.Abort("insufficient locked balance.")
 	}
@@ -129,4 +119,14 @@ func (st *StoragePowerActorState_I) _sampleMinersToSurprise(rt Runtime, challeng
 	}
 
 	return sampledMiners
+}
+
+func (st *StoragePowerActorState_I) _safeGetPowerEntry(rt Runtime, minerID addr.Address) PowerTableEntry {
+	powerEntry, found := st.PowerTable()[minerID]
+
+	if !found {
+		rt.Abort("sm._safeGetPowerEntry: miner not found in power table.")
+	}
+
+	return powerEntry
 }

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_state.go
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_state.go
@@ -27,11 +27,10 @@ func (st *StoragePowerActorState_I) _slashPledgeCollateral(rt Runtime, address a
 		currEntry.Impl().LockedPledgeCollateral_ = 0
 		// TODO: extra handling of not having enough pledgecollateral to be slashed
 	} else {
-		currEntry.Impl().LockedPledgeCollateral_ = currEntry.LockedPledgeCollateral() - amount
+		currEntry.Impl().LockedPledgeCollateral_ = currEntry.LockedPledgeCollateral() - amountToSlash
 	}
 
-	// TODO: send amountToSlash to TreasuryActor
-	panic(amountToSlash)
+	st.Impl().PledgeCollateralSlashed_ += amountToSlash
 	st.Impl().PowerTable_[minerID] = currEntry
 
 }

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_state.go
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_state.go
@@ -129,3 +129,21 @@ func (st *StoragePowerActorState_I) _safeGetPowerEntry(rt Runtime, minerID addr.
 
 	return powerEntry
 }
+
+func (st *StoragePowerActorState_I) _ensurePledgeCollateralSatisfied(rt Runtime) bool {
+
+	// TODO: convert msgSender to MinerActorID
+	var minerID addr.Address
+
+	powerEntry := st._safeGetPowerEntry(rt, minerID)
+	pledgeCollateralRequired := st._getPledgeCollateralReq(rt, powerEntry.ActivePower()+powerEntry.InactivePower())
+
+	if pledgeCollateralRequired < powerEntry.LockedPledgeCollateral() {
+		return true
+	} else if pledgeCollateralRequired < (powerEntry.LockedPledgeCollateral() + powerEntry.AvailableBalance()) {
+		st._lockPledgeCollateral(rt, minerID, (pledgeCollateralRequired - powerEntry.LockedPledgeCollateral()))
+		return true
+	}
+
+	return false
+}

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_state.go
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_state.go
@@ -142,3 +142,14 @@ func (st *StoragePowerActorState_I) _ensurePledgeCollateralSatisfied(rt Runtime)
 
 	return false
 }
+
+func (st *StoragePowerActorState_I) _getAffectedPledge(rt Runtime, minerID addr.Address, affectedPower block.StoragePower) actor.TokenAmount {
+
+	// TODO: revisit this calculation
+	powerEntry := st._safeGetPowerEntry(rt, minerID)
+	totalPower := powerEntry.ActivePower() + powerEntry.InactivePower()
+	pledgeRequired := st._getPledgeCollateralReq(rt, totalPower)
+	affectedPledge := actor.TokenAmount(uint64(pledgeRequired) * uint64(affectedPower) / uint64(totalPower))
+
+	return affectedPledge
+}

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_state.go
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_state.go
@@ -39,7 +39,7 @@ func (st *StoragePowerActorState_I) _lockPledgeCollateral(rt Runtime, address ad
 		rt.Abort("negative amount.")
 	}
 
-	minerID := rt.ToplevelSender()
+	minerID := rt.ImmediateCaller()
 	currEntry := st._safeGetPowerEntry(rt, minerID)
 
 	if currEntry.Impl().AvailableBalance() < amount {
@@ -57,7 +57,7 @@ func (st *StoragePowerActorState_I) _unlockPledgeCollateral(rt Runtime, address 
 		rt.Abort("negative amount.")
 	}
 
-	minerID := rt.ToplevelSender()
+	minerID := rt.ImmediateCaller()
 
 	currEntry := st._safeGetPowerEntry(rt, minerID)
 	if currEntry.Impl().LockedPledgeCollateral() < amount {
@@ -125,7 +125,7 @@ func (st *StoragePowerActorState_I) _safeGetPowerEntry(rt Runtime, minerID addr.
 
 func (st *StoragePowerActorState_I) _ensurePledgeCollateralSatisfied(rt Runtime) bool {
 
-	minerID := rt.ToplevelSender()
+	minerID := rt.ImmediateCaller()
 
 	powerEntry := st._safeGetPowerEntry(rt, minerID)
 	pledgeCollateralRequired := st._getPledgeCollateralReq(rt, powerEntry.ActivePower()+powerEntry.InactivePower())

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_state.go
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_state.go
@@ -10,7 +10,7 @@ import (
 	util "github.com/filecoin-project/specs/util"
 )
 
-func (st *StoragePowerActorState_I) _slashPledgeCollateral(rt Runtime, minerID addr.Address, amount actor.TokenAmount) {
+func (st *StoragePowerActorState_I) _slashPledgeCollateral(rt Runtime, minerID addr.Address, amount actor.TokenAmount) actor.TokenAmount {
 	if amount < 0 {
 		rt.Abort("negative amount.")
 	}
@@ -27,8 +27,9 @@ func (st *StoragePowerActorState_I) _slashPledgeCollateral(rt Runtime, minerID a
 		currEntry.Impl().LockedPledgeCollateral_ = currEntry.LockedPledgeCollateral() - amountToSlash
 	}
 
-	st.Impl().PledgeCollateralSlashed_ += amountToSlash
 	st.Impl().PowerTable_[minerID] = currEntry
+
+	return amountToSlash
 
 }
 

--- a/src/systems/filecoin_markets/deal/deal.go
+++ b/src/systems/filecoin_markets/deal/deal.go
@@ -44,14 +44,6 @@ func (p *StorageDealProposal_I) CID() ProposalCID {
 	return cid
 }
 
-type StorageFaultType = int
-
-const (
-	DeclaredFault   StorageFaultType = 0
-	DetectedFault   StorageFaultType = 1
-	TerminatedFault StorageFaultType = 2
-)
-
 func (amt *DealExpirationAMT_I) Size() int {
 	return 0
 }

--- a/src/systems/filecoin_markets/deal/deal.go
+++ b/src/systems/filecoin_markets/deal/deal.go
@@ -44,10 +44,12 @@ func (p *StorageDealProposal_I) CID() ProposalCID {
 	return cid
 }
 
-type StorageDealSlashAction = int
+type StorageFaultType = int
 
 const (
-	SlashTerminatedFaults StorageDealSlashAction = 0
+	DeclaredFault   StorageFaultType = 0
+	DetectedFault   StorageFaultType = 1
+	TerminatedFault StorageFaultType = 2
 )
 
 func (amt *DealExpirationAMT_I) Size() int {

--- a/src/systems/filecoin_markets/storage_market/enum.go
+++ b/src/systems/filecoin_markets/storage_market/enum.go
@@ -5,17 +5,17 @@ import deal "github.com/filecoin-project/specs/systems/filecoin_markets/deal"
 type StorageDealStatus int
 
 const (
-	StorageDealProposalNotFound StorageDealStatus = 0
-	StorageDealProposalRejected StorageDealStatus = 1
-	StorageDealProposalAccepted StorageDealStatus = 2
-	StorageDealProposalSigned   StorageDealStatus = 3
-	StorageDealPublished        StorageDealStatus = 4
-	StorageDealCommitted        StorageDealStatus = 5
-	StorageDealActive           StorageDealStatus = 6
-	StorageDealFailing          StorageDealStatus = 7
-	StorageDealRecovering       StorageDealStatus = 8
-	StorageDealExpired          StorageDealStatus = 9
-	StorageDealNotFound         StorageDealStatus = 10
+	StorageDealProposalNotFound StorageDealStatus = 1 + iota
+	StorageDealProposalRejected
+	StorageDealProposalAccepted
+	StorageDealProposalSigned
+	StorageDealPublished
+	StorageDealCommitted
+	StorageDealActive
+	StorageDealFailing
+	StorageDealRecovering
+	StorageDealExpired
+	StorageDealNotFound
 )
 
 type PublishStorageDealResponse struct {

--- a/src/systems/filecoin_markets/storage_market/storage_market_actor.id
+++ b/src/systems/filecoin_markets/storage_market/storage_market_actor.id
@@ -98,7 +98,7 @@ type StorageMarketActorCode struct {
     ProcessDealSlash(
         rt         Runtime
         dealIDs    [deal.DealID]
-        faultType  deal.StorageFaultType
+        faultType  sector.StorageFaultType
     )
 
     // batch process storage deal payment

--- a/src/systems/filecoin_markets/storage_market/storage_market_actor.id
+++ b/src/systems/filecoin_markets/storage_market/storage_market_actor.id
@@ -54,7 +54,7 @@ type StorageMarketActorState struct {
         newPaymentEpoch  block.ChainEpoch
     ) actor.TokenAmount
 
-    _slashTerminatedFaults(rt Runtime, dealIDs [deal.DealID])
+    _slashTerminatedFault(rt Runtime, dealIDs [deal.DealID])
     _terminateDeal(rt Runtime, dealID deal.DealID)
     _slashDealCollateral(
         rt      Runtime
@@ -96,9 +96,9 @@ type StorageMarketActorCode struct {
     // call by StorageMinerActor
     // slash deal collateral depending on the faults (only TerminatedFault)
     ProcessDealSlash(
-        rt           Runtime
-        dealIDs      [deal.DealID]
-        slashAction  deal.StorageDealSlashAction
+        rt         Runtime
+        dealIDs    [deal.DealID]
+        faultType  deal.StorageFaultType
     )
 
     // batch process storage deal payment

--- a/src/systems/filecoin_markets/storage_market/storage_market_actor.md
+++ b/src/systems/filecoin_markets/storage_market/storage_market_actor.md
@@ -10,9 +10,13 @@ title: Storage Market Actor
 
 {{< readfile file="storage_market_actor.id" code="true" lang="go" >}}
 
-# `StorageMarketActor` implementation
+# `StorageMarketActorState` implementation
 
-{{< readfile file="storage_market_actor.go" code="true" lang="go" >}}
+{{< readfile file="storage_market_actor_state.go" code="true" lang="go" >}}
+
+# `StorageMarketActorCode` implementation
+
+{{< readfile file="storage_market_actor_code.go" code="true" lang="go" >}}
 
 
 {{<label storage_deal_collateral>}}

--- a/src/systems/filecoin_markets/storage_market/storage_market_actor_code.go
+++ b/src/systems/filecoin_markets/storage_market/storage_market_actor_code.go
@@ -191,7 +191,7 @@ func (a *StorageMarketActorCode_I) ActivateDeals(rt Runtime, dealIDs []deal.Deal
 
 }
 
-func (a *StorageMarketActorCode_I) ProcessDealSlash(rt Runtime, dealIDs []deal.DealID, faultType deal.StorageFaultType) {
+func (a *StorageMarketActorCode_I) ProcessDealSlash(rt Runtime, dealIDs []deal.DealID, faultType sector.StorageFaultType) {
 
 	TODO() // only call by StorageMinerActor
 
@@ -200,7 +200,7 @@ func (a *StorageMarketActorCode_I) ProcessDealSlash(rt Runtime, dealIDs []deal.D
 	// only terminated fault will result in slashing of deal collateral
 
 	switch faultType {
-	case deal.TerminatedFault:
+	case sector.TerminatedFault:
 		st._slashTerminatedFault(rt, dealIDs)
 	default:
 		rt.Abort("sma.ProcessDealSlash: invalid action type")

--- a/src/systems/filecoin_markets/storage_market/storage_market_actor_code.go
+++ b/src/systems/filecoin_markets/storage_market/storage_market_actor_code.go
@@ -14,6 +14,7 @@ import (
 const (
 	MethodGetUnsealedCIDForDealIDs = actor.MethodPlaceholder
 	MethodProcessDealExpiration    = actor.MethodPlaceholder
+	MethodProcessDealSlash         = actor.MethodPlaceholder
 )
 
 const LastPaymentEpochNone = 0

--- a/src/systems/filecoin_markets/storage_market/storage_market_actor_code.go
+++ b/src/systems/filecoin_markets/storage_market/storage_market_actor_code.go
@@ -58,6 +58,7 @@ func DeserializeState(x Bytes) State {
 func (a *StorageMarketActorCode_I) WithdrawBalance(rt Runtime, amount actor.TokenAmount) {
 
 	msgSender := rt.ImmediateCaller()
+	panic("TODO: assert caller is miner worker")
 
 	h, st := a.State(rt)
 
@@ -92,10 +93,6 @@ func (a *StorageMarketActorCode_I) AddBalance(rt Runtime) {
 	msgValue := rt.ValueReceived()
 
 	h, st := a.State(rt)
-
-	if msgValue <= 0 {
-		rt.Abort("non-positive balance to add.")
-	}
 
 	senderBalance, found := st.Balances()[msgSender]
 	if found {

--- a/src/systems/filecoin_markets/storage_market/storage_market_actor_code.go
+++ b/src/systems/filecoin_markets/storage_market/storage_market_actor_code.go
@@ -12,7 +12,8 @@ import (
 )
 
 const (
-	MethodGetUnsealedCIDForDealIDs = actor.MethodNum(3)
+	MethodGetUnsealedCIDForDealIDs = actor.MethodPlaceholder
+	MethodProcessDealExpiration    = actor.MethodPlaceholder
 )
 
 const LastPaymentEpochNone = 0

--- a/src/systems/filecoin_markets/storage_market/storage_market_actor_code.go
+++ b/src/systems/filecoin_markets/storage_market/storage_market_actor_code.go
@@ -191,7 +191,7 @@ func (a *StorageMarketActorCode_I) ActivateDeals(rt Runtime, dealIDs []deal.Deal
 
 }
 
-func (a *StorageMarketActorCode_I) ProcessDealSlash(rt Runtime, dealIDs []deal.DealID, slashAction deal.StorageDealSlashAction) {
+func (a *StorageMarketActorCode_I) ProcessDealSlash(rt Runtime, dealIDs []deal.DealID, faultType deal.StorageFaultType) {
 
 	TODO() // only call by StorageMinerActor
 
@@ -199,9 +199,9 @@ func (a *StorageMarketActorCode_I) ProcessDealSlash(rt Runtime, dealIDs []deal.D
 
 	// only terminated fault will result in slashing of deal collateral
 
-	switch slashAction {
-	case deal.SlashTerminatedFaults:
-		st._slashTerminatedFaults(rt, dealIDs)
+	switch faultType {
+	case deal.TerminatedFault:
+		st._slashTerminatedFault(rt, dealIDs)
 	default:
 		rt.Abort("sma.ProcessDealSlash: invalid action type")
 	}

--- a/src/systems/filecoin_markets/storage_market/storage_market_actor_code.go
+++ b/src/systems/filecoin_markets/storage_market/storage_market_actor_code.go
@@ -6,7 +6,6 @@ import (
 	deal "github.com/filecoin-project/specs/systems/filecoin_markets/deal"
 	sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 	actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
-	addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 	vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
 	util "github.com/filecoin-project/specs/util"
 )
@@ -81,7 +80,7 @@ func (a *StorageMarketActorCode_I) WithdrawBalance(rt Runtime, amount actor.Toke
 	UpdateRelease(rt, h, st)
 
 	// send funds to miner
-	rt.SendPropagatingErrors(&msg.InvocInput_I{
+	rt.SendPropagatingErrors(&vmr.InvocInput_I{
 		To_:    msgSender,
 		Value_: amount,
 	})

--- a/src/systems/filecoin_mining/sector/sector.go
+++ b/src/systems/filecoin_mining/sector/sector.go
@@ -9,7 +9,7 @@ const MAX_PROVE_COMMIT_SECTOR_EPOCH = block.ChainEpoch(3)
 type StorageFaultType int
 
 const (
-	DeclaredFault   StorageFaultType = 0
-	DetectedFault   StorageFaultType = 1
-	TerminatedFault StorageFaultType = 2
+	DeclaredFault StorageFaultType = 1 + iota
+	DetectedFault
+	TerminatedFault
 )

--- a/src/systems/filecoin_mining/sector/sector.go
+++ b/src/systems/filecoin_mining/sector/sector.go
@@ -6,7 +6,7 @@ import block "github.com/filecoin-project/specs/systems/filecoin_blockchain/stru
 // ProveCommitSector needs to be submitted within MAX_PROVE_COMMIT_SECTOR_EPOCH after PreCommit
 const MAX_PROVE_COMMIT_SECTOR_EPOCH = block.ChainEpoch(3)
 
-type StorageFaultType = int
+type StorageFaultType int
 
 const (
 	DeclaredFault   StorageFaultType = 0

--- a/src/systems/filecoin_mining/sector/sector.go
+++ b/src/systems/filecoin_mining/sector/sector.go
@@ -1,20 +1,15 @@
 package sector
 
-import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 import block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
 
 // TODO: placeholder epoch value -- this will be set later
 // ProveCommitSector needs to be submitted within MAX_PROVE_COMMIT_SECTOR_EPOCH after PreCommit
 const MAX_PROVE_COMMIT_SECTOR_EPOCH = block.ChainEpoch(3)
 
-func (r *FaultReport_I) GetDeclaredFaultSlash() actor.TokenAmount {
-	return actor.TokenAmount(0)
-}
+type StorageFaultType = int
 
-func (r *FaultReport_I) GetDetectedFaultSlash() actor.TokenAmount {
-	return actor.TokenAmount(0)
-}
-
-func (r *FaultReport_I) GetTerminatedFaultSlash() actor.TokenAmount {
-	return actor.TokenAmount(0)
-}
+const (
+	DeclaredFault   StorageFaultType = 0
+	DetectedFault   StorageFaultType = 1
+	TerminatedFault StorageFaultType = 2
+)

--- a/src/systems/filecoin_mining/sector/sector.id
+++ b/src/systems/filecoin_mining/sector/sector.id
@@ -2,7 +2,6 @@ import piece "github.com/filecoin-project/specs/systems/filecoin_files/piece"
 import ipld "github.com/filecoin-project/specs/libraries/ipld"
 import deal "github.com/filecoin-project/specs/systems/filecoin_markets/deal"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
-import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 import block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
 
 type Bytes32 Bytes
@@ -16,16 +15,6 @@ type SealedSectorCID ipld.CID
 type SectorNumber UInt
 
 type FaultSet CompactSectorSet
-
-type FaultReport struct {
-    NewDeclaredFaults          CompactSectorSet  // diff value
-    NewDetectedFaults          CompactSectorSet  // diff value
-    NewTerminatedFaults        CompactSectorSet  // diff value
-
-    GetDeclaredFaultSlash()    actor.TokenAmount
-    GetDetectedFaultSlash()    actor.TokenAmount
-    GetTerminatedFaultSlash()  actor.TokenAmount
-}
 
 type SectorUtilizationInfo struct {
     DealExpirationAMT  deal.DealExpirationAMT

--- a/src/systems/filecoin_mining/storage_mining/mining_cycle.md
+++ b/src/systems/filecoin_mining/storage_mining/mining_cycle.md
@@ -9,9 +9,6 @@ Block miners should constantly be performing Proofs of SpaceTime, and also check
 
 After successfully calling `CreateStorageMiner`, a miner actor will be created on-chain, and registered in the storage market. This miner, like all other Filecoin State Machine actors, has a fixed set of methods that can be used to interact with or control it.
 
-{{< readfile file="storage_miner_actor.id" code="true" lang="go" >}}
-{{< readfile file="storage_miner_actor.go" code="true" lang="go" >}}
-
 ## Owner Worker distinction
 
 The miner actor has two distinct 'controller' addresses. One is the worker, which is the address which will be responsible for doing all of the work, submitting proofs, committing new sectors, and all other day to day activities. The owner address is the address that created the miner, paid the collateral, and has block rewards paid out to it. The reason for the distinction is to allow different parties to fulfil the different roles. One example would be for the owner to be a multisig wallet, or a cold storage key, and the worker key to be a 'hot wallet' key.

--- a/src/systems/filecoin_mining/storage_mining/sector_state_enum.go
+++ b/src/systems/filecoin_mining/storage_mining/sector_state_enum.go
@@ -14,11 +14,11 @@ type FaultCount uint8
 const MAX_CONSECUTIVE_FAULTS = FaultCount(3)
 
 const (
-	SectorClearedSN    uint8 = 0
-	SectorCommittedSN  uint8 = 1
-	SectorActiveSN     uint8 = 2
-	SectorRecoveringSN uint8 = 3
-	SectorFailingSN    uint8 = 4
+	SectorClearedSN uint8 = 1 + iota
+	SectorCommittedSN
+	SectorActiveSN
+	SectorRecoveringSN
+	SectorFailingSN
 )
 
 type SectorState struct {

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
@@ -132,16 +132,16 @@ type StorageMinerActorCode struct {
     _onMissedSurprisePoSt(rt Runtime)
     _onSuccessfulPoSt(rt Runtime, postSubmission poster.PoStSubmission)
 
-    _submitFaultReport(
+    _slashCollateralForStorageFaults(
         rt          Runtime
-        declared    sector.CompactSectorSet
-        detected    sector.CompactSectorSet
-        terminated  sector.CompactSectorSet
+        declared    sector.CompactSectorSet  // diff value
+        detected    sector.CompactSectorSet  // diff value
+        terminated  sector.CompactSectorSet  // diff value
     )
     _slashDealsForStorageFault(
         rt             Runtime
         sectorNumbers  [sector.SectorNumber]
-        faultType      deal.StorageFaultType
+        faultType      sector.StorageFaultType
     )
 
     _submitPowerReport(rt Runtime, lastPoSt block.ChainEpoch)

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
@@ -112,6 +112,7 @@ type StorageMinerActorState struct {
 }
 
 type StorageMinerActorCode struct {
+    _isChallenged(rt Runtime) bool
     NotifyOfSurprisePoStChallenge(rt Runtime)
 
     PreCommitSector(rt Runtime, info sector.SectorPreCommitInfo)  // TODO: check with Magik on sizes
@@ -127,13 +128,9 @@ type StorageMinerActorCode struct {
     DeclareFaults(rt Runtime, failingSet sector.CompactSectorSet)
     RecoverFaults(rt Runtime, recoveringSet sector.CompactSectorSet)
 
-    // get active deals and last challenge end epoch
-    // will fail if the sector is in Failing, Recovering, or Committed state or not found
-    // Send ProcessBatchDealPayment to StorageMarketActor
-    CreditSectorDealPayment(rt Runtime, sectorNo sector.SectorNumber)
-
+    _isSealVerificationCorrect(rt Runtime, onChainInfo sector.OnChainSealVerifyInfo) bool
     _onMissedSurprisePoSt(rt Runtime)
-    _onSuccessfulPoSt(rt Runtime)
+    _onSuccessfulPoSt(rt Runtime, postSubmission poster.PoStSubmission)
 
     _submitFaultReport(
         rt          Runtime
@@ -146,9 +143,10 @@ type StorageMinerActorCode struct {
         sectorNumbers  [sector.SectorNumber]
         action         deal.StorageDealSlashAction
     )
-    _submitPowerReport(rt Runtime, lastPoSt block.ChainEpoch)
 
+    _submitPowerReport(rt Runtime, lastPoSt block.ChainEpoch)
     _expirePreCommittedSectors(rt Runtime)
+    _ensurePledgeCollateralSatisfied(rt Runtime)
 }
 
 type MinerInfo struct {

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
@@ -138,10 +138,10 @@ type StorageMinerActorCode struct {
         detected    sector.CompactSectorSet
         terminated  sector.CompactSectorSet
     )
-    _slashDealsFromFaultReport(
+    _slashDealsForStorageFault(
         rt             Runtime
         sectorNumbers  [sector.SectorNumber]
-        action         deal.StorageDealSlashAction
+        faultType      deal.StorageFaultType
     )
 
     _submitPowerReport(rt Runtime, lastPoSt block.ChainEpoch)

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
@@ -130,7 +130,7 @@ type StorageMinerActorCode struct {
     _isChallenged(rt Runtime) bool
     _isSealVerificationCorrect(rt Runtime, onChainInfo sector.OnChainSealVerifyInfo) bool
     _onMissedSurprisePoSt(rt Runtime)
-    _onSuccessfulPoSt(rt Runtime, postSubmission poster.PoStSubmission)
+    _onSuccessfulPoSt(rt Runtime, onChainInfo sector.OnChainPoStVerifyInfo)
 
     _slashCollateralForStorageFaults(
         rt          Runtime

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
@@ -112,7 +112,6 @@ type StorageMinerActorState struct {
 }
 
 type StorageMinerActorCode struct {
-    _isChallenged(rt Runtime) bool
     NotifyOfSurprisePoStChallenge(rt Runtime)
 
     PreCommitSector(rt Runtime, info sector.SectorPreCommitInfo)  // TODO: check with Magik on sizes
@@ -128,6 +127,7 @@ type StorageMinerActorCode struct {
     DeclareFaults(rt Runtime, failingSet sector.CompactSectorSet)
     RecoverFaults(rt Runtime, recoveringSet sector.CompactSectorSet)
 
+    _isChallenged(rt Runtime) bool
     _isSealVerificationCorrect(rt Runtime, onChainInfo sector.OnChainSealVerifyInfo) bool
     _onMissedSurprisePoSt(rt Runtime)
     _onSuccessfulPoSt(rt Runtime, postSubmission poster.PoStSubmission)

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor.md
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor.md
@@ -10,6 +10,10 @@ title: Storage Miner Actor
 
 {{< readfile file="storage_miner_actor.id" code="true" lang="go" >}}
 
-# `StorageMinerActor` implementation
+# `StorageMinerActorState` implementation
 
-{{< readfile file="storage_miner_actor.go" code="true" lang="go" >}}
+{{< readfile file="storage_miner_actor_state.go" code="true" lang="go" >}}
+
+# `StorageMinerActorCode` implementation
+
+{{< readfile file="storage_miner_actor_code.go" code="true" lang="go" >}}

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor_code.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor_code.go
@@ -392,7 +392,8 @@ func (a *StorageMinerActorCode_I) RecoverFaults(rt Runtime, recoveringSet sector
 
 	UpdateRelease(rt, h, st)
 
-	// EnsureDealCollateral
+	// TODO: EnsureDealCollateral
+	panic("TODO")
 
 	return rt.SuccessReturn()
 }

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor_code.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor_code.go
@@ -181,14 +181,16 @@ func (a *StorageMinerActorCode_I) _submitPowerReport(rt Runtime, lastPoStRespons
 	activePower := st._getActivePower(rt)
 	inactivePower := st._getInactivePower(rt)
 
-	// serialize this in param
-	powerReport := &spc.PowerReport_I{
+	// power report in processPowerReportParam
+	_ = &spc.PowerReport_I{
 		ActivePower_:   activePower,
 		InactivePower_: inactivePower,
 	}
 
-	processPowerReportParam := make([]actor.MethodParam, len(spc.Serialize_PowerReport(powerReport)))
-	processDealExpirationParam := make([]actor.MethodParam, len(newExpiredDealIDs)) // this should be serialized
+	// @param powerReport spc.PowerReport
+	processPowerReportParam := make([]actor.MethodParam, 1)
+	// @param dealIDs []deal.DealID
+	processDealExpirationParam := make([]actor.MethodParam, 1)
 
 	Release(rt, h, st)
 
@@ -215,14 +217,6 @@ func (a *StorageMinerActorCode_I) _submitPowerReport(rt Runtime, lastPoStRespons
 	}
 
 }
-
-// Decision is to currently account for power based on sector
-// with at least one active deals and deals cannot be updated
-// an alternative proposal is to account for power based on active deals
-// an improvement proposal is to allow storage deal update in a sector
-
-// TODO: decide whether declared faults sectors should be
-// penalized in the same way as undeclared sectors and how
 
 // this method is called by both SubmitElectionPoSt and SubmitSurprisePoSt
 // - Process ProvingSet.SectorsOn()
@@ -453,6 +447,9 @@ func (a *StorageMinerActorCode_I) _slashDealsForStorageFault(rt Runtime, sectorN
 		dealIDs = append(dealIDs, activeDealIDs...)
 
 	}
+
+	// @param dealIDs []deal.DealID
+	// @param faultType sector.StorageFaultType
 	processDealSlashParam := make([]actor.MethodParam, 2)
 
 	Release(rt, h, st)
@@ -477,7 +474,9 @@ func (a *StorageMinerActorCode_I) _slashPledgeForStorageFault(rt Runtime, sector
 
 	Release(rt, h, st)
 
-	slashPledgeParams := make([]actor.MethodParam, len(block.Serialize_StoragePower(affectedPower)))
+	// @param affectedPower block.StoragePower
+	// @param faultType sector.StorageFaultType
+	slashPledgeParams := make([]actor.MethodParam, 2)
 	rt.SendPropagatingErrors(&vmr.InvocInput_I{
 		To_:     addr.StoragePowerActorAddr,
 		Method_: spc.MethodSlashPledgeForStorageFault,

--- a/src/systems/filecoin_vm/runtime/exitcode/vm_exitcodes.go
+++ b/src/systems/filecoin_vm/runtime/exitcode/vm_exitcodes.go
@@ -57,7 +57,8 @@ const (
 )
 
 var (
-	InvalidSectorPacking = UserDefinedError(1)
+	InvalidSectorPacking         = UserDefinedError(1)
+	InsufficientPledgeCollateral = UserDefinedError(2)
 )
 
 func OK() ExitCode {


### PR DESCRIPTION
In this PR:

- [x] `EnsurePledgeCollateral` is added to `SubmitSurprise`, a SurprisePoSt is only valid when the miner has sufficient balance in StoragePowerActor. In the event that a SurprisePoSt fails because of insufficient pledge collateral, miners need to add Balance to StoragePowerActor and submit SurprisePoSt again. Note that election PoSt will always go through but some block reward will be sent to LockedBalance in StoragePowerActor in the event of undercollateralization.
- [x] Add slashPledgeForStorageFault, the exact amount to slash and rules in determining how much to slash under different storage faults will be added in a future PR
- [x] Replace `_submitFaultReport` with `_slashCollateralForStorageFaults` that calls `_slashDealsForStorageFault` and `_slashPledgeForStorageFault` depending on the `StorageFaultType`
- [x] Add `_ensurePledgeCollateral` to `WithdrawBalance` 
- [x] Wire collateral slashing between actors with rt.SendCatchingErrors
- [x] Add PledgeCollateralSlashed to SMA (similar to DealCollateralSlashed in StorageMarketActor), we can migrate this to an actor later
- [x] Move `_slashCollateralForStorageFaults` to be invoked after `_submitPowerReport` so that utilizationInfo is up-to-date when checking for affected power

Future PRs:

- [ ] Align on the shape and mechanism for pledge collateral function
- [ ] Decide on how much pledge collateral to slash given different storage fault types
- [ ] Align and decide if we should add a condition to leader election such that Pledge Collateral must be satisfied before being eligible to win a block or add Pledge Collateral check to Block Validation to work well with ElectionPoSt
- [ ] Add block reward garnishing in the event of under collateralization