### PR TITLE
Pull InvocInput/Output and MessageReceipt up to interpreter package

### DIFF
--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_code.go
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_code.go
@@ -9,7 +9,6 @@ import (
 	sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 	actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 	addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
-	msg "github.com/filecoin-project/specs/systems/filecoin_vm/message"
 	vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
 	util "github.com/filecoin-project/specs/util"
 )
@@ -22,7 +21,7 @@ const (
 ////////////////////////////////////////////////////////////////////////////////
 // Boilerplate
 ////////////////////////////////////////////////////////////////////////////////
-type InvocOutput = msg.InvocOutput
+type InvocOutput = vmr.InvocOutput
 type Runtime = vmr.Runtime
 type Bytes = util.Bytes
 type State = StoragePowerActorState

--- a/src/systems/filecoin_markets/storage_market/storage_market_actor_code.go
+++ b/src/systems/filecoin_markets/storage_market/storage_market_actor_code.go
@@ -1,22 +1,14 @@
 package storage_market
 
 import (
+	ipld "github.com/filecoin-project/specs/libraries/ipld"
+	block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
+	deal "github.com/filecoin-project/specs/systems/filecoin_markets/deal"
+	sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 	actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 	addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
-
-	block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
-
-	deal "github.com/filecoin-project/specs/systems/filecoin_markets/deal"
-
-	ipld "github.com/filecoin-project/specs/libraries/ipld"
-
-	msg "github.com/filecoin-project/specs/systems/filecoin_vm/message"
-
-	sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
-
-	util "github.com/filecoin-project/specs/util"
-
 	vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
+	util "github.com/filecoin-project/specs/util"
 )
 
 const (
@@ -28,7 +20,7 @@ const LastPaymentEpochNone = 0
 ////////////////////////////////////////////////////////////////////////////////
 // Boilerplate
 ////////////////////////////////////////////////////////////////////////////////
-type InvocOutput = msg.InvocOutput
+type InvocOutput = vmr.InvocOutput
 type Runtime = vmr.Runtime
 type Bytes = util.Bytes
 type State = StorageMarketActorState

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor_code.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor_code.go
@@ -11,7 +11,6 @@ import (
 	poster "github.com/filecoin-project/specs/systems/filecoin_mining/storage_proving/poster"
 	actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 	addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
-	msg "github.com/filecoin-project/specs/systems/filecoin_vm/message"
 	vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
 	exitcode "github.com/filecoin-project/specs/systems/filecoin_vm/runtime/exitcode"
 	util "github.com/filecoin-project/specs/util"
@@ -28,7 +27,7 @@ type State = StorageMinerActorState
 type Any = util.Any
 type Bool = util.Bool
 type Bytes = util.Bytes
-type InvocOutput = msg.InvocOutput
+type InvocOutput = vmr.InvocOutput
 type Runtime = vmr.Runtime
 
 var TODO = util.TODO
@@ -491,7 +490,7 @@ func (a *StorageMinerActorCode_I) _isSealVerificationCorrect(rt Runtime, onChain
 	Release(rt, h, st) // if no modifications made; or
 
 	// TODO: serialize method param as {sectorSize,  DealIDs...}.
-	receipt := rt.SendCatchingErrors(&msg.InvocInput_I{
+	receipt := rt.SendCatchingErrors(&vmr.InvocInput_I{
 		To_:     addr.StorageMarketActorAddr,
 		Method_: storage_market.MethodGetUnsealedCIDForDealIDs,
 		Params_: params,

--- a/src/systems/filecoin_vm/interpreter/vm_interpreter.go
+++ b/src/systems/filecoin_vm/interpreter/vm_interpreter.go
@@ -25,10 +25,10 @@ const (
 
 // Applies all the message in a tipset, along with implicit block- and tipset-specific state
 // transitions.
-func (vmi *VMInterpreter_I) ApplyTipSetMessages(inTree st.StateTree, msgs TipSetMessages) (outTree st.StateTree, receipts []msg.MessageReceipt) {
+func (vmi *VMInterpreter_I) ApplyTipSetMessages(inTree st.StateTree, msgs TipSetMessages) (outTree st.StateTree, receipts []vmr.MessageReceipt) {
 	outTree = inTree
 	seenMsgs := make(map[ipld.CID]struct{}) // CIDs of messages already seen once.
-	var r msg.MessageReceipt
+	var r vmr.MessageReceipt
 	for _, blk := range msgs.Blocks() {
 		// Pay block reward.
 		reward := _makeBlockRewardMessage(outTree, blk.Miner())
@@ -68,7 +68,7 @@ func (vmi *VMInterpreter_I) ApplyTipSetMessages(inTree st.StateTree, msgs TipSet
 }
 
 func (vmi *VMInterpreter_I) ApplyMessage(inTree st.StateTree, message msg.UnsignedMessage, minerAddr addr.Address) (
-	st.StateTree, msg.MessageReceipt) {
+	st.StateTree, vmr.MessageReceipt) {
 
 	compTree := inTree
 	var outTree st.StateTree
@@ -115,7 +115,7 @@ func (vmi *VMInterpreter_I) ApplyMessage(inTree st.StateTree, message msg.Unsign
 	)
 
 	sendRet, sendRetStateTree := rt.SendToplevelFromInterpreter(
-		msg.InvocInput_Make(
+		vmr.InvocInput_Make(
 			message.To(),
 			message.Method(),
 			message.Params(),
@@ -162,12 +162,12 @@ func (vmi *VMInterpreter_I) ApplyMessage(inTree st.StateTree, message msg.Unsign
 	return outTree, sendRet
 }
 
-func _applyError(errCode exitcode.SystemErrorCode) msg.MessageReceipt {
+func _applyError(errCode exitcode.SystemErrorCode) vmr.MessageReceipt {
 	// TODO: should this gasUsed value be zero?
 	// If nonzero, there is not guaranteed to be a nonzero gas balance from which to deduct it.
 	gasUsed := gascost.ApplyMessageFail
 	TODO()
-	return msg.MessageReceipt_MakeSystemError(errCode, gasUsed)
+	return vmr.MessageReceipt_MakeSystemError(errCode, gasUsed)
 }
 
 func _withTransferFundsAssert(tree st.StateTree, from addr.Address, to addr.Address, amount actor.TokenAmount) st.StateTree {

--- a/src/systems/filecoin_vm/interpreter/vm_interpreter.id
+++ b/src/systems/filecoin_vm/interpreter/vm_interpreter.id
@@ -1,6 +1,7 @@
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import msg "github.com/filecoin-project/specs/systems/filecoin_vm/message"
 import st "github.com/filecoin-project/specs/systems/filecoin_vm/state_tree"
+import vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
 
 type UInt64 UInt
 
@@ -18,6 +19,6 @@ type TipSetMessages struct {
 }
 
 type VMInterpreter struct {
-    ApplyTipSetMessages(inTree st.StateTree, msgs TipSetMessages) struct {outTree st.StateTree, ret [msg.MessageReceipt]}
-    ApplyMessage(inTree st.StateTree, msg msg.Message, minerAddr addr.Address) struct {outTree st.StateTree, ret msg.MessageReceipt}
+    ApplyTipSetMessages(inTree st.StateTree, msgs TipSetMessages) struct {outTree st.StateTree, ret [vmr.MessageReceipt]}
+    ApplyMessage(inTree st.StateTree, msg msg.Message, minerAddr addr.Address) struct {outTree st.StateTree, ret vmr.MessageReceipt}
 }

--- a/src/systems/filecoin_vm/message/message.go
+++ b/src/systems/filecoin_vm/message/message.go
@@ -2,19 +2,10 @@ package message
 
 import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
-import exitcode "github.com/filecoin-project/specs/systems/filecoin_vm/runtime/exitcode"
 import filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
 import util "github.com/filecoin-project/specs/util"
 
 type Serialization = util.Serialization
-
-func MessageReceipt_Make(output InvocOutput, gasUsed GasAmount) MessageReceipt {
-	return &MessageReceipt_I{
-		ExitCode_:    output.ExitCode(),
-		ReturnValue_: output.ReturnValue(),
-		GasUsed_:     gasUsed,
-	}
-}
 
 func UnsignedMessage_Make(
 	from addr.Address,
@@ -83,27 +74,4 @@ func (x GasAmount) LessThan(y GasAmount) bool {
 
 func GasAmount_Zero() GasAmount {
 	panic("TODO")
-}
-
-func InvocInput_Make(to addr.Address, method actor.MethodNum, params actor.MethodParams, value actor.TokenAmount) InvocInput {
-	return &InvocInput_I{
-		To_:     to,
-		Method_: method,
-		Params_: params,
-		Value_:  value,
-	}
-}
-
-func InvocOutput_Make(exitCode exitcode.ExitCode, returnValue util.Bytes) InvocOutput {
-	return &InvocOutput_I{
-		ExitCode_:    exitCode,
-		ReturnValue_: returnValue,
-	}
-}
-
-func MessageReceipt_MakeSystemError(errCode exitcode.SystemErrorCode, gasUsed GasAmount) MessageReceipt {
-	return MessageReceipt_Make(
-		InvocOutput_Make(exitcode.SystemError(errCode), nil),
-		gasUsed,
-	)
 }

--- a/src/systems/filecoin_vm/message/message.id
+++ b/src/systems/filecoin_vm/message/message.id
@@ -1,7 +1,6 @@
 import filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
-import exitcode "github.com/filecoin-project/specs/systems/filecoin_vm/runtime/exitcode"
 
 // GasAmount is a quantity of gas.
 type GasAmount UVarint
@@ -33,22 +32,4 @@ type UnsignedMessage struct {
 type SignedMessage struct {
     Message    UnsignedMessage
     Signature  filcrypto.Signature
-}  // representation tuple
-
-type InvocInput struct {
-    To      addr.Address
-    Method  actor.MethodNum
-    Params  actor.MethodParams
-    Value   actor.TokenAmount
-}
-
-type InvocOutput struct {
-    ExitCode     exitcode.ExitCode
-    ReturnValue  Bytes
-}
-
-type MessageReceipt struct {
-    ExitCode     exitcode.ExitCode
-    ReturnValue  Bytes
-    GasUsed      GasAmount
 }  // representation tuple

--- a/src/systems/filecoin_vm/runtime/runtime.id
+++ b/src/systems/filecoin_vm/runtime/runtime.id
@@ -29,9 +29,9 @@ type Runtime interface {
 
     AcquireState()         ActorStateHandle
 
-    SuccessReturn()        msg.InvocOutput
-    ValueReturn(Bytes)     msg.InvocOutput
-    ErrorReturn(exitCode exitcode.ExitCode) msg.InvocOutput
+    SuccessReturn()        InvocOutput
+    ValueReturn(Bytes)     InvocOutput
+    ErrorReturn(exitCode exitcode.ExitCode) InvocOutput
 
     // Throw an error indicating a failure condition has occurred, from which the given actor
     // code is unable to recover. If an error is thrown in actor code, and not handled by any
@@ -60,8 +60,8 @@ type Runtime interface {
     Compute(ComputeFunctionID, args [Any]) Any
 
     // Send allows the current execution context to invoke methods on other actors in the system.
-    SendPropagatingErrors(input msg.InvocInput) msg.InvocOutput
-    SendCatchingErrors(input msg.InvocInput) msg.InvocOutput
+    SendPropagatingErrors(input InvocInput) InvocOutput
+    SendCatchingErrors(input InvocInput) InvocOutput
 
     // Computes an address for a new actor. The returned address is intended to uniquely refer to
     // the actor even in the event of a chain re-org (whereas an ID-address might refer to a
@@ -79,6 +79,24 @@ type Runtime interface {
     IpldGet(c ipld.CID) union {Bytes, error}
     IpldPut(x ipld.Object) ipld.CID
 }
+
+type InvocInput struct {
+    To      addr.Address
+    Method  actor.MethodNum
+    Params  actor.MethodParams
+    Value   actor.TokenAmount
+}
+
+type InvocOutput struct {
+    ExitCode     exitcode.ExitCode
+    ReturnValue  Bytes
+}
+
+type MessageReceipt struct {
+    ExitCode     exitcode.ExitCode
+    ReturnValue  Bytes
+    GasUsed      msg.GasAmount
+}  // representation tuple
 
 type ActorExecAddressSeed struct {
     creator             addr.Address

--- a/src/systems/filecoin_vm/sysactors/cron_actor.go
+++ b/src/systems/filecoin_vm/sysactors/cron_actor.go
@@ -2,7 +2,6 @@ package sysactors
 
 import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 import exitcode "github.com/filecoin-project/specs/systems/filecoin_vm/runtime/exitcode"
-import msg "github.com/filecoin-project/specs/systems/filecoin_vm/message"
 import vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
 
 func (a *CronActorCode_I) Constructor(rt vmr.Runtime) InvocOutput {
@@ -16,7 +15,7 @@ func (a *CronActorCode_I) EpochTick(rt vmr.Runtime) InvocOutput {
 	// a.actors is basically a static registry for now, loaded
 	// in the interpreter static registry.
 	for _, a := range a.Actors() {
-		rt.SendCatchingErrors(&msg.InvocInput_I{
+		rt.SendCatchingErrors(&vmr.InvocInput_I{
 			To_:     a,
 			Method_: actor.MethodCron,
 			Params_: []actor.MethodParam{},

--- a/src/systems/filecoin_vm/sysactors/init_actor.go
+++ b/src/systems/filecoin_vm/sysactors/init_actor.go
@@ -5,7 +5,6 @@ import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 import vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
 import exitcode "github.com/filecoin-project/specs/systems/filecoin_vm/runtime/exitcode"
 import util "github.com/filecoin-project/specs/util"
-import msg "github.com/filecoin-project/specs/systems/filecoin_vm/message"
 import ipld "github.com/filecoin-project/specs/libraries/ipld"
 
 const (
@@ -16,7 +15,7 @@ const (
 ////////////////////////////////////////////////////////////////////////////////
 // Boilerplate
 ////////////////////////////////////////////////////////////////////////////////
-type InvocOutput = msg.InvocOutput
+type InvocOutput = vmr.InvocOutput
 type Runtime = vmr.Runtime
 type Bytes = util.Bytes
 type Serialization = util.Serialization


### PR DESCRIPTION
The message package should not know about interpreter things like invocation input/output and receipts, so pulled them up a level.