### PR TITLE
[To be closed; ignore] Simplify how Surprise PoSts occur within a PP

### DIFF
--- a/src/algorithms/post/election_post.md
+++ b/src/algorithms/post/election_post.md
@@ -148,12 +148,12 @@ For i=0; i < challNumber; i++:
     ranHash = H(ticket, i)
     ranIndex = HashToInt(ranHash) mod len(PowerTable)
     chosenMiner = PowerTable[ranIndex].address
-    // a miner should only be challenged if they have not submitted a post in ProvingPeriod/SURPRISE_CHALLENGE_FREQUENCY epochs and are not currently challenged
-    if chosenMiner.shouldChallenge(SURPRISE_NO_CHALLENGE_PERIOD):
+    // a miner can be challenged at any time in the proving period
+    if chosenMiner.shouldChallenge():
         sampledMiners.append(chosenMiner)
 ```
 
-The surprise process described above is triggered by the cron actor in the storage_power_actor (through which the power table is searched for challengeable miners). A miner should be getting randomly sampled SURPRISE_CHALLENGE_FREQUENCY times per proving period on expectation, but would only be sampled if they are past the SURPRISE_NO_CHALLENGE_PERIOD (which should be PP/SPF so they are challenged in that period) in their proving period leading to one challenge per proving period on expectation.
+The surprise process described above is triggered by the cron actor in the storage_power_actor (through which the power table is searched for challengeable miners). A miner should be getting randomly sampled SURPRISE_CHALLENGE_FREQUENCY times per proving period on expectation.
 
 This is done as follows: if there are M miners in the power table and a Proving Period of length P, SPF*M/P challenges will be issued at each epoch. Miners are sampled using a randomness ticket from the chain and will only be challenged if they have not submitted a PoSt in at least PP/SPF epochs and are not currently being challenged (this is checked using the storage_miner_actor).
 

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor.id
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor.id
@@ -64,12 +64,6 @@ type StoragePowerActorCode struct {
 
     Surprise(rt Runtime, ticket block.Ticket) [addr.Address]
 
-    shouldChallenge(
-        minerAddr            addr.Address
-        currEpoch            block.ChainEpoch
-        challengeFreePeriod  block.ChainEpoch
-    ) bool
-
     // this should call ReportConsensusFault, numSectors should be all sectors
     // ReportUncommittedPowerFault(cheaterAddr addr.Address, numSectors UVarint)
 }

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_state.go
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_state.go
@@ -122,7 +122,7 @@ func (st *StoragePowerActorState_I) _sampleMinersToSurprise(rt Runtime, challeng
 		minerIndexInt := 0
 		potentialChallengee := allMiners[minerIndexInt]
 		// call to storage miner actor:
-		// if should_challenge(lookupMinerActorStateByAddr(potentialChallengee).ShouldChallenge(rt, SURPRISE_NO_CHALLENGE_PERIOD)){
+		// if should_challenge(lookupMinerActorStateByAddr(potentialChallengee).ShouldChallenge(rt)){
 		// hack below TODO fix
 		if true {
 			sampledMiners = append(sampledMiners, potentialChallengee)

--- a/src/systems/filecoin_mining/storage_mining/challenge_status.go
+++ b/src/systems/filecoin_mining/storage_mining/challenge_status.go
@@ -45,7 +45,7 @@ func (cs *ChallengeStatus_I) CanBeElected(currEpoch block.ChainEpoch) bool {
 
 	// TODO: pull in from consts
 	PROVING_PERIOD := block.ChainEpoch(0)
-	return currEpoch < cs._lastPoStSuccessEpoch()+PROVING_PERIOD
+	return currEpoch < cs._lastPoStSuccessEpoch()+PROVING_PERIOD || cs._lastPoStFailureEpoch() > cs._lastPoStSuccessEpoch()
 }
 
 func (cs *ChallengeStatus_I) ShouldChallenge() bool {

--- a/src/systems/filecoin_mining/storage_mining/challenge_status.go
+++ b/src/systems/filecoin_mining/storage_mining/challenge_status.go
@@ -45,9 +45,9 @@ func (cs *ChallengeStatus_I) CanBeElected(currEpoch block.ChainEpoch) bool {
 
 	// TODO: pull in from consts
 	PROVING_PERIOD := block.ChainEpoch(0)
-	return !cs.IsChallenged() && currEpoch < cs._lastPoStSuccessEpoch()+PROVING_PERIOD
+	return currEpoch < cs._lastPoStSuccessEpoch()+PROVING_PERIOD
 }
 
-func (cs *ChallengeStatus_I) ShouldChallenge(currEpoch block.ChainEpoch, challengeFreePeriod block.ChainEpoch) bool {
-	return currEpoch > (cs.LastChallengeEpoch()+challengeFreePeriod) && !cs.IsChallenged()
+func (cs *ChallengeStatus_I) ShouldChallenge() bool {
+	return !cs.IsChallenged()
 }

--- a/src/systems/filecoin_mining/storage_mining/constants.go
+++ b/src/systems/filecoin_mining/storage_mining/constants.go
@@ -9,5 +9,3 @@ const POST_CHALLENGE_TIME = block.ChainEpoch(1)               // placeholder
 const PROVING_PERIOD = block.ChainEpoch(2)                    // placeholder
 // how many times per PP should a miner get challenged on expectation
 const SURPRISE_CHALLENGE_FREQUENCY = 2 // placeholder
-// how far into their PP does a miner get their first challenge
-const SUPRISE_NO_CHALLENGE_PERIOD = PROVING_PERIOD / SURPRISE_CHALLENGE_FREQUENCY

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
@@ -51,10 +51,7 @@ type ChallengeStatus struct {
     IsChallenged() bool  // only True when proving SurprisePoSt (implicit because ElectionPoSt completes within a block)
     ChallengeHasExpired(currEpoch block.ChainEpoch) bool
     CanBeElected(currEpoch block.ChainEpoch) bool
-    ShouldChallenge(
-        currEpoch            block.ChainEpoch
-        challengeFreePeriod  block.ChainEpoch
-    ) bool
+    ShouldChallenge() bool
 }
 
 type PreCommittedSector struct {
@@ -87,10 +84,7 @@ type StorageMinerActorState struct {
     _isChallenged()         bool
     _canBeElected(currEpoch block.ChainEpoch) bool
     _challengeHasExpired(currEpoch block.ChainEpoch) bool
-    _shouldChallenge(
-        currEpoch            block.ChainEpoch
-        challengeFreePeriod  block.ChainEpoch
-    ) bool
+    _shouldChallenge() bool
     _verifySeal(rt Runtime, onChainInfo sector.OnChainSealVerifyInfo) bool
     _assertSectorDidNotExist(rt Runtime, sectorNo sector.SectorNumber)
 

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor_state.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor_state.go
@@ -18,8 +18,8 @@ func (st *StorageMinerActorState_I) _challengeHasExpired(epoch block.ChainEpoch)
 	return st.ChallengeStatus().ChallengeHasExpired(epoch)
 }
 
-func (st *StorageMinerActorState_I) ShouldChallenge(currEpoch block.ChainEpoch, challengeFreePeriod block.ChainEpoch) bool {
-	return st.ChallengeStatus().ShouldChallenge(currEpoch, challengeFreePeriod)
+func (st *StorageMinerActorState_I) ShouldChallenge() bool {
+	return st.ChallengeStatus().ShouldChallenge()
 }
 
 func (st *StorageMinerActorState_I) _processStagedCommittedSectors(rt Runtime) {


### PR DESCRIPTION
In this PR I simplify the surprise sampling mechanism. This is how it worked:
- At every cron tick, `SURPRISE_CHALLENGE_FREQUENCY * len(PT) / ProvingPeriod` miners are randomly chosen for sampling (meaning each should be chosen SURPRISE_POST_FREQUENCY times per proving period on expectation).
- If a chosenMiner should be challenged (`ShouldChallenge`), then it is issued the surprise.
  - `ShouldChallenge` checks that the miner is not already being challenged, and that more than `SURPRISE_NO_CHALLENGE_PERIOD` has passed since their last successful PoSt (ePoSt or sPoSt) submission. 
  - We set `SURPRISE_NO_CHALLENGE_PERIOD = PROVING_PERIOD / SURPRISE_CHALLENGE_FREQUENCY` meaning that if SURPRISE_CHALLENGE_FREQ = 2, then a miner will not get surprised in the first half of their PP.
- Finally, a miner cannot do an ePoSt after they have been challenged.

This is how this PR modifies it:
1. A miner can now ePoSt even after being challenged (and can do that instead of replying to the challenge) the first time (i.e. if they fail the challenge they can no longer do so).
2. There is no more `SURPRISE_NO_CHALLENGE_PERIOD`: a miner can get surprised at any time during a proving period, and given a certain `SURPRISE_CHALLENGE_FREQUENCY` may get challenged more than once per PP. (In fact in order to ensure that each miner gets at least 1 challenge per PP, SCF should be set high enough).

It is suboptimal but removes unnecessary complexity from the process.