### PR TITLE
Remove GetSignaturePublicKey from Actor

### DIFF
--- a/src/systems/filecoin_vm/actor/actor.go
+++ b/src/systems/filecoin_vm/actor/actor.go
@@ -1,6 +1,5 @@
 package actor
 
-import filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
 import ipld "github.com/filecoin-project/specs/libraries/ipld"
 import util "github.com/filecoin-project/specs/util"
 
@@ -11,18 +10,12 @@ type Serialization = util.Serialization
 const (
 	MethodSend        = MethodNum(0)
 	MethodConstructor = MethodNum(1)
-	MethodCron        = MethodNum(2)
 
 	// TODO: remove this once canonical method numbers are finalized
 	MethodPlaceholder = MethodNum(-(1 << 30))
 )
 
 func (st *ActorState_I) CID() ipld.CID {
-	panic("TODO")
-}
-
-// Note: may be nil if actor has no public key
-func (st *ActorState_I) GetSignaturePublicKey() filcrypto.PublicKey {
 	panic("TODO")
 }
 

--- a/src/systems/filecoin_vm/actor/actor.id
+++ b/src/systems/filecoin_vm/actor/actor.id
@@ -1,7 +1,6 @@
 // This contains actor things that are _outside_ of VM exection.
 // The VM uses this to execute actors.
 
-import filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
 import ipld "github.com/filecoin-project/specs/libraries/ipld"
 
 // TokenAmount is an amount of Filecoin tokens. This type is used within
@@ -74,24 +73,18 @@ type BuiltinActorID enum {
 // to Actors in the Actor Model (programming), or Objects in Object-
 // Oriented Programming, or Ethereum Contracts in the EVM.
 //
-// Questions for id language:
-// - we should not do inheritance, we should do composition.
-//   but we should make including actor state nicer.
-//
-// ActorState represents the on-chain storage actors keep.
+// ActorState represents the on-chain storage all actors keep.
 type ActorState struct {
-    // common fields for all actors
-
+    // Identifies the code this actor executes.
     CodeID
-    // use a CID here, load it in interpreter.
-    // Alternative is to use ActorState here but tricky w/ the type system
-    State                    ActorSubstateCID
-
-    Balance                  TokenAmount
-    CallSeqNum  // FKA Nonce
-
-    // Note: may be nil if actor has no public key
-    GetSignaturePublicKey()  filcrypto.PublicKey
+    // CID of the root of optional actor-specific sub-state.
+    State       ActorSubstateCID
+    // Balance of tokens held by this actor.
+    Balance     TokenAmount
+    // Expected sequence number of the next message sent by this actor.
+    // Initially zero, incremented when an account actor originates a top-level message.
+    // Always zero for other actors.
+    CallSeqNum
 }
 
 type ActorSystemStateCID ipld.CID

--- a/src/systems/filecoin_vm/runtime/runtime.go
+++ b/src/systems/filecoin_vm/runtime/runtime.go
@@ -1,7 +1,6 @@
 package runtime
 
 import (
-	filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
 	ipld "github.com/filecoin-project/specs/libraries/ipld"
 	block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
 	actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
@@ -546,19 +545,6 @@ func (rt *VMContext) AcquireState() ActorStateHandle {
 		_initValue: rt._globalStatePending.GetActorState(rt._actorAddress).State().Ref(),
 		_rt:        rt,
 	}
-}
-
-func (rt *VMContext) VerifySignature(signerActor addr.Address, sig filcrypto.Signature, m filcrypto.Message) bool {
-	st := rt._globalStatePending.Impl().GetActorState(signerActor)
-	if st == nil {
-		rt.AbortAPI("VerifySignature: signer actor not found")
-	}
-	pk := st.GetSignaturePublicKey()
-	if pk == nil {
-		rt.AbortAPI("VerifySignature: signer actor has no public key")
-	}
-	ret := rt.Compute(ComputeFunctionID_VerifySignature, []Any{pk, sig, m})
-	return ret.(bool)
 }
 
 func (rt *VMContext) Compute(f ComputeFunctionID, args []Any) Any {

--- a/src/systems/filecoin_vm/runtime/runtime.id
+++ b/src/systems/filecoin_vm/runtime/runtime.id
@@ -2,7 +2,6 @@ import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
 import exitcode "github.com/filecoin-project/specs/systems/filecoin_vm/runtime/exitcode"
-import filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
 import ipld "github.com/filecoin-project/specs/libraries/ipld"
 import msg "github.com/filecoin-project/specs/systems/filecoin_vm/message"
 
@@ -57,12 +56,6 @@ type Runtime interface {
 
     CurrentBalance()  actor.TokenAmount
     ValueReceived()   actor.TokenAmount
-
-    VerifySignature(
-        signerActor  addr.Address
-        sig          filcrypto.Signature
-        m            filcrypto.Message
-    ) bool
 
     // Run a (pure function) computation, consuming the gas cost associated with that function.
     // This mechanism is intended to capture the notion of an ABI between the VM and native

--- a/src/systems/filecoin_vm/sysactors/cron_actor.go
+++ b/src/systems/filecoin_vm/sysactors/cron_actor.go
@@ -5,6 +5,10 @@ import exitcode "github.com/filecoin-project/specs/systems/filecoin_vm/runtime/e
 import util "github.com/filecoin-project/specs/util"
 import vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
 
+const (
+	Method_CronActor_EpochTick = actor.MethodPlaceholder + iota
+)
+
 func (a *CronActorCode_I) Constructor(rt vmr.Runtime) InvocOutput {
 	// Nothing. intentionally left blank.
 	return rt.SuccessReturn()
@@ -33,7 +37,7 @@ func (a *CronActorCode_I) InvokeMethod(rt Runtime, method actor.MethodNum, param
 		rt.Assert(len(params) == 0)
 		return a.Constructor(rt)
 
-	case actor.MethodCron:
+	case Method_CronActor_EpochTick:
 		rt.Assert(len(params) == 0)
 		return a.EpochTick(rt)
 


### PR DESCRIPTION
Remove GetSignaturePublicKey (unimplemented) from Actor. The missing implementation obscured the fact that this can't be implemented here. GetSignaturePublicKey does not belong on the base actor. Only account actors have keys, and not even all of them do. The account actor's address/key is stored in the account actor's substate.

If we need on-chain access to keys, the actor account might need a method to either fetch the key or verify a signature. If only off-chain, the VM can inspect the account actor's state.

Also remove legacy cron reserved method number.