### PR TITLE
Remove VerifySignature method in AccountActor; replace state with public key

### DIFF
--- a/src/systems/filecoin_vm/sysactors/account_actor.go
+++ b/src/systems/filecoin_vm/sysactors/account_actor.go
@@ -1,6 +1,5 @@
 package sysactors
 
-import filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
 import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 import exitcode "github.com/filecoin-project/specs/systems/filecoin_vm/runtime/exitcode"
 import vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
@@ -43,16 +42,8 @@ func (a *AccountActorCode_I) Constructor(rt vmr.Runtime) InvocOutput {
 	return rt.SuccessReturn()
 }
 
-func (a *AccountActorCode_I) VerifySignature(rt vmr.Runtime, sig filcrypto.Signature) InvocOutput {
-	panic("TODO")
-}
-
 func (a *AccountActorCode_I) InvokeMethod(rt vmr.Runtime, method actor.MethodNum, params actor.MethodParams) InvocOutput {
 	switch method {
-	case actor.MethodConstructor:
-		rt.Assert(len(params) == 0)
-		return a.Constructor(rt)
-
 	default:
 		return rt.ErrorReturn(exitcode.SystemError(exitcode.InvalidMethod))
 	}

--- a/src/systems/filecoin_vm/sysactors/account_actor.id
+++ b/src/systems/filecoin_vm/sysactors/account_actor.id
@@ -1,12 +1,7 @@
-import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
-import vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
 
-type AccountActorCode struct {
-    VerifySignature(rt vmr.Runtime, sig filcrypto.Signature) InvocOutput
-}
+type AccountActorCode struct {}
 
 type AccountActorState struct {
-    // normal keypair backed accounts
-    Address addr.Address
+    PublicKey filcrypto.PublicKey
 }

--- a/src/systems/filecoin_vm/sysactors/init_actor.go
+++ b/src/systems/filecoin_vm/sysactors/init_actor.go
@@ -58,7 +58,6 @@ func (a *InitActorCode_I) Constructor(rt Runtime) InvocOutput {
 	h, st := a.State(rt)
 	st = &InitActorState_I{
 		AddressMap_: map[addr.Address]addr.ActorID{}, // TODO: HAMT
-		IDMap_:      map[addr.ActorID]addr.Address{}, // TODO: HAMT
 		NextID_:     addr.ActorID(0),
 	}
 	UpdateRelease(rt, h, st)
@@ -87,7 +86,6 @@ func (a *InitActorCode_I) Exec(rt Runtime, codeID actor.CodeID, constructorParam
 
 	// Store the mappings of address to actor ID.
 	st.AddressMap()[newAddr] = actorID
-	st.IDMap()[actorID] = newAddr
 
 	UpdateRelease(rt, h, st)
 

--- a/src/systems/filecoin_vm/sysactors/init_actor.id
+++ b/src/systems/filecoin_vm/sysactors/init_actor.id
@@ -5,7 +5,6 @@ import vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
 type InitActorState struct {
     // responsible for create new actors
     AddressMap       {addr.Address: addr.ActorID}
-    IDMap            {addr.ActorID: addr.Address}
     NextID           addr.ActorID
 
     _assignNextID()  addr.ActorID


### PR DESCRIPTION
- VerifySignature is now handled by the runtime/VM context