### PR TITLE
Clean up state tree to be just a HAMT of actor states.

### DIFF
--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_consensus_subsystem.go
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_consensus_subsystem.go
@@ -64,7 +64,8 @@ var node node_base.FilecoinNode
 
 func (spc *StoragePowerConsensusSubsystem_I) _getStoragePowerActorState(stateTree stateTree.StateTree) StoragePowerActorState {
 	powerAddr := addr.StoragePowerActorAddr
-	actorState := stateTree.GetActorState(powerAddr)
+	actorState, ok := stateTree.GetActor(powerAddr)
+	util.Assert(ok)
 	substateCID := actorState.State()
 
 	substate, err := node.LocalGraph().Get(ipld.CID(substateCID))

--- a/src/systems/filecoin_mining/storage_mining/storage_mining_subsystem.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_mining_subsystem.go
@@ -152,7 +152,8 @@ func (sms *StorageMiningSubsystem_I) PrepareNewTicket(randomness util.Randomness
 var node node_base.FilecoinNode
 
 func (sms *StorageMiningSubsystem_I) _getStorageMinerActorState(stateTree stateTree.StateTree, minerAddr addr.Address) StorageMinerActorState {
-	actorState := stateTree.GetActorState(minerAddr)
+	actorState, ok := stateTree.GetActor(minerAddr)
+	util.Assert(ok)
 	substateCID := actorState.State()
 
 	substate, err := node.LocalGraph().Get(ipld.CID(substateCID))
@@ -172,7 +173,8 @@ func (sms *StorageMiningSubsystem_I) _getStorageMinerActorState(stateTree stateT
 
 func (sms *StorageMiningSubsystem_I) _getStoragePowerActorState(stateTree stateTree.StateTree) spc.StoragePowerActorState {
 	powerAddr := addr.StoragePowerActorAddr
-	actorState := stateTree.GetActorState(powerAddr)
+	actorState, ok := stateTree.GetActor(powerAddr)
+	util.Assert(ok)
 	substateCID := actorState.State()
 
 	substate, err := node.LocalGraph().Get(ipld.CID(substateCID))

--- a/src/systems/filecoin_vm/actor/address/address.go
+++ b/src/systems/filecoin_vm/actor/address/address.go
@@ -56,6 +56,10 @@ func Deserialize_Address_Compact(AddressString) (Address, error) {
 	panic("TODO")
 }
 
+func (a *Address_I) IsIDType() bool {
+	panic("TODO")
+}
+
 func (a *Address_I) IsKeyType() bool {
 	panic("TODO")
 }

--- a/src/systems/filecoin_vm/actor/address/address.id
+++ b/src/systems/filecoin_vm/actor/address/address.id
@@ -18,7 +18,8 @@ type Address struct {
 
     VerifySyntax()   bool
     String()         AddressString
-    IsKeyType()      bool
+    IsIDType()       bool  // Whether the address is an ID-address
+    IsKeyType()      bool  // Whether the address is a public key address (SECP or BLS)
     Equals(Address)  bool
     Ref()            Address_Ptr
 }

--- a/src/systems/filecoin_vm/interpreter/vm_interpreter.go
+++ b/src/systems/filecoin_vm/interpreter/vm_interpreter.go
@@ -310,7 +310,8 @@ func _makeBlockRewardMessage(state st.StateTree, minerAddr addr.Address, penalty
 	params[0] = addr.Serialize_Address(minerAddr)
 	params[1] = actor.Serialize_TokenAmount(penalty)
 
-	sysActor := state.GetActorState(addr.SystemActorAddr)
+	sysActor, ok := state.GetActor(addr.SystemActorAddr)
+	Assert(ok)
 	return &msg.UnsignedMessage_I{
 		From_:       addr.SystemActorAddr,
 		To_:         addr.RewardActorAddr,
@@ -328,7 +329,8 @@ func _makeElectionPoStMessage(state st.StateTree, minerActorAddr addr.Address) m
 	// TODO: determine parameters necessary for this message.
 	params := make([]util.Serialization, 0)
 
-	sysActor := state.GetActorState(addr.SystemActorAddr)
+	sysActor, ok := state.GetActor(addr.SystemActorAddr)
+	Assert(ok)
 	return &msg.UnsignedMessage_I{
 		From_:       addr.SystemActorAddr,
 		To_:         minerActorAddr,
@@ -343,7 +345,8 @@ func _makeElectionPoStMessage(state st.StateTree, minerActorAddr addr.Address) m
 
 // Builds a message for invoking the cron actor tick.
 func _makeCronTickMessage(state st.StateTree, minerActorAddr addr.Address) msg.UnsignedMessage {
-	sysActor := state.GetActorState(addr.SystemActorAddr)
+	sysActor, ok := state.GetActor(addr.SystemActorAddr)
+	Assert(ok)
 	return &msg.UnsignedMessage_I{
 		From_:       addr.SystemActorAddr,
 		To_:         addr.CronActorAddr,

--- a/src/systems/filecoin_vm/interpreter/vm_interpreter.go
+++ b/src/systems/filecoin_vm/interpreter/vm_interpreter.go
@@ -157,10 +157,16 @@ func (vmi *VMInterpreter_I) ApplyMessage(
 		return
 	}
 
-	fromActor := inTree.GetActorState(message.From())
-	if fromActor == nil {
+	fromActor, ok := inTree.GetActor(message.From())
+	if !ok {
 		// Execution error; sender does not exist at time of message execution.
 		_applyError(inTree, exitcode.ActorNotFound, SenderResolveSpec_Invalid)
+		return
+	}
+
+	// make sure this is the right message order for fromActor
+	if message.CallSeqNum() != fromActor.CallSeqNum() {
+		_applyError(inTree, exitcode.InvalidCallSeqNum, SenderResolveSpec_Invalid)
 		return
 	}
 
@@ -173,31 +179,26 @@ func (vmi *VMInterpreter_I) ApplyMessage(
 		return
 	}
 
-	// make sure this is the right message order for fromActor
-	if message.CallSeqNum() != fromActor.CallSeqNum() {
-		_applyError(inTree, exitcode.InvalidCallSeqNum, SenderResolveSpec_Invalid)
+	// Check receiving actor and method exists, possibly creating an account actor.
+	// If this succeeds, compTreePreSend will become a state snapshot which includes
+	// implicit receiver creation, the sender (rather than miner) paying gas, and the sender's
+	// CallSeqNum being incremented; at least that much state change will be persisted even if the
+	// method invocation subsequently fails.
+	compTreePreSend, ok := _ensureReceiver(inTree, message)
+	if !ok {
+		// Execution error; receiver actor does not exist (and could not be implicitly created)
+		// at time of message execution.
+		_applyError(inTree, exitcode.ActorNotFound, SenderResolveSpec_Invalid)
 		return
 	}
 
-	compTreePreSend := inTree
-
-	// Deduct gas limit funds from sender first.
+	// Deduct gas limit funds from sender.
 	// (This should always succeed, due to the sender balance check above.)
 	compTreePreSend = _withTransferFundsAssert(
 		compTreePreSend, message.From(), addr.BurntFundsActorAddr, gasLimitCost)
 
 	// Increment sender CallSeqNum.
 	compTreePreSend = compTreePreSend.Impl().WithIncrementedCallSeqNum_Assert(message.From())
-
-	// WithActorForAddress may create new account actors
-	var toActor actor.ActorState
-	compTreePreSend, toActor = compTreePreSend.Impl().WithActorForAddress(message.To())
-	if toActor == nil {
-		// Execution error; receiver actor does not exist (and could not be implicitly created)
-		// at time of message execution.
-		_applyError(compTreePreSend, exitcode.ActorNotFound, SenderResolveSpec_OK)
-		return
-	}
 
 	sendRet, compTreePostSend := _applyMessageInternal(compTreePreSend, message, vmiGasRemaining, minerAddr)
 
@@ -224,6 +225,29 @@ func (vmi *VMInterpreter_I) ApplyMessage(
 	return
 }
 
+// Ensures a messages's receiving actor exists in the state tree.
+// If it doesn't, and the message is a simple value send to a pubkey-style address,
+// creates the receiver as an account actor in the returned state.
+func _ensureReceiver(tree st.StateTree, message msg.UnsignedMessage) (st.StateTree, bool) {
+	_, found := tree.GetActor(message.To())
+
+	if found {
+		return tree, true
+	}
+	if !message.To().IsKeyType() {
+		// Don't implicitly create an account actor for an address without an associated key.
+		return tree, false
+	}
+	if message.Method() != actor.MethodSend {
+		// Don't implicitly create account actor if message was expecting to invoke a method.
+		return tree, false
+	}
+	// TODO Create a new account actor via the InitActor, which will receive a new ID address
+	// and be placed in the state tree under that address.
+	// The init actor will maintain a map from pubkey address to ID address.
+	return tree, true
+}
+
 func _applyMessageBuiltinAssert(tree st.StateTree, message msg.UnsignedMessage, topLevelBlockWinner addr.Address) st.StateTree {
 	Assert(message.From().Equals(addr.SystemActorAddr))
 	tree = tree.Impl().WithIncrementedCallSeqNum_Assert(message.From())
@@ -240,8 +264,8 @@ func _applyMessageInternal(
 	tree st.StateTree, message msg.UnsignedMessage, gasRemainingInit msg.GasAmount, topLevelBlockWinner addr.Address) (
 	vmr.MessageReceipt, st.StateTree) {
 
-	fromActor := tree.GetActorState(message.From())
-	Assert(fromActor != nil)
+	fromActor, ok := tree.GetActor(message.From())
+	Assert(ok)
 
 	rt := vmr.VMContext_Make(
 		message.From(),

--- a/src/systems/filecoin_vm/runtime/runtime.go
+++ b/src/systems/filecoin_vm/runtime/runtime.go
@@ -439,7 +439,7 @@ func (rtOuter *VMContext) _sendInternal(input InvocInput, errSpec ErrorHandlingS
 		rtOuter._toplevelSender,
 		rtOuter._toplevelBlockWinner,
 		rtOuter._toplevelSenderCallSeqNum,
-		rtOuter._internalCallSeqNum,
+		rtOuter._internalCallSeqNum+1,
 		rtOuter._globalStatePending,
 		input.To(),
 		input.Value(),

--- a/src/systems/filecoin_vm/state_tree/state_tree.go
+++ b/src/systems/filecoin_vm/state_tree/state_tree.go
@@ -1,46 +1,21 @@
 package state_tree
 
 import (
-	actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
+	"github.com/filecoin-project/specs/libraries/ipld"
+	"github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 	addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
-	util "github.com/filecoin-project/specs/util"
+	"github.com/filecoin-project/specs/util"
 )
 
 var Assert = util.Assert
 
-func (inTree *StateTree_I) WithActorForAddress(a addr.Address) (StateTree, actor.ActorState) {
-	var err error
-	var actorState actor.ActorState
-	var compTree StateTree
-
-	actorState = inTree.GetActorState(a)
-	if actorState != nil {
-		return inTree, actorState // done
-	}
-
-	if !a.IsKeyType() { // BLS or Secp
-		return inTree, nil // not a key type, done.
-	}
-
-	compTree, actorState, err = inTree.Impl().WithNewAccountActor(a)
-	if err != nil {
-		return inTree, nil
-	}
-
-	return compTree, actorState
-}
-
-func (st *StateTree_I) GetActorAddress(n ActorName) addr.Address {
+func (st *StateTree_I) RootCID() ipld.CID {
 	panic("TODO")
 }
 
-// Note: may be nil if not found
-func (st *StateTree_I) GetActorState(a addr.Address) actor.ActorState {
-	panic("TODO")
-}
-
-func (st *StateTree_I) Balance(a addr.Address) actor.TokenAmount {
-	panic("TODO")
+func (st *StateTree_I) GetActor(a addr.Address) (actor.ActorState, bool) {
+	as, found := st.ActorStates()[a]
+	return as, found
 }
 
 func (st *StateTree_I) WithActorSubstate(a addr.Address, actorState actor.ActorSubstateCID) (StateTree, error) {

--- a/src/systems/filecoin_vm/state_tree/state_tree.id
+++ b/src/systems/filecoin_vm/state_tree/state_tree.id
@@ -1,30 +1,15 @@
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
+import ipld "github.com/filecoin-project/specs/libraries/ipld"
 
-// Epoch is an epoch in time in the StateTree.
-// It corresponds to rounds in the blockchain, but it
-// is defined here as actors need a notion of time.
-type Epoch UVarint
-
-// TODO: move this into a directory w/ all the actors + states
-type ActorName enum {
-    StoragePowerActor
-    StorageMarketActor
-    StorageMinerActor
-    PaymentChannelActor
-    InitActor
-    AccountActor
-    CronActor
-}
-
+// The on-chain state data structure is a map (HAMT) of addresses to actor states.
+// Only ID addresses are expected as keys.
 type StateTree struct {
-    SystemActors  {ActorName: addr.Address}
-    ActorStates   {addr.Address: actor.ActorState}
+    ActorStates  {addr.Address: actor.ActorState}  // HAMT
 
-    // TODO: API ConvenienceAPI
-    GetActorAddress(n ActorName) addr.Address
-    GetActorState(a addr.Address) actor.ActorState
+    // Returns the CID of the root node of the HAMT.
+    RootCID()    ipld.CID
 
-    // Balance returns the balance of a given actor
-    Balance(a addr.Address) actor.TokenAmount
+    // Looks up an actor state by address.
+    GetActor(a addr.Address) (state actor.ActorState, ok bool)
 }


### PR DESCRIPTION
Replace incorrect implicit receiver actor creation with a placeholder and comment.
Fix accidental persistence of CallSeqNum and gas burn when implicit receiver creation fails.

FYI @icorderi 