### PR TITLE
Add NewActorAddress() to runtime in place of three different less abstract accessors.

### DIFF
--- a/src/systems/filecoin_vm/runtime/runtime.id
+++ b/src/systems/filecoin_vm/runtime/runtime.id
@@ -22,27 +22,15 @@ type Runtime interface {
     ValidateImmediateCallerAcceptAny()
     ValidateImmediateCallerMatches(CallerPattern)
 
-    CurrMethodNum()             actor.MethodNum
-
-    // Note: This is the actor in the From field of the initial on-chain message.
-    // Not necessarily the immediate caller.
-    ToplevelSender()            addr.Address
+    CurrMethodNum()        actor.MethodNum
 
     // The actor who mined the block in which the initial on-chain message appears.
-    ToplevelBlockWinner()       addr.Address
+    ToplevelBlockWinner()  addr.Address
 
-    // Top-level call sequence number of the "From" actor in the initial on-chain message.
-    ToplevelSenderCallSeqNum()  actor.CallSeqNum
+    AcquireState()         ActorStateHandle
 
-    // Sequence number representing the total number of calls (to any actor, any method)
-    // during the current top-level message execution.
-    // Note: resets with every top-level message, and therefore not necessarily monotonic.
-    InternalCallSeqNum()        actor.CallSeqNum
-
-    AcquireState()              ActorStateHandle
-
-    SuccessReturn()             msg.InvocOutput
-    ValueReturn(Bytes)          msg.InvocOutput
+    SuccessReturn()        msg.InvocOutput
+    ValueReturn(Bytes)     msg.InvocOutput
     ErrorReturn(exitCode exitcode.ExitCode) msg.InvocOutput
 
     // Throw an error indicating a failure condition has occurred, from which the given actor
@@ -75,6 +63,11 @@ type Runtime interface {
     SendPropagatingErrors(input msg.InvocInput) msg.InvocOutput
     SendCatchingErrors(input msg.InvocInput) msg.InvocOutput
 
+    // Computes an address for a new actor. The returned address is intended to uniquely refer to
+    // the actor even in the event of a chain re-org (whereas an ID-address might refer to a
+    // different actor after messages are re-ordered).
+    NewActorAddress() addr.Address
+
     // Create an actor in the state tree. May only be called by InitActor.
     CreateActor(
         stateCID           actor.ActorSystemStateCID
@@ -85,4 +78,10 @@ type Runtime interface {
 
     IpldGet(c ipld.CID) union {Bytes, error}
     IpldPut(x ipld.Object) ipld.CID
+}
+
+type ActorExecAddressSeed struct {
+    creator             addr.Address
+    toplevelCallSeqNum  actor.CallSeqNum
+    internalCallSeqNum  actor.CallSeqNum
 }

--- a/src/systems/filecoin_vm/sysactors/init_actor.go
+++ b/src/systems/filecoin_vm/sysactors/init_actor.go
@@ -70,7 +70,7 @@ func (a *InitActorCode_I) Exec(rt Runtime, codeID actor.CodeID, constructorParam
 		rt.Abort("cannot exec an actor of this type")
 	}
 
-	newAddr := _computeNewActorExecAddress(rt)
+	newAddr := rt.NewActorAddress()
 
 	actorState := &actor.ActorState_I{
 		CodeID_:     codeID,
@@ -104,18 +104,6 @@ func (s *InitActorState_I) _assignNextID() addr.ActorID {
 	actorID := s.NextID_
 	s.NextID_++
 	return actorID
-}
-
-func _computeNewActorExecAddress(rt Runtime) addr.Address {
-	seed := &ActorExecAddressSeed_I{
-		creator_:            rt.ImmediateCaller(),
-		toplevelCallSeqNum_: rt.ToplevelSenderCallSeqNum(),
-		internalCallSeqNum_: rt.InternalCallSeqNum(),
-	}
-	hash := addr.ActorExecHash(Serialize_ActorExecAddressSeed(seed))
-
-	// Intended to be a unique identifier, stable across reorgs
-	return addr.Address_Make_ActorExec(addr.Address_NetworkID_Testnet, hash)
 }
 
 func (a *InitActorCode_I) GetActorIDForAddress(rt Runtime, address addr.Address) InvocOutput {

--- a/src/systems/filecoin_vm/sysactors/init_actor.id
+++ b/src/systems/filecoin_vm/sysactors/init_actor.id
@@ -16,9 +16,3 @@ type InitActorCode struct {
     Exec(r vmr.Runtime, code actor.CodeID, params actor.MethodParams) addr.Address
     GetActorIDForAddress(r vmr.Runtime, address addr.Address) addr.ActorID
 }
-
-type ActorExecAddressSeed struct {
-    creator             addr.Address
-    toplevelCallSeqNum  actor.CallSeqNum
-    internalCallSeqNum  actor.CallSeqNum
-}


### PR DESCRIPTION
`ToplevelSender()`, `InternalCallSeqNum` and `ToplevelSenderCallSeqNum` existed on the runtime only to be used to compute new actor addresses. The runtime should present as abstract an interface as possible, so moving the new address computation inside reduces the surface area.

It may be necessary to add `ToplevelSender` back at some point, but until a concrete case emerges we should keep the interface narrow.

cc @icorderi 