### PR TITLE
add precommit deposit and garbage collection

### DIFF
--- a/src/systems/filecoin_markets/deal/deal.id
+++ b/src/systems/filecoin_markets/deal/deal.id
@@ -53,7 +53,7 @@ type StorageDeal struct {
 
 type OnChainDeal struct {
     Deal              StorageDeal
-    LastPaymentEpoch  block.ChainEpoch  // 0 = published
+    LastPaymentEpoch  block.ChainEpoch  // -1 = published
     ID                DealID
 }
 

--- a/src/systems/filecoin_markets/storage_market/storage_market_actor.id
+++ b/src/systems/filecoin_markets/storage_market/storage_market_actor.id
@@ -116,4 +116,6 @@ type StorageMarketActorCode struct {
     ProcessDealExpiration(rt Runtime, dealIDs [deal.DealID])
 
     GetPieceInfosForDealIDs(rt Runtime, dealIDs [deal.DealID]) [sector.PieceInfo]
+
+    ClearInactiveDealIDs(rt Runtime, dealIDs [deal.DealID])
 }

--- a/src/systems/filecoin_markets/storage_market/storage_market_actor_state.go
+++ b/src/systems/filecoin_markets/storage_market/storage_market_actor_state.go
@@ -269,7 +269,7 @@ func (st *StorageMarketActorState_I) _slashDealCollateral(rt Runtime, dealP deal
 }
 
 // delete deal from active deals
-// send deal collateral to TreasuryActor
+// send deal collateral to BurntFundsActor
 // return locked storage fee to client
 // return client collateral
 func (st *StorageMarketActorState_I) _terminateDeal(rt Runtime, dealID deal.DealID) actor.TokenAmount {

--- a/src/systems/filecoin_mining/storage_mining/constants.go
+++ b/src/systems/filecoin_mining/storage_mining/constants.go
@@ -1,6 +1,9 @@
 package storage_mining
 
-import block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
+import (
+	block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
+	actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
+)
 
 // TODO: placeholder epoch value -- this will be set later
 const MAX_PROVE_COMMIT_SECTOR_PERIOD = block.ChainEpoch(3)    // placeholder
@@ -11,5 +14,10 @@ const PROVING_PERIOD = block.ChainEpoch(2)                    // placeholder
 const SURPRISE_CHALLENGE_FREQUENCY = 2 // placeholder
 // how far into their PP does a miner get their first challenge
 const SUPRISE_NO_CHALLENGE_PERIOD = PROVING_PERIOD / SURPRISE_CHALLENGE_FREQUENCY
+
 const EPOST_SAMPLE_NUM = 1
 const EPOST_SAMPLE_DENOM = 25
+
+// FIL deposit per sector precommit in Interactive PoRep
+// refunded after ProveCommit but burned if PreCommit expires
+const PRECOMMIT_DEPOSIT_PER_BYTE = actor.TokenAmount(0) // placeholder

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
@@ -69,6 +69,7 @@ type SectorsAMT {sector.SectorNumber: SectorOnChainInfo}
 // map from SectorNumber to amout of storage in active deals
 type SectorUtilizationAMT {sector.SectorNumber: sector.SectorUtilizationInfo}
 
+// Balance of a StorageMinerActor should equal exactly the sum of PreCommit deposits that are not yet returned or burned
 type StorageMinerActorState struct {
     PreCommittedSectors     PreCommittedSectorsAMT
     StagedCommittedSectors  StagedCommittedSectorAMT

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
@@ -4,6 +4,7 @@ import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 import address "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
 import deal "github.com/filecoin-project/specs/systems/filecoin_markets/deal"
+import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 
 type SectorExpirationQueueItem struct {
     SectorNumber  sector.SectorNumber
@@ -111,6 +112,8 @@ type StorageMinerActorState struct {
     _getInactivePower(rt Runtime) block.StoragePower
     _getUtilizationInfo(rt Runtime, sectorNo sector.SectorNumber) sector.SectorUtilizationInfo
     _getCurrUtilization(sectorNo sector.SectorNumber) (utilization block.StoragePower, found bool)
+
+    _getPreCommitDepositReq(rt Runtime) actor.TokenAmount
 }
 
 type StorageMinerActorCode struct {

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor_code.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor_code.go
@@ -627,11 +627,7 @@ func (a *StorageMinerActorCode_I) PreCommitSector(rt Runtime, info sector.Sector
 	h, st := a.State(rt)
 
 	msgValue := rt.ValueReceived()
-
-	// TODO: move this to Construct
-	minerInfo := st.Info()
-	sectorSize := minerInfo.SectorSize()
-	depositReq := actor.TokenAmount(uint64(PRECOMMIT_DEPOSIT_PER_BYTE) * sectorSize)
+	depositReq := st._getPreCommitDepositReq(rt)
 
 	if msgValue < depositReq {
 		rt.AbortFundsMsg("sm.PreCommitSector: insufficient precommit deposit.")
@@ -790,7 +786,7 @@ func (a *StorageMinerActorCode_I) ProveCommitSector(rt Runtime, info sector.Sect
 
 	// now remove SectorNumber from PreCommittedSectors (processed)
 	delete(st.PreCommittedSectors(), preCommitSector.Info().SectorNumber())
-
+	depositReq := st._getPreCommitDepositReq(rt)
 	UpdateRelease(rt, h, st)
 
 	// return deposit requirement to sender
@@ -829,8 +825,7 @@ func (a *StorageMinerActorCode_I) _expirePreCommittedSectors(rt Runtime) {
 		}
 	}
 
-	depositToBurn := actor.TokenAmount(expiredSectorNum * int(PRECOMMIT_DEPOSIT))
-
+	depositToBurn := st._getPreCommitDepositReq(rt)
 	UpdateRelease(rt, h, st)
 
 	// send funds to BurntFundsActor

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor_state.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor_state.go
@@ -4,6 +4,7 @@ import (
 	block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
 	deal "github.com/filecoin-project/specs/systems/filecoin_markets/deal"
 	sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
+	actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 )
 
 func (st *StorageMinerActorState_I) _isChallenged() bool {
@@ -258,4 +259,14 @@ func (st *StorageMinerActorState_I) _initializeUtilizationInfo(rt Runtime, deals
 
 	return initialUtilizationInfo
 
+}
+
+func (st *StorageMinerActorState_I) _getPreCommitDepositReq(rt Runtime) actor.TokenAmount {
+
+	// TODO: move this to Construct
+	minerInfo := st.Info()
+	sectorSize := minerInfo.SectorSize()
+	depositReq := actor.TokenAmount(uint64(PRECOMMIT_DEPOSIT_PER_BYTE) * uint64(sectorSize))
+
+	return depositReq
 }


### PR DESCRIPTION
**In this PR**

- [x] Add PRECOMMIT_DEPOSIT
- [x] Miners need to include at least that amount in PreCommitSector
- [x] Miners get back the PRECOMMIT_DEPOSIT at ProveCommitSector
- [x] PRECOMMIT_DEPOSIT will be burned when PreCommit expires before receiving a ProveCommit
- [x] Burn PRECOMMIT_DEPOSIT at `_expirePreCommittedSectors` and clear inactive deals in PreCommittedSectors as a form of garbage collection