### PR TITLE
Spec/network name

### DIFF
--- a/src/systems/filecoin_markets/retrieval_market/retrieval_protocols.md
+++ b/src/systems/filecoin_markets/retrieval_market/retrieval_protocols.md
@@ -5,14 +5,14 @@ title: "Retrieval Protocols"
 The `retrieval market` will initially be implemented as two `libp2p` services.
 
 - **Name**: Query Protocol
-- **Protocol ID V0**: `/fil/retrieval/qry/0.0.1`
-- **Protocol ID V1**: `/fil/retrieval/qry/1.0.0`
+- **Protocol ID V0**: `/fil/<network-name>/retrieval/qry/0.0.1`
+- **Protocol ID V1**: `/fil/<network-name>/retrieval/qry/1.0.0`
 
 Request: CBOR Encoded RetrievalQuery Data Structure
 Response: CBOR Encoded RetrievalQueryResponse Data Structure
 
 - **Name**: Retrieval Protocol
-- **Protocol ID V0**: `/fil/retrieval/0.0.1` 
+- **Protocol ID V0**: `/fil/<network-name>/retrieval/0.0.1` 
 
 V0:
 Request: CBOR Encoded RetrievalDealProposal Data Structure

--- a/src/systems/filecoin_nodes/network/_index.md
+++ b/src/systems/filecoin_nodes/network/_index.md
@@ -10,13 +10,27 @@ Filecoin nodes use the libp2p protocol for peer discovery, peer routing, and mes
 
 Here is the list of libp2p protocols used by Filecoin.
 
-- Graphsync: [Draft spec](https://github.com/ipld/specs/blob/master/block-layer/graphsync/graphsync.md)
-- Bitswap:  TODO
-- Gossipsub: block headers and messages are broadcasted through a Gossip PubSub protocol where nodes can subscribe to topics such as `NewBlock`, `BlockHeader`, `BlockMessage`, etc and receive messages in those topics. When receiving messages related to a topic, nodes processes the message and forwards it to its peers who also subscribed to the same topic.  Spec is [here](https://github.com/libp2p/specs/tree/master/pubsub/gossipsub)
-- KademliaDHT: Kademlia DHT is a distributed hash table with a logarithmic bound on the maximum number of lookups for a particular node. Kad DHT is used primarily for peer routing as well as peer discovery in the Filecoin protocol.  Spec TODO [reference implementation](https://github.com/libp2p/go-libp2p-kad-dht)
-- Bootstrap List: Bootstrap is a list of nodes that a new node attempts to connect upon joining the network. The list of bootstrap nodes and their addresses are defined by the users.
-- Peer Exchange: spec [TODO](https://github.com/libp2p/specs/issues/222)
+- Graphsync: 
+	- Graphsync is used to transfer blockchain and user data
+	- [Draft spec](https://github.com/ipld/specs/blob/master/block-layer/graphsync/graphsync.md)
+	- No filecoin specific modifications to the protocol id
+- Gossipsub: 
+	- block headers and messages are broadcasted through a Gossip PubSub protocol where nodes can subscribe to topics for blockchain data and receive messages in those topics. When receiving messages related to a topic, nodes processes the message and forwards it to its peers who also subscribed to the same topic.  
+	- Spec is [here](https://github.com/libp2p/specs/tree/master/pubsub/gossipsub)
+	- No filecoin specific modifications to the protocol id.  However the topic identifiers MUST be of the form `fil/blocks/<network-name>` and `fil/msgs/<network-name>`
+- KademliaDHT: 
+	- Kademlia DHT is a distributed hash table with a logarithmic bound on the maximum number of lookups for a particular node. Kad DHT is used primarily for peer routing as well as peer discovery in the Filecoin protocol.
+	- Spec TODO [reference implementation](https://github.com/libp2p/go-libp2p-kad-dht)
+	- The protocol id must be of the form `fil/kad/<network-name>`
+- Bootstrap List: 
+	- Bootstrap is a list of nodes that a new node attempts to connect upon joining the network. The list of bootstrap nodes and their addresses are defined by the users.
+- Peer Exchange: 
+	- Peer Exchange is a discovery protocol enabling peers to create and issue queries for desired peers against their existing peers
+	- spec [TODO](https://github.com/libp2p/specs/issues/222)
+	- No Filecoin specific modifications to the protocol id.
 - DNSDiscovery: Design and spec needed before implementing
-- HTTPDiscovery: Design and spec needed before implementing 
-
-Filecoin network protocols should be differentiated from non-filecoin network protocols.  Additionally different filecoin networks should differentiate protocols from each other.  To achieve this filecoin network protocol IDs MUST adhere to the following format: `/fil/<libp2p-protocol>/<network-name>`.  For example: `fil/kad-dht/mainnet`.
+- HTTPDiscovery: Design and spec needed before implementing
+- Hello:
+	- Hello protocol handles new connections to filecoin nodes.  It is an important part of the discovery process for ambient protocols (like KademliaDHT)
+	- Spec TODO.
+	- No Filecoin specific modifications to the protocol id.

--- a/src/systems/filecoin_nodes/network/_index.md
+++ b/src/systems/filecoin_nodes/network/_index.md
@@ -6,7 +6,7 @@ statusIcon: ⚠️
 {{< readfile file="network.id" code="true" lang="go" >}}
 
 
-Filecoin nodes use the libp2p protocol for peer discovery, peer routing, and message multicast, and so on. Libp2p is a set of modular protocols common to the peer-to-peer networking stack. Nodes open connections with one another and mount different protocols or streams over the same connection. In the initial handshake, nodes exchange the protocols that each of them supports and all Filecoin related protcols will be mounted under `/filecoin/...` protocol identifiers.
+Filecoin nodes use the libp2p protocol for peer discovery, peer routing, and message multicast, and so on. Libp2p is a set of modular protocols common to the peer-to-peer networking stack. Nodes open connections with one another and mount different protocols or streams over the same connection. In the initial handshake, nodes exchange the protocols that each of them supports and all Filecoin related protcols will be mounted under `/fil/...` protocol identifiers.
 
 Here is the list of libp2p protocols used by Filecoin.
 

--- a/src/systems/filecoin_nodes/network/_index.md
+++ b/src/systems/filecoin_nodes/network/_index.md
@@ -18,3 +18,5 @@ Here is the list of libp2p protocols used by Filecoin.
 - Peer Exchange: spec [TODO](https://github.com/libp2p/specs/issues/222)
 - DNSDiscovery: Design and spec needed before implementing
 - HTTPDiscovery: Design and spec needed before implementing 
+
+Filecoin network protocols should be differentiated from non-filecoin network protocols.  Additionally different filecoin networks should differentiate protocols from each other.  To achieve this filecoin network protocol IDs MUST adhere to the following format: `/fil/<libp2p-protocol>/<network-name>`.  For example: `fil/kad-dht/mainnet`.

--- a/src/systems/filecoin_vm/runtime/runtime.go
+++ b/src/systems/filecoin_vm/runtime/runtime.go
@@ -20,10 +20,16 @@ var EnsureErrorCode = exitcode.EnsureErrorCode
 var SystemError = exitcode.SystemError
 var IMPL_FINISH = util.IMPL_FINISH
 var TODO = util.TODO
+// This should be set per network
+var Name = "FilecoinMainnet"
 
 func ActorSubstateCID_Equals(x, y ActorSubstateCID) bool {
 	IMPL_FINISH()
 	panic("")
+}
+
+func NetworkName() string {
+	return Name
 }
 
 // ActorCode is the interface that all actor code types should satisfy.

--- a/src/systems/filecoin_vm/runtime/runtime.go
+++ b/src/systems/filecoin_vm/runtime/runtime.go
@@ -20,8 +20,9 @@ var EnsureErrorCode = exitcode.EnsureErrorCode
 var SystemError = exitcode.SystemError
 var IMPL_FINISH = util.IMPL_FINISH
 var TODO = util.TODO
-// This should be set per network
-var Name = "FilecoinMainnet"
+
+// Name should be set per unique filecoin network
+var Name = "mainnet"
 
 func ActorSubstateCID_Equals(x, y ActorSubstateCID) bool {
 	IMPL_FINISH()

--- a/src/systems/filecoin_vm/sysactors/_index.md
+++ b/src/systems/filecoin_vm/sysactors/_index.md
@@ -10,7 +10,7 @@ entries:
 
 - There are two system actors required for VM processing:
   - [CronActor](#CronActor) - runs critical functions at every epoch
-  - [InitActor](#InitActor) - initializes new actors
+  - [InitActor](#InitActor) - initializes new actors, records the network name
 - There are two more VM level actors:
   - [AccountActor](#AccountActor) - for user accounts (non-singleton).
   - [RewardActor](#RewardActor) - for block reward and token vesting (singleton).

--- a/src/systems/filecoin_vm/sysactors/init_actor.go
+++ b/src/systems/filecoin_vm/sysactors/init_actor.go
@@ -59,6 +59,7 @@ func (a *InitActorCode_I) Constructor(rt Runtime) InvocOutput {
 	st := &InitActorState_I{
 		AddressMap_: map[addr.Address]addr.ActorID{}, // TODO: HAMT
 		NextID_:     addr.ActorID(addr.FirstNonSingletonActorId),
+		NetworkName_: vmr.NetworkName(),
 	}
 	UpdateRelease(rt, h, st)
 	return rt.ValueReturn(nil)

--- a/src/systems/filecoin_vm/sysactors/init_actor.go
+++ b/src/systems/filecoin_vm/sysactors/init_actor.go
@@ -57,8 +57,8 @@ func (st *InitActorState_I) CID() ipld.CID {
 func (a *InitActorCode_I) Constructor(rt Runtime) InvocOutput {
 	h := rt.AcquireState()
 	st := &InitActorState_I{
-		AddressMap_: map[addr.Address]addr.ActorID{}, // TODO: HAMT
-		NextID_:     addr.ActorID(addr.FirstNonSingletonActorId),
+		AddressMap_:  map[addr.Address]addr.ActorID{}, // TODO: HAMT
+		NextID_:      addr.ActorID(addr.FirstNonSingletonActorId),
 		NetworkName_: vmr.NetworkName(),
 	}
 	UpdateRelease(rt, h, st)

--- a/src/systems/filecoin_vm/sysactors/init_actor.id
+++ b/src/systems/filecoin_vm/sysactors/init_actor.id
@@ -6,12 +6,13 @@ type InitActorState struct {
     // responsible for create new actors
     AddressMap       {addr.Address: addr.ActorID}
     NextID           addr.ActorID
+    NetworkName      string
 
     _assignNextID()  addr.ActorID
 }
 
 type InitActorCode struct {
-    Constructor(r vmr.Runtime)
+    Constructor(r vmr.Runtime, networkName string)
     Exec(r vmr.Runtime, code actor.CodeID, params actor.MethodParams) addr.Address
     GetActorIDForAddress(r vmr.Runtime, address addr.Address) addr.ActorID
 }


### PR DESCRIPTION
In this PR
- [x] Land the change proposed here: https://github.com/filecoin-project/specs/pull/456, putting the network name inside the init actor's state.
- [x] Spec the network protocol id requirement differentiating network protocols (1) from non-filecoin networks (2) filecoin networks with different network names