### PR TITLE
[WIP] remove unnecessary params from post verifs

### DIFF
--- a/src/systems/filecoin_mining/storage_mining/challenge_status.go
+++ b/src/systems/filecoin_mining/storage_mining/challenge_status.go
@@ -28,7 +28,7 @@ func (cs *ChallengeStatus_I) LastPoStResponseEpoch() block.ChainEpoch {
 }
 
 func (cs *ChallengeStatus_I) IsChallenged() bool {
-	// true if most recent challenge has gone unanswered
+	// true if most recent challenge has gone unanswered (with a PoSt or a failure)
 	return cs.LastChallengeEpoch() > cs.LastPoStResponseEpoch()
 }
 

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
@@ -123,8 +123,8 @@ type StorageMinerActorCode struct {
     PreCommitSector(rt Runtime, info sector.SectorPreCommitInfo)  // TODO: check with Magik on sizes
     ProveCommitSector(rt Runtime, info sector.SectorProveCommitInfo)
 
-    SubmitVerifiedSurprisePoSt(rt Runtime, onChainInfo sector.OnChainPoStVerifyInfo)
-    SubmitVerifiedElectionPoSt(rt Runtime, onChainInfo sector.OnChainPoStVerifyInfo)
+    SubmitVerifiedSurprisePoSt(rt Runtime)
+    SubmitVerifiedElectionPoSt(rt Runtime)
 
     _checkSurprisePoStSubmissionHappened(rt Runtime)
 
@@ -134,7 +134,7 @@ type StorageMinerActorCode struct {
     _isChallenged(rt Runtime) bool
     _isSealVerificationCorrect(rt Runtime, onChainInfo sector.OnChainSealVerifyInfo) bool
     _onMissedSurprisePoSt(rt Runtime)
-    _onSuccessfulPoSt(rt Runtime, onChainInfo sector.OnChainPoStVerifyInfo)
+    _onSuccessfulPoSt(rt Runtime)
 
     _slashCollateralForStorageFaults(
         rt          Runtime

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
@@ -123,8 +123,8 @@ type StorageMinerActorCode struct {
     PreCommitSector(rt Runtime, info sector.SectorPreCommitInfo)  // TODO: check with Magik on sizes
     ProveCommitSector(rt Runtime, info sector.SectorProveCommitInfo)
 
-    SubmitVerifiedSurprisePoSt(rt Runtime)
-    SubmitVerifiedElectionPoSt(rt Runtime)
+    ProcessVerifiedSurprisePoSt(rt Runtime)
+    ProcessVerifiedElectionPoSt(rt Runtime)
 
     _checkSurprisePoStSubmissionHappened(rt Runtime)
 

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor_code.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor_code.go
@@ -271,8 +271,6 @@ func (a *StorageMinerActorCode_I) _claimDealPayments(rt Runtime) {
 func (a *StorageMinerActorCode_I) _onSuccessfulPoSt(rt Runtime) InvocOutput {
 	h, st := a.State(rt)
 
-	// TODO add info on chain
-
 	// The proof is verified, process ProvingSet.SectorsOn():
 	// ProvingSet.SectorsOn() contains SectorCommitted, SectorActive, SectorRecovering
 	// ProvingSet itself does not store states, states are all stored in Sectors.State

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor_code.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor_code.go
@@ -268,7 +268,7 @@ func (a *StorageMinerActorCode_I) _claimDealPayments(rt Runtime) {
 //       - Failing / Recovering / Active / Committed -> Cleared
 //     - Remove SectorNumber from Sectors, ProvingSet
 // - Update ChallengeEndEpoch
-func (a *StorageMinerActorCode_I) _onSuccessfulPoSt(rt Runtime, onChainInfo sector.OnChainPoStVerifyInfo) InvocOutput {
+func (a *StorageMinerActorCode_I) _onSuccessfulPoSt(rt Runtime) InvocOutput {
 	h, st := a.State(rt)
 
 	// TODO add info on chain
@@ -342,20 +342,22 @@ func (a *StorageMinerActorCode_I) _onSuccessfulPoSt(rt Runtime, onChainInfo sect
 }
 
 // called by verifier to update miner state on successful surprise post
-func (a *StorageMinerActorCode_I) SubmitVerifiedSurprisePoSt(rt Runtime, onChainInfo sector.OnChainPoStVerifyInfo) InvocOutput {
+// after it has been verified in the storage_mining_subsystem
+func (a *StorageMinerActorCode_I) SubmitVerifiedSurprisePoSt(rt Runtime) InvocOutput {
 	TODO() // TODO: validate caller
 
 	// Ensure pledge collateral satisfied
 	// otherwise, abort SubmitVerifiedSurprisePoSt
 	a._ensurePledgeCollateralSatisfied(rt)
 
-	return a._onSuccessfulPoSt(rt, onChainInfo)
+	return a._onSuccessfulPoSt(rt)
 
 }
 
 // Called by StoragePowerConsensus subsystem after verifying the Election proof
 // and verifying the PoSt proof in the block header.
-// Assume ElectionPoSt has already been successfully verified when the function gets called.
+// Assume ElectionPoSt has already been successfully verified (both proof and partial ticket
+// value) when the function gets called.
 // Likewise assume that the rewards have already been granted to the storage miner actor. This only handles sector management.
 func (a *StorageMinerActorCode_I) SubmitVerifiedElectionPoSt(rt Runtime, onChainInfo sector.OnChainPoStVerifyInfo) InvocOutput {
 	rt.ValidateImmediateCallerIs(addr.SystemActorAddr)
@@ -369,7 +371,7 @@ func (a *StorageMinerActorCode_I) SubmitVerifiedElectionPoSt(rt Runtime, onChain
 	// notneeded := a._verifyPoStSubmission(rt)
 
 	// the following will update last challenge response time
-	return a._onSuccessfulPoSt(rt, onChainInfo)
+	return a._onSuccessfulPoSt(rt)
 
 }
 

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor_code.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor_code.go
@@ -17,8 +17,8 @@ import (
 )
 
 const (
-	Method_StorageMinerActor_SubmitVerifiedSurprisePoSt = actor.MethodPlaceholder + iota
-	Method_StorageMinerActor_SubmitVerifiedElectionPoSt
+	Method_StorageMinerActor_ProcessVerifiedSurprisePoSt = actor.MethodPlaceholder + iota
+	Method_StorageMinerActor_ProcessVerifiedElectionPoSt
 	Method_StorageMinerActor_NotifyOfSurprisePoStChallenge
 )
 
@@ -336,16 +336,15 @@ func (a *StorageMinerActorCode_I) _onSuccessfulPoSt(rt Runtime) InvocOutput {
 	UpdateRelease(rt, h, st)
 
 	return rt.SuccessReturn()
-
 }
 
 // called by verifier to update miner state on successful surprise post
 // after it has been verified in the storage_mining_subsystem
-func (a *StorageMinerActorCode_I) SubmitVerifiedSurprisePoSt(rt Runtime) InvocOutput {
+func (a *StorageMinerActorCode_I) ProcessVerifiedSurprisePoSt(rt Runtime) InvocOutput {
 	TODO() // TODO: validate caller
 
 	// Ensure pledge collateral satisfied
-	// otherwise, abort SubmitVerifiedSurprisePoSt
+	// otherwise, abort ProcessVerifiedSurprisePoSt
 	a._ensurePledgeCollateralSatisfied(rt)
 
 	return a._onSuccessfulPoSt(rt)
@@ -357,7 +356,7 @@ func (a *StorageMinerActorCode_I) SubmitVerifiedSurprisePoSt(rt Runtime) InvocOu
 // Assume ElectionPoSt has already been successfully verified (both proof and partial ticket
 // value) when the function gets called.
 // Likewise assume that the rewards have already been granted to the storage miner actor. This only handles sector management.
-func (a *StorageMinerActorCode_I) SubmitVerifiedElectionPoSt(rt Runtime, onChainInfo sector.OnChainPoStVerifyInfo) InvocOutput {
+func (a *StorageMinerActorCode_I) ProcessVerifiedElectionPoSt(rt Runtime) InvocOutput {
 	rt.ValidateImmediateCallerIs(addr.SystemActorAddr)
 	// The receiver must be the miner who produced the block for which this message is created.
 	Assert(rt.ToplevelBlockWinner() == rt.CurrReceiver())
@@ -370,7 +369,6 @@ func (a *StorageMinerActorCode_I) SubmitVerifiedElectionPoSt(rt Runtime, onChain
 
 	// the following will update last challenge response time
 	return a._onSuccessfulPoSt(rt)
-
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/systems/filecoin_vm/interpreter/vm_interpreter.go
+++ b/src/systems/filecoin_vm/interpreter/vm_interpreter.go
@@ -36,7 +36,7 @@ func (vmi *VMInterpreter_I) ApplyTipSetMessages(inTree st.StateTree, msgs TipSet
 
 	for _, blk := range msgs.Blocks() {
 		// Process block miner's Election PoSt.
-		epostMessage := _makeElectionPoStMessage(outTree, blk.Miner(), msgs.Epoch())
+		epostMessage := _makeElectionPoStMessage(outTree, blk.Miner())
 		outTree = _applyMessageBuiltinAssert(outTree, epostMessage, blk.Miner())
 
 		minerPenaltyTotal := actor.TokenAmount(0)
@@ -300,7 +300,7 @@ func _makeBlockRewardMessage(state st.StateTree, minerAddr addr.Address, penalty
 }
 
 // Builds a message for submitting ElectionPost on behalf of a miner actor.
-func _makeElectionPoStMessage(state st.StateTree, minerActorAddr addr.Address, epoch UInt64) msg.UnsignedMessage {
+func _makeElectionPoStMessage(state st.StateTree, minerActorAddr addr.Address) msg.UnsignedMessage {
 	// TODO: determine parameters necessary for this message.
 	params := make([]util.Serialization, 0)
 
@@ -308,7 +308,7 @@ func _makeElectionPoStMessage(state st.StateTree, minerActorAddr addr.Address, e
 	return &msg.UnsignedMessage_I{
 		From_:       addr.SystemActorAddr,
 		To_:         minerActorAddr,
-		Method_:     storage_mining.Method_StorageMinerActor_SubmitVerifiedElectionPoSt,
+		Method_:     storage_mining.Method_StorageMinerActor_ProcessVerifiedElectionPoSt,
 		Params_:     params,
 		CallSeqNum_: sysActor.CallSeqNum(),
 		Value_:      0,


### PR DESCRIPTION
Remove `OnChainPoStVerifyInfo` from `_onSuccessfulPoSt` and upstream methods