### PR TITLE
Specify the order of tipset message execution, including implicit messages.

### DIFF
--- a/src/systems/filecoin_blockchain/struct/tipset/_index.md
+++ b/src/systems/filecoin_blockchain/struct/tipset/_index.md
@@ -7,7 +7,7 @@ Expected Consensus probabilistically elects multiple leaders in each epoch meani
 
 Each block references a parent tipset and validates _that tipset's state_, while proposing messages to be included for the current epoch. The state to which a new block's messages apply cannot be known until that block is incorporated into a tipset. It is thus not meaningful to execute the messages from a single block in isolation: a new state tree is only known once all messages in that block's tipset are executed. 
  
-A valid tipset contains a non-empty collection of blocks that all specify identical:
+A valid tipset contains a non-empty collection of blocks that have distinct miners and all specify identical:
 
 - `Epoch` 
 - `Parents`

--- a/src/systems/filecoin_vm/interpreter/_index.md
+++ b/src/systems/filecoin_vm/interpreter/_index.md
@@ -19,8 +19,10 @@ For each tipset:
 
 - the `CronActor`'s tick method is invoked implicitly after all the blocks' messages.
 
-These implicit messages must succeed (have an exit code of zero) in order for the new state to be
-computed. Receipts for them are included in the receipt list just like other messages. 
+These implicit messages specify a gas price of zero, but must be included in the computation.
+They must succeed (have an exit code of zero) in order for the new state to be
+computed. Receipts for them are excluded from the receipt list; only explicit messages have an 
+explicit receipt. 
 
 The gas payment for each message execution is paid to the miner owner account immediately after
 that message is executed. There are no encumbrances to either the block reward or gas fees earned: 

--- a/src/systems/filecoin_vm/interpreter/_index.md
+++ b/src/systems/filecoin_vm/interpreter/_index.md
@@ -2,11 +2,46 @@
 menuTitle: Interpreter
 statusIcon: ⚠️
 title: VM Interpreter - Message Invocation (Outside VM)
-entries:
-- vm_outside
-- vm_inside
-# suppressMenu: true
 ---
+
+The VM interpreter orchestrates the execution of messages from a tipset on that tipset's parent state,
+producing a new state and a sequence of message receipts. The CIDs of this new state and of the receipt
+collection are included in blocks from the subsequent epoch, which must agree about those CIDs 
+in order to form a new tipset.
+
+The messages from all the blocks in a tipset must be executed in order to produce a next state.
+In addition, for each block:
+- the block reward is paid to the miner owner account, and 
+- the block producer's election PoSt is processed by an implicit invocation on the associated actor  
+before that block's messages are executed 
+
+For each tipset:
+
+- the `CronActor`'s tick method is invoked implicitly after all the blocks' messages.
+
+These implicit messages must succeed (have an exit code of zero) in order for the new state to be
+computed. Receipts for them are included in the receipt list just like other messages. 
+
+The gas payment for each message execution is paid to the miner owner account immediately after
+that message is executed. There are no encumbrances to either the block reward or gas fees earned: 
+both may be spent immediately, including by a message in the same block in which they are earned.  
+
+Since different miners produce blocks in the same epoch, multiple blocks in a single tipset may 
+include the same message (identified by the same CID). 
+When this happens, the message is processed only the first time it is encountered in the tipset's
+canonical order. Subsequent instances of the message are ignored and do not result in any 
+state mutation or produce a receipt. 
+
+The sequence of executions for a tipset is thus summarised:
+
+- pay reward for first block
+- process election post for first block
+- messages for first block
+- pay reward for second block
+- process election post for second block
+- messages for second block (skipping any already encountered)
+- [... subsequent blocks ...]
+- cron tick 
 
 (You can see the _old_ VM interpreter [here](docs/systems/filecoin_vm/vm_interpreter_old) )
 

--- a/src/systems/filecoin_vm/interpreter/vm_interpreter.go
+++ b/src/systems/filecoin_vm/interpreter/vm_interpreter.go
@@ -33,12 +33,16 @@ func (vmi *VMInterpreter_I) ApplyTipSetMessages(inTree st.StateTree, msgs TipSet
 		// Pay block reward.
 		reward := _makeBlockRewardMessage(outTree, blk.Miner())
 		outTree, r = vmi.ApplyMessage(outTree, reward, blk.Miner())
-		receipts = append(receipts, r)
+		if r.ExitCode() != exitcode.OK() {
+			panic("block reward failed")
+		}
 
 		// Process block miner's Election PoSt.
 		epost := _makeElectionPoStMessage(outTree, blk.Miner(), msgs.Epoch(), blk.PoStProof())
 		outTree, r = vmi.ApplyMessage(outTree, epost, blk.Miner())
-		receipts = append(receipts, r)
+		if r.ExitCode() != exitcode.OK() {
+			panic("election post failed")
+		}
 
 		// Process messages from the block.
 		for _, m := range blk.Messages() {
@@ -56,7 +60,9 @@ func (vmi *VMInterpreter_I) ApplyTipSetMessages(inTree st.StateTree, msgs TipSet
 	cronSender := msgs.Blocks()[0].Miner()
 	cron := _makeCronTickMessage(outTree, cronSender)
 	outTree, r = vmi.ApplyMessage(outTree, cron, cronSender)
-	receipts = append(receipts, r)
+	if r.ExitCode() != exitcode.OK() {
+		panic("cron tick failed")
+	}
 
 	return
 }

--- a/src/systems/filecoin_vm/interpreter/vm_interpreter.go
+++ b/src/systems/filecoin_vm/interpreter/vm_interpreter.go
@@ -1,42 +1,64 @@
 package interpreter
 
-import msg "github.com/filecoin-project/specs/systems/filecoin_vm/message"
-import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
-import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
-import exitcode "github.com/filecoin-project/specs/systems/filecoin_vm/runtime/exitcode"
-import st "github.com/filecoin-project/specs/systems/filecoin_vm/state_tree"
-import vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
-import gascost "github.com/filecoin-project/specs/systems/filecoin_vm/runtime/gascost"
-import util "github.com/filecoin-project/specs/util"
+import (
+	ipld "github.com/filecoin-project/specs/libraries/ipld"
+	actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
+	addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
+	msg "github.com/filecoin-project/specs/systems/filecoin_vm/message"
+	vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
+	exitcode "github.com/filecoin-project/specs/systems/filecoin_vm/runtime/exitcode"
+	gascost "github.com/filecoin-project/specs/systems/filecoin_vm/runtime/gascost"
+	st "github.com/filecoin-project/specs/systems/filecoin_vm/state_tree"
+	util "github.com/filecoin-project/specs/util"
+)
+
+type Bytes = util.Bytes
 
 var TODO = util.TODO
 
-func (vmi *VMInterpreter_I) ApplyMessageBatch(inTree st.StateTree, msgs []MessageRef) (outTree st.StateTree, ret []msg.MessageReceipt) {
-	compTree := inTree
-	for _, m := range msgs {
-		oT, r := vmi.ApplyMessage(compTree, m.Message(), m.Miner())
-		compTree = oT        // assign the current tree. (this call always succeeds)
-		ret = append(ret, r) // add message receipt
-	}
-	return compTree, ret
-}
+const (
+	// TODO: reduce these when expected gas costs are known
+	sumbitElectionPostGasLimit = 1e18
+	payBlockRewardGasLimit     = 1e1
+	cronTickGasLimit           = 1e18
+)
 
-func _applyError(errCode exitcode.SystemErrorCode) msg.MessageReceipt {
-	// TODO: should this gasUsed value be zero?
-	// If nonzero, there is not guaranteed to be a nonzero gas balance from which to deduct it.
-	gasUsed := gascost.ApplyMessageFail
-	TODO()
-	return msg.MessageReceipt_MakeSystemError(errCode, gasUsed)
-}
+// Applies all the message in a tipset, along with implicit block- and tipset-specific state
+// transitions.
+func (vmi *VMInterpreter_I) ApplyTipSetMessages(inTree st.StateTree, msgs TipSetMessages) (outTree st.StateTree, receipts []msg.MessageReceipt) {
+	outTree = inTree
+	seenMsgs := make(map[ipld.CID]struct{}) // CIDs of messages already seen once.
+	var r msg.MessageReceipt
+	for _, blk := range msgs.Blocks() {
+		// Pay block reward.
+		reward := _makeBlockRewardMessage(outTree, blk.Miner())
+		outTree, r = vmi.ApplyMessage(outTree, reward, blk.Miner())
+		receipts = append(receipts, r)
 
-func _withTransferFundsAssert(tree st.StateTree, from addr.Address, to addr.Address, amount actor.TokenAmount) st.StateTree {
-	// TODO: assert amount nonnegative
-	retTree, err := tree.Impl().WithFundsTransfer(from, to, amount)
-	if err != nil {
-		panic("Interpreter error: insufficient funds (or transfer error) despite checks")
-	} else {
-		return retTree
+		// Process block miner's Election PoSt.
+		epost := _makeElectionPoStMessage(outTree, blk.Miner(), msgs.Epoch(), blk.PoStProof())
+		outTree, r = vmi.ApplyMessage(outTree, epost, blk.Miner())
+		receipts = append(receipts, r)
+
+		// Process messages from the block.
+		for _, m := range blk.Messages() {
+			_, found := seenMsgs[_msgCID(m)]
+			if found {
+				continue
+			}
+			outTree, r = vmi.ApplyMessage(outTree, m, blk.Miner())
+			receipts = append(receipts, r)
+			seenMsgs[_msgCID(m)] = struct{}{}
+		}
 	}
+
+	// Invoke cron tick, attributing it to the miner of the first block.
+	cronSender := msgs.Blocks()[0].Miner()
+	cron := _makeCronTickMessage(outTree, cronSender)
+	outTree, r = vmi.ApplyMessage(outTree, cron, cronSender)
+	receipts = append(receipts, r)
+
+	return
 }
 
 func (vmi *VMInterpreter_I) ApplyMessage(inTree st.StateTree, message msg.UnsignedMessage, minerAddr addr.Address) (
@@ -54,7 +76,7 @@ func (vmi *VMInterpreter_I) ApplyMessage(inTree st.StateTree, message msg.Unsign
 	}
 
 	// make sure fromActor has enough money to run the max invocation
-	maxGasCost := gasToFIL(message.GasLimit(), message.GasPrice())
+	maxGasCost := _gasToFIL(message.GasLimit(), message.GasPrice())
 	totalCost := message.Value() + actor.TokenAmount(maxGasCost)
 	if fromActor.Balance() < totalCost {
 		return inTree, _applyError(exitcode.InsufficientFunds)
@@ -102,7 +124,7 @@ func (vmi *VMInterpreter_I) ApplyMessage(inTree st.StateTree, message msg.Unsign
 			outTree,
 			message.From(),
 			addr.BurntFundsActorAddr,
-			gasToFIL(sendRet.GasUsed(), message.GasPrice()),
+			_gasToFIL(sendRet.GasUsed(), message.GasPrice()),
 		)
 	} else {
 		// success -- refund unused gas
@@ -113,7 +135,7 @@ func (vmi *VMInterpreter_I) ApplyMessage(inTree st.StateTree, message msg.Unsign
 			outTree,
 			addr.BurntFundsActorAddr,
 			message.From(),
-			gasToFIL(refundGas, message.GasPrice()),
+			_gasToFIL(refundGas, message.GasPrice()),
 		)
 	}
 
@@ -128,12 +150,90 @@ func (vmi *VMInterpreter_I) ApplyMessage(inTree st.StateTree, message msg.Unsign
 		outTree,
 		addr.BurntFundsActorAddr,
 		minerAddr, // TODO: may not exist
-		gasToFIL(sendRet.GasUsed(), message.GasPrice()),
+		_gasToFIL(sendRet.GasUsed(), message.GasPrice()),
 	)
 
 	return outTree, sendRet
 }
 
-func gasToFIL(gas msg.GasAmount, price msg.GasPrice) actor.TokenAmount {
+func _applyError(errCode exitcode.SystemErrorCode) msg.MessageReceipt {
+	// TODO: should this gasUsed value be zero?
+	// If nonzero, there is not guaranteed to be a nonzero gas balance from which to deduct it.
+	gasUsed := gascost.ApplyMessageFail
+	TODO()
+	return msg.MessageReceipt_MakeSystemError(errCode, gasUsed)
+}
+
+func _withTransferFundsAssert(tree st.StateTree, from addr.Address, to addr.Address, amount actor.TokenAmount) st.StateTree {
+	// TODO: assert amount nonnegative
+	retTree, err := tree.Impl().WithFundsTransfer(from, to, amount)
+	if err != nil {
+		panic("Interpreter error: insufficient funds (or transfer error) despite checks")
+	} else {
+		return retTree
+	}
+}
+
+func _gasToFIL(gas msg.GasAmount, price msg.GasPrice) actor.TokenAmount {
 	return actor.TokenAmount(util.UVarint(gas) * util.UVarint(price))
+}
+
+// Builds a message for paying block reward from the treasury account to a miner owner.
+func _makeBlockRewardMessage(state st.StateTree, minerActorAddr addr.Address) msg.UnsignedMessage {
+	// networkTreasuryActor := loadActor(NetworkTreasuryActorAddress)
+	// minerActor := loadActorSubstate(minerActorAddr)
+	// minerWorker := loadActor(minerActor.Info.Worker)
+	//return &UnsignedMessage_I{
+	//	From_:       minerActor.Info.Worker,
+	//	To_:         NetworkTreasuryActorAddress,
+	//	Method_:     NetworkTreasury.PayBlockReward,
+	//	Params_:     serialize([minerActorAddr]),
+	//	CallSeqNum_: minerWorker.CallSeqNum,
+	//	Value_:      0,
+	//	GasPrice_:   0,
+	//	GasLimit_:   payBlockRewardGasLimit,
+	//}
+	panic("TODO: implement when network treasury actor implemented")
+}
+
+// Builds a message for submitting ElectionPost on behalf of a miner actor.
+func _makeElectionPoStMessage(state st.StateTree, minerActorAddr addr.Address, epoch UInt64, postProof Bytes) msg.UnsignedMessage {
+	// minerActor := loadActorSubstate(minerActorAddr)
+	// minerWorker := loadActor(minerActor.Info.Worker)
+	//return &UnsignedMessage_I{
+	//	From_:       minerActor.Info.Worker,
+	//	To_:         minerActorAddr,
+	//	Method_:     StorageMinerActor.SubmitElectionPoSt,
+	//	Params_:     serialize([PoStSubmission{postProof, epoch}]),
+	//	CallSeqNum_: minerWorker.CallSeqNum,
+	//	Value_:      0,
+	//	GasPrice_:   0,
+	//	GasLimit_:   sumbitElectionPostGasLimit,
+	//}
+	panic("TODO: implement when necessary dependencies are importable")
+}
+
+// Builds a message for invoking the cron actor tick.
+func _makeCronTickMessage(state st.StateTree, minerActorAddr addr.Address) msg.UnsignedMessage {
+	// minerActor := loadActorSubstate(minerActorAddr)
+	// minerWorker := loadActor(minerActor.Info.Worker)
+	//return &UnsignedMessage_I{
+	//	From_:       minerActor.Info.Worker,
+	//	To_:         CronActorAddress,
+	//	Method_:     CronActor.EpochTick,
+	//	Params_:     nil,
+	//	CallSeqNum_: minerWorker.CallSeqNum,
+	//	Value_:      0,
+	//	GasPrice_:   0,
+	//	GasLimit_:   cronTickGasLimit,
+	//}
+	panic("TODO: implement when necessary dependencies are importable")
+}
+
+func _msgCID(msg msg.UnsignedMessage) ipld.CID {
+	panic("TODO")
+}
+
+func _encodeParams(p []interface{}) Bytes {
+	panic("TODO")
 }

--- a/src/systems/filecoin_vm/interpreter/vm_interpreter.id
+++ b/src/systems/filecoin_vm/interpreter/vm_interpreter.id
@@ -1,13 +1,23 @@
+import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import msg "github.com/filecoin-project/specs/systems/filecoin_vm/message"
 import st "github.com/filecoin-project/specs/systems/filecoin_vm/state_tree"
-import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 
-type MessageRef struct {
-    Message  msg.UnsignedMessage
-    Miner    addr.Address
+type UInt64 UInt
+
+// The messages from one block in a tipset.
+type BlockMessages struct {
+    Messages  [msg.UnsignedMessage]
+    Miner     addr.Address      // The block miner's actor address
+    PoStProof Bytes             // The miner's Election PoSt proof output
+}
+
+// The messages from a tipset, grouped by block.
+type TipSetMessages struct {
+    Blocks  [BlockMessages]
+    Epoch   UInt64              // The chain epoch of the blocks
 }
 
 type VMInterpreter struct {
-    ApplyMessageBatch(inTree st.StateTree, msgs [MessageRef]) struct {outTree st.StateTree, ret [msg.MessageReceipt]}
+    ApplyTipSetMessages(inTree st.StateTree, msgs TipSetMessages) struct {outTree st.StateTree, ret [msg.MessageReceipt]}
     ApplyMessage(inTree st.StateTree, msg msg.Message, minerAddr addr.Address) struct {outTree st.StateTree, ret msg.MessageReceipt}
 }

--- a/src/systems/filecoin_vm/interpreter/vm_interpreter.id
+++ b/src/systems/filecoin_vm/interpreter/vm_interpreter.id
@@ -6,15 +6,15 @@ type UInt64 UInt
 
 // The messages from one block in a tipset.
 type BlockMessages struct {
-    Messages  [msg.UnsignedMessage]
-    Miner     addr.Address      // The block miner's actor address
-    PoStProof Bytes             // The miner's Election PoSt proof output
+    Messages   [msg.UnsignedMessage]
+    Miner      addr.Address  // The block miner's actor address
+    PoStProof  Bytes  // The miner's Election PoSt proof output
 }
 
 // The messages from a tipset, grouped by block.
 type TipSetMessages struct {
     Blocks  [BlockMessages]
-    Epoch   UInt64              // The chain epoch of the blocks
+    Epoch   UInt64  // The chain epoch of the blocks
 }
 
 type VMInterpreter struct {


### PR DESCRIPTION
Prose and code for the execution of a tipset's messages, including message construction
pseudocode for the implicit processing of election post, block reward payment, and
cron tick.

~All messages, including the implicit ones, produce receipts, so we have exactly one receipt per state mutation (this differs from what I'd previously proposed in person).~

Coming later:
- fixes to the rest of vm_interpreter.go
- block/message validation do-over

cc @jzimmerman @acruikshank @icorderi @magik6k 