### PR TITLE
Randomness API with domain separation

### DIFF
--- a/src/algorithms/crypto/domain.go
+++ b/src/algorithms/crypto/domain.go
@@ -1,0 +1,9 @@
+package crypto
+
+type DomainSeparationTag int
+
+const (
+	DomainSeparationTag_TicketProduction DomainSeparationTag = 1 + iota
+	DomainSeparationTag_ElectionPoSt
+	// ...
+)

--- a/src/algorithms/crypto/hash.go
+++ b/src/algorithms/crypto/hash.go
@@ -1,0 +1,11 @@
+package crypto
+
+import (
+	util "github.com/filecoin-project/specs/util"
+)
+
+type Bytes = util.Bytes
+
+func SHA256(Bytes) Bytes {
+	panic("TODO")
+}

--- a/src/algorithms/crypto/randomness.go
+++ b/src/algorithms/crypto/randomness.go
@@ -1,0 +1,40 @@
+package crypto
+
+import (
+	util "github.com/filecoin-project/specs/util"
+)
+
+type Randomness = util.Randomness
+type Serialization = util.Serialization
+
+// Derive a random byte string from a domain separation tag and an arbitrary
+// serializable object.
+//
+// Note: to produce values of type Serialization, use the auto-generated method prototypes
+//   Serialize_T(T) Serialization
+// for each type T defined in .id.
+//
+// In order to derive randomness from a collection of objects, rather than just a single
+// object, define a struct at the .id level that contains those objects as member fields.
+// This will then cause a Serialize_*() method to be generated for the struct type.
+func (tag DomainSeparationTag) DeriveRand(s Serialization) Randomness {
+	return _deriveRandInternal(tag, s, 0)
+}
+
+// As in DeriveRand(), but additionally accepts an index into the implicit pseudorandom stream.
+// Index must be strictly positive.
+func (tag DomainSeparationTag) DeriveRandWithIndex(s Serialization, index int) Randomness {
+	if index <= 0 {
+		panic("DeriveRandWithIndex only accepts indices > 0")
+	}
+	return _deriveRandInternal(tag, s, index)
+}
+
+func _deriveRandInternal(tag DomainSeparationTag, s Serialization, index int) Randomness {
+	buffer := []byte{}
+	buffer = append(buffer, util.IntToBytesLittleEndian(int(tag))...)
+	buffer = append(buffer, util.IntToBytesLittleEndian(int(index))...)
+	buffer = append(buffer, Bytes(s)...)
+	ret := SHA256(buffer)
+	return Randomness(ret)
+}

--- a/tools/codeGen/util/util.go
+++ b/tools/codeGen/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"bytes"
+	"encoding/binary"
 	"io"
 	"log"
 	big "math/big"
@@ -90,6 +91,13 @@ func TextAbbrev(s string, maxLen int) string {
 		return s
 	}
 	return s[:maxLen-3] + "..."
+}
+
+func IntToBytesLittleEndian(x int) Bytes {
+	buf := bytes.NewBuffer(make([]byte, 0, 8))
+	err := binary.Write(buf, binary.LittleEndian, x)
+	Assert(err == nil)
+	return buf.Bytes()
 }
 
 func IntMin(x, y int) int {


### PR DESCRIPTION
Establish a single consistent API for generating randomness with domain separation. (Note: the same domain separation enum should also apply for signatures.)