### PR TITLE
Keep time using an int64

### DIFF
--- a/src/systems/filecoin_blockchain/blockchain.id
+++ b/src/systems/filecoin_blockchain/blockchain.id
@@ -29,7 +29,7 @@ type BlockchainSubsystem struct @(mutable) {
     SyncState()        SyncState
 
     // time of round cutoff time for accepting new blocks
-    epochCutoffTime()  clock.Time
+    epochCutoffTime()  clock.UnixTime
 
     // call by StorageClient in StorageDealMake
     VerifySectorExists(sectorId SectorID) bool

--- a/src/systems/filecoin_blockchain/struct/block/block.id
+++ b/src/systems/filecoin_blockchain/struct/block/block.id
@@ -27,7 +27,7 @@ type BlockHeader struct {
     MessageReceipts  ReceiptRoot
 
     // Consensus things
-    Timestamp        clock.Time
+    Timestamp        clock.UnixTime
     Ticket
     ElectionProof
 

--- a/src/systems/filecoin_blockchain/struct/block/tipset.go
+++ b/src/systems/filecoin_blockchain/struct/block/tipset.go
@@ -24,10 +24,10 @@ func (ts *Tipset_I) MinTicket() Ticket {
 	return ret
 }
 
-func (ts *Tipset_I) LatestTimestamp() clock.Time {
-	var latest clock.Time
+func (ts *Tipset_I) LatestTimestamp() clock.UnixTime {
+	var latest clock.UnixTime
 	for _, blk := range ts.Blocks_ {
-		if blk.Timestamp() > latest || latest == clock.Time(0) {
+		if blk.Timestamp() > latest || latest == clock.UnixTime(0) {
 			latest = blk.Timestamp()
 		}
 	}

--- a/src/systems/filecoin_blockchain/struct/block/tipset.id
+++ b/src/systems/filecoin_blockchain/struct/block/tipset.id
@@ -11,6 +11,6 @@ type Tipset struct {
     Weight             ChainWeight    @(cached)
     Epoch              ChainEpoch     @(cached)
 
-    LatestTimestamp()  clock.Time     @(cached)
+    LatestTimestamp()  clock.UnixTime @(cached)
     MinTicket()        Ticket         @(cached)
 }

--- a/src/systems/filecoin_blockchain/struct/block/tipset.id
+++ b/src/systems/filecoin_blockchain/struct/block/tipset.id
@@ -5,12 +5,12 @@ type Tipset struct {
     BlockCIDs          [BlockCID]
     Blocks             [BlockHeader]
 
-    Has(block Block)   bool           @(cached)
-    Parents            Tipset         @(cached)
-    StateTree          st.StateTree   @(cached)
-    Weight             ChainWeight    @(cached)
-    Epoch              ChainEpoch     @(cached)
+    Has(block Block)   bool            @(cached)
+    Parents            Tipset          @(cached)
+    StateTree          st.StateTree    @(cached)
+    Weight             ChainWeight     @(cached)
+    Epoch              ChainEpoch      @(cached)
 
-    LatestTimestamp()  clock.UnixTime @(cached)
-    MinTicket()        Ticket         @(cached)
+    LatestTimestamp()  clock.UnixTime  @(cached)
+    MinTicket()        Ticket          @(cached)
 }

--- a/src/systems/filecoin_nodes/clock/clock_subsystem.go
+++ b/src/systems/filecoin_nodes/clock/clock_subsystem.go
@@ -9,7 +9,7 @@ var UTCMaxDrift = time.Second
 // source, such as NTP, or a very precise hardware clock.
 var UTCSyncPeriod = time.Hour
 
-// EpochDuration is a constant that represents the time in seconds
+// EpochDuration is a constant that represents the duration in seconds
 // of a blockchain epoch.
 var EpochDuration = UnixTime(15)
 
@@ -17,14 +17,10 @@ func (_ *UTCClock_I) NowUTCUnix() UnixTime {
 	return UnixTime(time.Now().Unix())
 }
 
-// EpochAtTime returns the ChainEpoch corresponding to t.
+// EpochAtTime returns the ChainEpoch corresponding to time `t`.
 // It first subtracts GenesisTime, then divides by EpochDuration
-// and returns the resulting number of epochs. If t is before
-// GenesisTime zero is returned.
+// and returns the resulting number of epochs.
 func (c *ChainEpochClock_I) EpochAtTime(t UnixTime) ChainEpoch {
-	if t <= c.GenesisTime() {
-		return ChainEpoch(0)
-	}
 	difference := t - c.GenesisTime()
 	epochs := difference / EpochDuration
 	return ChainEpoch(epochs)

--- a/src/systems/filecoin_nodes/clock/clock_subsystem.go
+++ b/src/systems/filecoin_nodes/clock/clock_subsystem.go
@@ -9,43 +9,23 @@ var UTCMaxDrift = time.Second
 // source, such as NTP, or a very precise hardware clock.
 var UTCSyncPeriod = time.Hour
 
-// EpochDuration is a constant that represents the UTC time duration
+// EpochDuration is a constant that represents the time in seconds
 // of a blockchain epoch.
-var EpochDuration = time.Second * 15
-
-// ISOFormat is the ISO timestamp format we use, in Go time package notation.
-var ISOFormat = "2006-01-02T15:04:05.999999999Z"
-
-func (_ *UTCClock_I) NowUTC() Time {
-	return Time(time.Now().Format(ISOFormat))
-}
+var EpochDuration = UnixTime(15)
 
 func (_ *UTCClock_I) NowUTCUnix() UnixTime {
 	return UnixTime(time.Now().Unix())
 }
 
-func (_ *UTCClock_I) NowUTCUnixNano() UnixTimeNano {
-	return UnixTimeNano(time.Now().UnixNano())
-}
-
 // EpochAtTime returns the ChainEpoch corresponding to t.
 // It first subtracts GenesisTime, then divides by EpochDuration
-// and returns the resulting number of epochs.
-func (c *ChainEpochClock_I) EpochAtTime(t Time) ChainEpoch {
-	g1 := c.GenesisTime()
-	g2, err := time.Parse(ISOFormat, string(g1))
-	if err != nil {
-		// an implementation should probably not panic here
-		// this is for simplicity of the spec
-		panic(err)
+// and returns the resulting number of epochs. If t is before
+// GenesisTime zero is returned.
+func (c *ChainEpochClock_I) EpochAtTime(t UnixTime) ChainEpoch {
+	if t <= c.GenesisTime() {
+		return ChainEpoch(0)
 	}
-
-	t2, err := time.Parse(ISOFormat, string(t))
-	if err != nil {
-		panic(err)
-	}
-
-	difference := t2.Sub(g2)
+	difference := t - c.GenesisTime()
 	epochs := difference / EpochDuration
 	return ChainEpoch(epochs)
 }

--- a/src/systems/filecoin_nodes/clock/clock_subsystem.id
+++ b/src/systems/filecoin_nodes/clock/clock_subsystem.id
@@ -3,7 +3,7 @@ type UnixTime int64  // unix timestamp
 // UTCClock is a normal, system clock reporting UTC time.
 // It should be kept in sync, with drift less than 1 second.
 type UTCClock struct {
-    NowUTCUnix()      UnixTime
+    NowUTCUnix() UnixTime
 }
 
 // ChainEpoch represents a round of a blockchain protocol.
@@ -13,7 +13,7 @@ type ChainEpoch UVarint
 type ChainEpochClock struct {
     // GenesisTime is the time of the first block. EpochClock counts
     // up from there.
-    GenesisTime          UnixTime
+    GenesisTime              UnixTime
 
     EpochAtTime(t UnixTime)  ChainEpoch
 }

--- a/src/systems/filecoin_nodes/clock/clock_subsystem.id
+++ b/src/systems/filecoin_nodes/clock/clock_subsystem.id
@@ -1,13 +1,9 @@
-type Time string  // ISO nano timestamp
 type UnixTime int64  // unix timestamp
-type UnixTimeNano int64  // unix timestamp in nanoseconds
 
 // UTCClock is a normal, system clock reporting UTC time.
 // It should be kept in sync, with drift less than 1 second.
 type UTCClock struct {
-    NowUTC()          Time
     NowUTCUnix()      UnixTime
-    NowUTCUnixNano()  UnixTimeNano
 }
 
 // ChainEpoch represents a round of a blockchain protocol.
@@ -17,7 +13,7 @@ type ChainEpoch UVarint
 type ChainEpochClock struct {
     // GenesisTime is the time of the first block. EpochClock counts
     // up from there.
-    GenesisTime          Time
+    GenesisTime          UnixTime
 
-    EpochAtTime(t Time)  ChainEpoch
+    EpochAtTime(t UnixTime)  ChainEpoch
 }


### PR DESCRIPTION
### What changed?
- fixes #653: we should not use strings to represent time in block headers.
- simplify UTCClock: nanosecond precision is unnecessary.
- correct parts of spec that referenced time as string (was called `clock.Time`), use `clock.UnixTime` (an int64 under-the-hood) everywhere. 

### Questions:
1. Is returning ChainEpoch as 0 for all times before genesis acceptable? https://github.com/filecoin-project/specs/compare/frrist/fix-chain-epoch-clock?expand=1#diff-7e23591a34c702689c658c6fe73d893dR24-R26
2. BlockHeader Timestamp is an int64, meaning its max value is `9223372036854775807` or `12/04/292277026596 @ ~3:30pm (UTC)`, is this future-poof enough? https://github.com/filecoin-project/specs/compare/frrist/fix-chain-epoch-clock?expand=1#diff-f39f7b025d293796b93d9d8172d323c1R30

### Related Bits:
Here is a reference implementation in go-filecoin that led to this change: https://github.com/filecoin-project/go-filecoin/pull/3669