### PR TITLE
Integrate minimal usage of dynamic external orient transformations for Chung

### DIFF
--- a/bin/preprocessing/chung_spec.py
+++ b/bin/preprocessing/chung_spec.py
@@ -90,6 +90,7 @@ def main():
     jinput, alphaT,betaT, degreeT = parse()
     alpha = extract_value(jinput,alphaT)
     degree = extract_value(jinput,degreeT)
+
     if alpha is None or degree is None:
         # default behavior: return same thing if nothing to be done
         # sys.stderr.write("alpha %s or degree %s" % (alpha,degree))
@@ -99,7 +100,7 @@ def main():
     beta = find_max_beta(degree,alpha)
     # sys.stderr.write("found alpha %f -> beta %f" % (alpha,beta))
     rounded = round(beta,5)
-    inject_value(jinput,alphaT,betaT,rounded)        
+    inject_value(jinput,alphaT,betaT,rounded)
     json.dump(jinput,sys.stdout)
 
 main()

--- a/bin/preprocessing/preprocessing.sh
+++ b/bin/preprocessing/preprocessing.sh
@@ -1,28 +1,28 @@
-#!/usr/bin/sh
+#!/usr/bin/env sh
 
-scripts_dir=$(dirname $0)
-script_name=$(basename $0)
-tmp=$(mktemp)
+# scripts_dir=$(dirname $0)
+# script_name=$(basename $0)
+# tmp=$(mktemp)
 
-for jinput in "$@"
-do
-    echo "[+] Preprocessing JSON file $(basename $jinput)"
-    for script in $(ls $scripts_dir)
-    do
-        if [ $script == $script_name ]; then
-            # dont execute this script
-            continue
-        fi
-        fullpath=$scripts_dir/$script
-        # because the following issue, we need to make a temp file
-        # https://stackoverflow.com/questions/6696842/how-can-i-use-a-file-in-a-command-and-redirect-output-to-the-same-file-without-t
-        ./$fullpath $jinput > $tmp
-        exit_code=$?
-        test $exit_code -eq 0 || (echo "Error with script $(basename $script).  Exit" && exit 1)
-        # Format via jq by default
-        cat $tmp | jq > $jinput
-        echo -e "\t-> $(basename $script) OK"
-    done
-done
-echo "[+] All preprocessing done"
-rm $tmp
+# for jinput in "$@"
+# do
+#     echo "[+] Preprocessing JSON file $(basename $jinput)"
+#     for script in $(ls $scripts_dir)
+#     do
+#         if [ $script == $script_name ]; then
+#             # dont execute this script
+#             continue
+#         fi
+#         fullpath=$scripts_dir/$script
+#         # because the following issue, we need to make a temp file
+#         # https://stackoverflow.com/questions/6696842/how-can-i-use-a-file-in-a-command-and-redirect-output-to-the-same-file-without-t
+#         ./$fullpath $jinput > $tmp
+#         exit_code=$?
+#         test $exit_code -eq 0 || (echo "Error with script $(basename $script).  Exit" && exit 1)
+#         # Format via jq by default
+#         cat $tmp | jq > $jinput
+#         echo -e "\t-> $(basename $script) OK"
+#     done
+# done
+# echo "[+] All preprocessing done"
+# rm $tmp

--- a/bin/preprocessing/test.sh
+++ b/bin/preprocessing/test.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 ##
 ## This script is a simple test outputting what is given on its 
 ## argument

--- a/src/orient/chung.json
+++ b/src/orient/chung.json
@@ -1,0 +1,4 @@
+{
+"alpha": 65,
+"expander_degree": 8
+}

--- a/src/orient/chung.orient
+++ b/src/orient/chung.orient
@@ -1,0 +1,4 @@
+Chung: ../../bin/preprocessing/chung_spec.py
+  beta = extern(alpha, expander_degree)
+  alpha = extern(beta, expander_degree)
+


### PR DESCRIPTION
This PR integrates Orient changes to support dynamic external transformations (https://github.com/filecoin-project/orient/pull/44).

I have minimally adapted @nikkolasg's preprocessing PR in order to demonstrate usage and ensure this works for our intended purpose. This satisfies the minimum requirement @nicola requested to unblock modeling with Chung.

I also changed script paths to use `/usr/bin/env` because I was getting errors on MacOS when testing.

This transcript shows the effect of these changes:

```
(base) ➜  specs git:(dynamic-chung) ✗ make orient
bin/solve-orient.sh src/orient/chung.orient src/orient/chung.json build/orient/chung.orient.json
(base) ➜  specs git:(dynamic-chung) ✗ cat build/orient/chung.orient.json
[
[{"alpha":65,"beta":0,"expander_degree":8}]
]
```

Fair warning: I will probably change this syntax as the interface for external engines improves and evolves over time. What you see here is a minimal consistent solution which handles what we need for Chung now.