### PR TITLE
fix(retrieval): add missing link to id file

### DIFF
--- a/src/systems/filecoin_markets/retrieval_market/_index.md
+++ b/src/systems/filecoin_markets/retrieval_market/_index.md
@@ -78,7 +78,7 @@ The evolved protocol for proposing and accepting a deal will work as follows:
 - The provider unpauses the request and data resumes sending 
 - The process continues until the end of the query
 
-### Bootstrapping Trust
+# Bootstrapping Trust
 
 Neither the client nor the provider have any specific reason to trust the other. Therefore, payment for a retrieval deal is done in pieces, sending vouchers as bytes are sent and verified.
 
@@ -95,6 +95,6 @@ The trust process is as follows:
    - The process continues till the end of the retrieval, when the last payment will simply be for the remainder of bytes
 - Additional trust mechanisms in the V1 version of the protocol will include agreed upon timeouts and cancellation fees
 
-### Common Data Types
+# Common Data Types
 
 {{< readfile file="types.id" code="true" lang="go" >}}

--- a/src/systems/filecoin_markets/retrieval_market/_index.md
+++ b/src/systems/filecoin_markets/retrieval_market/_index.md
@@ -94,3 +94,7 @@ The trust process is as follows:
    requests payment, assuming it's received at least 1300 bytes since last payment
    - The process continues till the end of the retrieval, when the last payment will simply be for the remainder of bytes
 - Additional trust mechanisms in the V1 version of the protocol will include agreed upon timeouts and cancellation fees
+
+### Common Data Types
+
+{{< readfile file="types.id" code="true" lang="go" >}}

--- a/src/systems/filecoin_markets/retrieval_market/retrieval_client.md
+++ b/src/systems/filecoin_markets/retrieval_market/retrieval_client.md
@@ -2,7 +2,7 @@
 title: "Retrieval Client"
 ---
 
-### Client Dependencies
+# Client Dependencies
 
 The Retrieval Client Depends On The Following Dependencies
 
@@ -11,6 +11,6 @@ The Retrieval Client Depends On The Following Dependencies
 - **BlockStore**: Same as one used by data transfer module
 - **Data Transfer**: V1 only --Module used for transferring payload. Writes to the blockstore.
 
-### API
+# API
 
 {{< readfile file="retrieval_client.id" code="true" lang="go" >}}

--- a/src/systems/filecoin_markets/retrieval_market/retrieval_protocols.md
+++ b/src/systems/filecoin_markets/retrieval_market/retrieval_protocols.md
@@ -1,8 +1,6 @@
 ---
-title: "Retrieval Peer Resolver"
+title: "Retrieval Protocols"
 ---
-
-# Retrieval Protocols
 
 The `retrieval market` will initially be implemented as two `libp2p` services.
 

--- a/src/systems/filecoin_markets/retrieval_market/retrieval_provider.md
+++ b/src/systems/filecoin_markets/retrieval_market/retrieval_provider.md
@@ -2,16 +2,16 @@
 title: "Retrieval Provider (Miner)"
 ---
 
-### Provider Dependencies
+# Provider Dependencies
 
 The Retrieval Provider Depends On The Following Dependencies
 
 - **Host**: A libp2p host (set setup the libp2p protocols)
-- **Node**: A node implementation to query the chain for pieces and to setup and manage payment channels
-- **StorageMiner**: For unsealing sectors
+- **Filecoin Node**: A node implementation to query the chain for pieces and to setup and manage payment channels
+- **StorageMining Subsystem**: For unsealing sectors
 - **BlockStore**: Same as one used by data transfer module
 - **Data Transfer**: V1 only -- Module used for transferring payload. Reads from the blockstore.
 
-### API
+# API
 
 {{< readfile file="retrieval_provider.id" code="true" lang="go" >}}


### PR DESCRIPTION
# Goals

Eeek! I forgot to link my types.id file in the retrieval market PR and it's not showing up on the website :(

# Implementation

- Add a link in HTML to the types.id file for retrieval market so it shows up on the spec site
- Fix some headers so the sections have correct depth