### PR TITLE
Miner actor cleanup

### DIFF
--- a/src/libraries/filcrypto/filproofs/algorithms.go
+++ b/src/libraries/filcrypto/filproofs/algorithms.go
@@ -452,7 +452,7 @@ func (sdr *WinStackedDRG_I) CreatePrivateSealProof(randomness sector.Interactive
 	_ = replicaTree // FIXME: Use it.
 
 	windows := int(sdr.WindowCount())
-	windowSize := int(sdr.Cfg().SealCfg().SectorSize() / UInt(sdr.WindowCount()))
+	windowSize := int(uint64(sdr.Cfg().SealCfg().SectorSize()) / UInt(sdr.WindowCount()))
 
 	for c := range windowChallenges {
 		windowChallengeProof := createWindowChallengeProof(sdr.Drg(), sdr.Expander(), sealSeeds, UInt(c), nodeSize, columnTree, aux, windows, windowSize)
@@ -759,11 +759,11 @@ func (sdr *WinStackedDRG_I) VerifySeal(sv sector.SealVerifyInfo) bool {
 	return sdr._verifyOfflineCircuitProof(commD, commR, sealSeeds, windowChallenges, sealProof)
 }
 
-func ComputeUnsealedSectorCIDFromPieceInfos(sectorSize UInt, pieceInfos []PieceInfo) (unsealedCID sector.UnsealedSectorCID, err error) {
+func ComputeUnsealedSectorCIDFromPieceInfos(sectorSize sector.SectorSize, pieceInfos []PieceInfo) (unsealedCID sector.UnsealedSectorCID, err error) {
 	rootPieceInfo := computeRootPieceInfo(pieceInfos)
 	rootSize := rootPieceInfo.Size()
 
-	if rootSize != sectorSize {
+	if rootSize != uint64(sectorSize) {
 		return unsealedCID, errors.New("Wrong sector size.")
 	}
 

--- a/src/systems/filecoin_markets/storage_market/storage_market_actor_code.go
+++ b/src/systems/filecoin_markets/storage_market/storage_market_actor_code.go
@@ -16,6 +16,7 @@ const (
 	Method_StorageMarketActor_GetPieceInfosForDealIDs
 	Method_StorageMarketActor_ProcessDealExpiration
 	Method_StorageMarketActor_ProcessDealSlash
+	Method_StorageMarketActor_ProcessDealPayment
 	Method_StorageMarketActor_VerifyPublishedDealIDs
 	Method_StorageMarketActor_ActivateDeals
 )

--- a/src/systems/filecoin_markets/storage_market/storage_market_actor_code.go
+++ b/src/systems/filecoin_markets/storage_market/storage_market_actor_code.go
@@ -13,9 +13,11 @@ import (
 
 const (
 	Method_StorageMarketActor_EpochTick = actor.MethodPlaceholder + iota
-	Method_StorageMarketActor_GetUnsealedCIDForDealIDs
+	Method_StorageMarketActor_GetPieceInfosForDealIDs
 	Method_StorageMarketActor_ProcessDealExpiration
 	Method_StorageMarketActor_ProcessDealSlash
+	Method_StorageMarketActor_VerifyPublishedDealIDs
+	Method_StorageMarketActor_ActivateDeals
 )
 
 const LastPaymentEpochNone = 0

--- a/src/systems/filecoin_mining/sector/posting.id
+++ b/src/systems/filecoin_mining/sector/posting.id
@@ -5,7 +5,7 @@ type PoStRandomness Bytes
 // Can move to a new posting.id if we think worth it.
 type PoStCfg struct {
     Type         PoStType
-    SectorSize   UInt
+    SectorSize
     WindowCount  UInt
     Partitions   UInt
 }

--- a/src/systems/filecoin_mining/sector/sealing.id
+++ b/src/systems/filecoin_mining/sector/sealing.id
@@ -14,7 +14,7 @@ type InteractiveSealRandomness Bytes
 type SealSeed Bytes
 
 type SealCfg struct {
-    SectorSize   UInt
+    SectorSize
     WindowCount  UInt
     Partitions   UInt
 }

--- a/src/systems/filecoin_mining/sector/sector.go
+++ b/src/systems/filecoin_mining/sector/sector.go
@@ -6,8 +6,6 @@ import block "github.com/filecoin-project/specs/systems/filecoin_blockchain/stru
 // ProveCommitSector needs to be submitted within MAX_PROVE_COMMIT_SECTOR_EPOCH after PreCommit
 const MAX_PROVE_COMMIT_SECTOR_EPOCH = block.ChainEpoch(3)
 
-type StorageFaultType int
-
 const (
 	DeclaredFault StorageFaultType = 1 + iota
 	DetectedFault

--- a/src/systems/filecoin_mining/sector/sector.id
+++ b/src/systems/filecoin_mining/sector/sector.id
@@ -15,6 +15,7 @@ type SealedSectorCID ipld.CID
 type SectorNumber UInt
 
 type FaultSet CompactSectorSet
+type StorageFaultType int
 
 type SectorUtilizationInfo struct {
     DealExpirationAMT  deal.DealExpirationAMT

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
@@ -106,7 +106,7 @@ type StorageMinerActorState struct {
     _updateSectorUtilization(rt Runtime, lastPoStResponse block.ChainEpoch) [deal.DealID]
     _initializeUtilizationInfo(rt Runtime, deals [deal.OnChainDeal]) sector.SectorUtilizationInfo
 
-    _getActivePower(rt Runtime) block.StoragePower
+    _getActivePower(rt Runtime, getActiveDealIDs bool) (activePower block.StoragePower, activeDealIDs [deal.DealID])
     _getInactivePower(rt Runtime) block.StoragePower
     _getUtilizationInfo(rt Runtime, sectorNo sector.SectorNumber) sector.SectorUtilizationInfo
     _getCurrUtilization(sectorNo sector.SectorNumber) (utilization block.StoragePower, found bool)
@@ -145,7 +145,7 @@ type StorageMinerActorCode struct {
         faultType      sector.StorageFaultType
     )
 
-    _submitPowerReport(rt Runtime, lastPoSt block.ChainEpoch)
+    _submitPowerReport(rt Runtime, lastPoSt block.ChainEpoch, getActiveDealIDs bool)
     _expirePreCommittedSectors(rt Runtime)
     _ensurePledgeCollateralSatisfied(rt Runtime)
 }

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
@@ -106,7 +106,7 @@ type StorageMinerActorState struct {
     _updateSectorUtilization(rt Runtime, lastPoStResponse block.ChainEpoch) [deal.DealID]
     _initializeUtilizationInfo(rt Runtime, deals [deal.OnChainDeal]) sector.SectorUtilizationInfo
 
-    _getActivePower(rt Runtime, getActiveDealIDs bool) (activePower block.StoragePower, activeDealIDs [deal.DealID])
+    _getActivePower(rt Runtime) block.StoragePower
     _getInactivePower(rt Runtime) block.StoragePower
     _getUtilizationInfo(rt Runtime, sectorNo sector.SectorNumber) sector.SectorUtilizationInfo
     _getCurrUtilization(sectorNo sector.SectorNumber) (utilization block.StoragePower, found bool)
@@ -122,8 +122,6 @@ type StorageMinerActorCode struct {
     SubmitVerifiedElectionPoSt(rt Runtime, onChainInfo sector.OnChainPoStVerifyInfo)
 
     _checkSurprisePoStSubmissionHappened(rt Runtime)
-
-    // TODO: should depledge be in here or in storage market actor?
 
     DeclareFaults(rt Runtime, failingSet sector.CompactSectorSet)
     RecoverFaults(rt Runtime, recoveringSet sector.CompactSectorSet)
@@ -145,6 +143,7 @@ type StorageMinerActorCode struct {
         faultType      sector.StorageFaultType
     )
 
+    _claimDealPayments(rt Runtime)
     _submitPowerReport(rt Runtime, lastPoSt block.ChainEpoch, getActiveDealIDs bool)
     _expirePreCommittedSectors(rt Runtime)
     _ensurePledgeCollateralSatisfied(rt Runtime)

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
@@ -121,7 +121,7 @@ type StorageMinerActorCode struct {
     SubmitVerifiedSurprisePoSt(rt Runtime, onChainInfo sector.OnChainPoStVerifyInfo)
     SubmitVerifiedElectionPoSt(rt Runtime, onChainInfo sector.OnChainPoStVerifyInfo)
 
-    CheckSurprisePoStSubmissionHappened(rt Runtime)
+    _checkSurprisePoStSubmissionHappened(rt Runtime)
 
     // TODO: should depledge be in here or in storage market actor?
 

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
@@ -165,7 +165,7 @@ type MinerInfo struct {
     PeerId                  libp2p.PeerID
 
     // Amount of space in each sector committed to the network by this miner.
-    SectorSize              util.BytesAmount
+    SectorSize              sector.SectorSize
     WindowCount             UVarint
     SealPartitions          UVarint
     ElectionPoStPartitions  UVarint

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
@@ -144,7 +144,7 @@ type StorageMinerActorCode struct {
     )
 
     _claimDealPayments(rt Runtime)
-    _submitPowerReport(rt Runtime, lastPoSt block.ChainEpoch, getActiveDealIDs bool)
+    _submitPowerReport(rt Runtime, lastPoSt block.ChainEpoch)
     _expirePreCommittedSectors(rt Runtime)
     _ensurePledgeCollateralSatisfied(rt Runtime)
 }

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor_code.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor_code.go
@@ -394,12 +394,8 @@ func (a *StorageMinerActorCode_I) RecoverFaults(rt Runtime, recoveringSet sector
 		}
 		switch sectorState.State().StateNumber {
 		case SectorFailingSN:
-			// Check if miners have sufficient balances in sma
-
-			// SendMessage(sma.PublishStorageDeals) or sma.ResumeStorageDeals?
-			// throw if miner cannot cover StorageDealCollateral
-			// TODO: EnsureDealCollateral
-			panic("TODO")
+			// pledge collateral is ensured at PoSt submission
+			// no need to top up deal collateral because none was slashed during declared/detected faults
 
 			// copy over the same FaultCount
 			st.Sectors()[sectorNo].Impl().State_ = SectorRecovering(sectorState.State().FaultCount)

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor_code.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor_code.go
@@ -553,7 +553,7 @@ func (a *StorageMinerActorCode_I) _verifySeal(rt Runtime, onChainInfo sector.OnC
 	// @param sectorSize util.UVarint
 	// @param dealIDs []deal.DealID onChainInfo.DealIDs()
 	getPieceInfoParams := make([]util.Serialization, 2)
-	getPieceInfoParams = append(getPieceInfoParams, util.SerializeUVarint(sectorSize))
+	getPieceInfoParams = append(getPieceInfoParams, sector.Serialize_SectorSize(sectorSize))
 	for _, dealID := range onChainInfo.DealIDs() {
 		getPieceInfoParams = append(getPieceInfoParams, deal.Serialize_DealID(dealID))
 	}

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor_state.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor_state.go
@@ -54,7 +54,6 @@ func (st *StorageMinerActorState_I) _updateSectorUtilization(rt Runtime, lastPoS
 			expiredPower := expiredDeal.Power()
 			newUtilization -= expiredPower
 			newExpiredDealIDs = append(newExpiredDealIDs, expiredDeal.ID())
-
 		}
 
 		st.SectorUtilization()[sectorNo].Impl().CurrUtilization_ = newUtilization
@@ -116,8 +115,6 @@ func (st *StorageMinerActorState_I) _updateClearSector(rt Runtime, sectorNo sect
 	delete(st.SectorUtilization(), sectorNo)
 	st.ProvingSet_.Remove(sectorNo)
 	st.SectorExpirationQueue().Remove(sectorNo)
-
-	// Send message to SMA
 }
 
 // move Sector from Committed/Recovering into Active State
@@ -176,9 +173,7 @@ func (st *StorageMinerActorState_I) _updateFailSector(rt Runtime, sectorNo secto
 	}
 
 	if newFaultCount > MAX_CONSECUTIVE_FAULTS {
-		// TODO: heavy penalization: slash pledge collateral and delete sector
-		// TODO: SendMessage(SPA.SlashPledgeCollateral)
-
+		// slashing is done at _slashCollateralForStorageFaults
 		st._updateClearSector(rt, sectorNo)
 		st.SectorTable().Impl().TerminatedFaults_.Add(sectorNo)
 	}
@@ -198,25 +193,19 @@ func (st *StorageMinerActorState_I) _updateExpireSectors(rt Runtime) {
 			// Note: in order to verify if something was stored in the past, one must
 			// scan the chain. SectorNumber can be re-used.
 
-			// do nothing about deal payment
-			// it will be evaluated after _updateSectorUtilization
+			// expiration settlement will be done at _updateSectorUtilization
 			st._updateClearSector(rt, expiredSectorNo)
 		case SectorFailingSN:
 			// TODO: check if there is any fault that we should handle here
-			// If a SectorFailing Expires, return remaining StorageDealCollateral and remove sector
-			// SendMessage(sma.SettleExpiredDeals(sc.DealIDs()))
 
 			// a failing sector expires, no change to FaultCount
+			// expiration settlement will be done at _updateSectorUtilization
 			st._updateClearSector(rt, expiredSectorNo)
 		default:
 			// Note: SectorCommittedSN, SectorRecoveringSN transition first to SectorFailingSN, then expire
 			rt.AbortStateMsg("Invalid sector state in SectorExpirationQueue")
 		}
 	}
-
-	// Return PledgeCollateral for active expirations
-	// SendMessage(spa.Depledge) // TODO
-	panic("TODO: refactor use of this method in order for caller to send this message")
 }
 
 func (st *StorageMinerActorState_I) _assertSectorDidNotExist(rt Runtime, sectorNo sector.SectorNumber) {

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor_state.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor_state.go
@@ -64,8 +64,9 @@ func (st *StorageMinerActorState_I) _updateSectorUtilization(rt Runtime, lastPoS
 
 }
 
-func (st *StorageMinerActorState_I) _getActivePower(rt Runtime) block.StoragePower {
-	var activePower = block.StoragePower(0)
+func (st *StorageMinerActorState_I) _getActivePower(rt Runtime, getActiveDealIDs bool) (block.StoragePower, []deal.DealID) {
+	activePower := block.StoragePower(0)
+	activeDealIDs := make([]deal.DealID, 0)
 
 	for _, sectorNo := range st.SectorTable().Impl().ActiveSectors_.SectorsOn() {
 		utilizationInfo, found := st.SectorUtilization()[sectorNo]
@@ -73,9 +74,14 @@ func (st *StorageMinerActorState_I) _getActivePower(rt Runtime) block.StoragePow
 			rt.AbortStateMsg("sm._getActivePower: sectorNo not found in SectorUtilization")
 		}
 		activePower += utilizationInfo.CurrUtilization()
+
+		if getActiveDealIDs {
+			newActiveDealIDs := utilizationInfo.DealExpirationAMT().Impl().ActiveDealIDs()
+			activeDealIDs = append(activeDealIDs, newActiveDealIDs...)
+		}
 	}
 
-	return activePower
+	return activePower, activeDealIDs
 }
 
 func (st *StorageMinerActorState_I) _getInactivePower(rt Runtime) block.StoragePower {

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor_state.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor_state.go
@@ -64,24 +64,15 @@ func (st *StorageMinerActorState_I) _updateSectorUtilization(rt Runtime, lastPoS
 
 }
 
-func (st *StorageMinerActorState_I) _getActivePower(rt Runtime, getActiveDealIDs bool) (block.StoragePower, []deal.DealID) {
+func (st *StorageMinerActorState_I) _getActivePower(rt Runtime) block.StoragePower {
 	activePower := block.StoragePower(0)
-	activeDealIDs := make([]deal.DealID, 0)
 
 	for _, sectorNo := range st.SectorTable().Impl().ActiveSectors_.SectorsOn() {
-		utilizationInfo, found := st.SectorUtilization()[sectorNo]
-		if !found {
-			rt.AbortStateMsg("sm._getActivePower: sectorNo not found in SectorUtilization")
-		}
+		utilizationInfo := st._getUtilizationInfo(rt, sectorNo)
 		activePower += utilizationInfo.CurrUtilization()
-
-		if getActiveDealIDs {
-			newActiveDealIDs := utilizationInfo.DealExpirationAMT().Impl().ActiveDealIDs()
-			activeDealIDs = append(activeDealIDs, newActiveDealIDs...)
-		}
 	}
 
-	return activePower, activeDealIDs
+	return activePower
 }
 
 func (st *StorageMinerActorState_I) _getInactivePower(rt Runtime) block.StoragePower {

--- a/src/systems/filecoin_mining/storage_proving/storage_proving_subsystem.go
+++ b/src/systems/filecoin_mining/storage_proving/storage_proving_subsystem.go
@@ -23,7 +23,7 @@ func (sps *StorageProvingSubsystem_I) VerifySeal(sv sector.SealVerifyInfo) Stora
 	return StorageProvingSubsystem_VerifySeal_FunRet_Make_ok(StorageProvingSubsystem_VerifySeal_FunRet_ok(result)) //,
 }
 
-func (sps *StorageProvingSubsystem_I) ComputeUnsealedSectorCID(sectorSize util.UInt, pieceInfos []*sector.PieceInfo_I) StorageProvingSubsystem_ComputeUnsealedSectorCID_FunRet {
+func (sps *StorageProvingSubsystem_I) ComputeUnsealedSectorCID(sectorSize sector.SectorSize, pieceInfos []*sector.PieceInfo_I) StorageProvingSubsystem_ComputeUnsealedSectorCID_FunRet {
 	unsealedCID, err := filproofs.ComputeUnsealedSectorCIDFromPieceInfos(sectorSize, pieceInfos)
 
 	if err != nil {

--- a/tools/codeGen/util/util.go
+++ b/tools/codeGen/util/util.go
@@ -121,12 +121,6 @@ func SerializeBytes(b Bytes) Serialization {
 	return b
 }
 
-func SerializeUVarint(i UVarint) Serialization {
-	panic("TODO")
-	var ret Serialization
-	return ret
-}
-
 func IntMin(x, y int) int {
 	if y < x {
 		return y

--- a/tools/codeGen/util/util.go
+++ b/tools/codeGen/util/util.go
@@ -121,6 +121,12 @@ func SerializeBytes(b Bytes) Serialization {
 	return b
 }
 
+func SerializeUVarint(i UVarint) Serialization {
+	panic("TODO")
+	var ret Serialization
+	return ret
+}
+
 func IntMin(x, y int) int {
 	if y < x {
 		return y


### PR DESCRIPTION
**In this PR:**
- [x] Add Send calls to `StorageMinerActorCode`
- [x] Remove Send comments from `StorageMinerActorState`
- ~~[x] Add `ProcessDealPayment` to `_onSuccessfulPoSt` and add flag to `_getActivePower` (deal payment is only triggered in `_onSuccessfulPoSt`)~~
- [x] Add `_claimDealPayments` and invoke `_claimDealPayments` at `_onSuccessfulPoSt`
- [x] Remove comment on depledge (we dont need this as a separate mechanism), miners' pledge collateral requirement gets updated based on the power they have and they can call `WithdrawBalance` from StoragePowerActor (depledge)
- [x] Add Serialization helpers for Send calls