### PR TITLE
Message description and validation text.

### DIFF
--- a/src/systems/filecoin_vm/message/_index.md
+++ b/src/systems/filecoin_vm/message/_index.md
@@ -4,6 +4,64 @@ statusIcon: 🔁
 title: VM Message - Actor Method Invocation
 ---
 
+A message is the unit of communication between two actors, and thus the primitive cause of changes
+in state. A message combines:
+
+- a token amount to be transferred from the sender to the receiver, and
+- a method with parameters to be invoked on the receiver (optional).
+
+Actor code may send additional messages to other actors while processing a received message. 
+Messages are processed synchronously: an actor waits for a sent message to complete before resuming control.
+
+The processing of a message consumes units of computation and storage denominated in gas. 
+A message's gas limit provides an upper bound on its computation. The sender of a message pays 
+for the gas units consumed by a message's execution (including all nested messages) at a
+gas price they determine. A block producer chooses which messages to include in a block and is
+rewarded according to each message's gas price and consumption, forming a market.
+
+# Message syntax validation
+
+A syntactically invalid message must not be transmitted, retained in a message pool, or
+included in a block.
+
+A syntactically valid `UnsignedMessage`:
+
+- has a well-formed, non-empty `To` address,
+- has a well-formed, non-empty `From` address, 
+- has a non-negative `CallSeqNum`,
+- has `Value` no less than zero and no greater than the total token supply (`2e9 * 1e18`), and
+- has a non-negative `MethodNum`,
+- has non-empty `Params` only if `MethodNum` is zero,
+- has non-negative `GasPrice`,
+- has `GasLimit` that is at least equal to the gas consumption associated with the message's serialized bytes,
+- has `GasLimit` that is no greater than the block gas limit network parameter
+- has a total serialized size no greater than 32 KiB.
+
+# Message semantic validation
+
+Semantic validation refers to validation requiring information outside of the message itself.
+
+A semantically valid `SignedMessage` must carry a signature that verifies the payload as having
+been signed with the public key of the account actor identified by the `From` address. 
+Note that when the `From` address is an ID-address, the public key must be
+looked up in the state of the sending account actor in the parent state identified by the block.
+
+Note: the sending actor must exist _in the parent state identified by the block_ that includes the message.
+This means that it is not valid for a single block to include a message that creates a new account 
+actor and a message from that same actor. 
+The first message from that actor must wait until a subsequent epoch.
+Message pools may exclude messages from an actor that is not yet present in the chain state.
+
+There is no further semantic validation of a message that can cause a block including the message 
+to be invalid. Every syntactically valid and correctly signed message can be included in a block and 
+will produce a receipt from execution. 
+However, a message may fail to execute to completion, in which case it will not effect the desired state change.  
+
+The reason for this "no message semantic validation" policy is that the state that a message will
+be applied to cannot be known before the message is executed _as part of a tipset_. A block producer
+does not know whether another block will precede it in the tipset, thus altering the state to
+which the block's messages will apply from the declared parent state.
+
 {{< readfile file="message.id" code="true" lang="go" >}}
 
 {{< readfile file="message.go" code="true" lang="go" >}}

--- a/src/systems/filecoin_vm/message/message.id
+++ b/src/systems/filecoin_vm/message/message.id
@@ -9,16 +9,20 @@ type GasAmount UVarint
 type GasPrice actor.TokenAmount
 
 type UnsignedMessage struct {
-    From        addr.Address
+    // Address of the receiving actor.
     To          addr.Address
-
-    Method      actor.MethodNum
-    Params      actor.MethodParams  // Serialized parameters to the method.
-
-    // When receiving a message from a user account the nonce in the message must match
-    // the expected nonce in the "from" actor. This prevents replay attacks.
+    // Address of the sending actor.
+    From        addr.Address
+    // Expected CallSeqNum of the sending actor (only for top-level messages).
     CallSeqNum  actor.CallSeqNum
+
+    // Amount of value to transfer from sender's to receiver's balance.
     Value       actor.TokenAmount
+
+    // Optional method to invoke on receiver, zero for a plain value send.
+    Method      actor.MethodNum
+    /// Serialized parameters to the method (if method is non-zero).
+    Params      actor.MethodParams
 
     GasPrice
     GasLimit    GasAmount


### PR DESCRIPTION
Cleaned up the UnsignedMessage to more closely align with the existing implementations.
Added prose for message syntactic validity, and interpreter notes about condition that
will cause execution to fail.

Reviewers: please take a moment to think about what's _not_ written but should be.

@jzimmerman please check the notes on the interpreter. I didn't touch the code so as not to clash with your #676, but we should align them.