### PR TITLE
Clean up interplay between InitActor.Exec and Runtime.CreateActor.

### DIFF
--- a/src/systems/filecoin_vm/runtime/runtime.id
+++ b/src/systems/filecoin_vm/runtime/runtime.id
@@ -78,12 +78,12 @@ type Runtime interface {
     // different actor after messages are re-ordered).
     NewActorAddress() addr.Address
 
-    // Create an actor in the state tree. May only be called by InitActor.
+    // Creates an actor in the state tree, with empty state. May only be called by InitActor.
     CreateActor(
-        stateCID           actor.ActorSystemStateCID
-        a                  addr.Address
-        initBalance        actor.TokenAmount
-        constructorParams  actor.MethodParams
+        // The new actor's code identifier.
+        codeId   actor.CodeID
+        // Address under which the new actor's state will be stored.
+        address  addr.Address
     )
 
     IpldGet(c ipld.CID) union {Bytes, error}


### PR DESCRIPTION
This change started out with an implementation-driven delta from @icorderi, which I then adjusted. The new arrangement clearly distinguishes:
1. Allocating an actor ID
1. Creating empty actor state in the state tree, keyed by that ID address
1. Calling the constructor

They have to happen in that order. @icorderi the snippet you sent me attempted to send to the constructor method by the actor address before the init actor had persisted the mapping to ID address.