### PR TITLE
update sref for messages

### DIFF
--- a/hugo/data/sref_locations.yaml
+++ b/hugo/data/sref_locations.yaml
@@ -8,6 +8,7 @@ vrf: [algorithms, crypto, vrf]
 
 # blockchain
 message: [systems, filecoin_vm, message]
+message_syntax: [systems, filecoin_vm, message, message_syntax]
 sys_vm: [systems, filecoin_vm]
 vm_interpreter: [systems, filecoin_vm, interpreter]
 
@@ -38,8 +39,8 @@ block_validation: [systems, filecoin_blockchain, chainsync, block_validation]
 
 ### Message Pool
 message_pool: [systems, filecoin_blockchain, message_pool]
-message_syncer: [systems, filecoin_blockchain, message_syncer]
-message_storage: [systems, filecoin_blockchain, message_storage]
+message_syncer: [systems, filecoin_blockchain, message_pool, message_syncer]
+message_storage: [systems, filecoin_blockchain, message_pool, message_storage]
 
 # files
 

--- a/hugo/data/sref_titles.yaml
+++ b/hugo/data/sref_titles.yaml
@@ -8,6 +8,7 @@ vrf: "VRF"
 
 # blockchain
 message: "Message"
+message_syntax: "Message Syntax"
 sys_vm: "VM"
 vm_interpreter: "VM Interpreter"
 

--- a/src/systems/filecoin_blockchain/message_pool/_index.md
+++ b/src/systems/filecoin_blockchain/message_pool/_index.md
@@ -20,8 +20,8 @@ Clients that use a message pool include:
 
 The message pool subsystem is made of two components:
 
-- The message syncer {{<sref message_syncer>}} -- which receives and propagates messages.
-- Message storage {{<sref message_storage>}} -- which caches messages according to a given policy.
+- The {{<sref message_syncer>}} -- which receives and propagates messages.
+- {{<sref message_storage>}} -- which caches messages according to a given policy.
 
 TODOs:
 

--- a/src/systems/filecoin_vm/interpreter/_index.md
+++ b/src/systems/filecoin_vm/interpreter/_index.md
@@ -54,8 +54,8 @@ The sequence of executions for a tipset is thus summarised:
 
 # Message validity and failure
 Every message in a valid block can be processed and produce a receipt (note that block validity
-implies all messages are syntactically valid and correctly signed). However, execution may
-or may not succeed, depending on the state to which the message is applied. If the execution
+implies all messages are syntactically valid -- see {{<sref message_syntax>}} -- and correctly signed).
+However, execution may or may not succeed, depending on the state to which the message is applied. If the execution
 of a message fails, the corresponding receipt will carry a non-zero exit code. 
 
 If a message fails due to a reason that can reasonably be attributed to the miner including a

--- a/src/systems/filecoin_vm/message/_index.md
+++ b/src/systems/filecoin_vm/message/_index.md
@@ -19,6 +19,7 @@ for the gas units consumed by a message's execution (including all nested messag
 gas price they determine. A block producer chooses which messages to include in a block and is
 rewarded according to each message's gas price and consumption, forming a market.
 
+{{<label message_syntax>}}
 # Message syntax validation
 
 A syntactically invalid message must not be transmitted, retained in a message pool, or


### PR DESCRIPTION
Update on #688 for links to show @anorth how I do it (see the message_syntax stuff).

Cc @jzimmerman @jbenet on the fact that the sref tooling in hugo doesn't quite work as expecteed. It seems like links to `index.md` files don't work, wheres links to named md files do. Changing things in the `sref_locations.yaml` file doesn't do anything.

I don't want to much around in there, but whoever built it might have a quick fix.