### PR TITLE
general typo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ make website
 
 ### Diagrams
 
-Install dependencies for digram making
+Install dependencies for diagram making
 ```
 make deps-diag
 ```

--- a/src/algorithms/crypto/signatures.md
+++ b/src/algorithms/crypto/signatures.md
@@ -13,6 +13,7 @@ example, Filecoin uses signatures in order to validate deal messages which repre
 action like a storage deal. 
 Filecoin uses signatures to verify the authenticity of the following objects (non
 exhaustive list):
+
 - Messages: Users authenticate their transactions to the blockchain.
 - Tickets: Miner authenticates its ticket (see {{<sref storage_mining_subsystem>}}).
 - Blocks: Block leader signs over all data in the block. 
@@ -86,8 +87,10 @@ Filecoin uses the [BLS signature scheme](https://datatracker.ietf.org/doc/draft-
 curve which generally yield three groups: G_1, G_2 and G_T. In the BLS signature
 scheme, there is a choice on which group to define the public key and the
 signature:
+
 - Public key is on G_1 and signature on G_2
 - Public key is on G_2 and signature on G_1
+
 The group G_1 is "smaller" and hence offer faster arithmetic operations and
 smaller byte representation of its elements. Filecoin currently uses the group
 **G_1 for representing public keys** and the group **G_2 for representing
@@ -100,6 +103,7 @@ explained in the [RFC Section
 **Rationale**: 
 BLS signatures have two main characteristics that are making them ideal
 candidates in recent blockchain systems:
+
 - BLS signatures are deterministic: for a given message and a given secret key,
   the signature is always the same.  That feature removes an important security 
   weakness of most randomized signature schemes: signer must never re-use the
@@ -120,6 +124,7 @@ PK2, sig12 = sig1 + sig2)` then aggregate with the third tuple to produce
 vulnerable to rogue-key attacks where the attacker can freely choose its public
 key. To prevent against this class of attacks there exists three different kind
 of measures, as explained [here](https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html):
+
 - Enforce distinct messages
 - Prove knowledge of the secret key
 - Use a modified scheme (such as [BLS Multi Sig](https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html))

--- a/src/algorithms/expected_consensus/_index.md
+++ b/src/algorithms/expected_consensus/_index.md
@@ -175,7 +175,7 @@ When selecting between Tipsets of equal weight, a miner chooses the one with the
 
 In the case where two Tipsets of equal weight have the same min ticket, the miner will compare the next smallest ticket (and select the Tipset with the next smaller ticket). This continues until one Tipset is selected.
 
-The above case may happen in situations under certain block propagation conditions. Assume three blocks B, C, and D have been mined (by miners 1, 2, and 3 respectively) off of block A, with minTicket(B) < minTicket(C) < minTicket (D).
+The above case may happen in situations under certain block propagation conditions. Assume three blocks B, C, and D have been mined (by miners 1, 2, and 3 respectively) off of block A, with minTicket(B) < minTicket(C) < minTicket(D).
 
 Miner 1 outputs their block B and shuts down. Miners 2 and 3 both receive B but not each others' blocks. We have miner 2 mining a Tipset made of B and C and miner 3 mining a Tipset made of B and D. If both succesfully mine blocks now, other miners in the network will receive new blocks built off of Tipsets with equal weight and the same smallest ticket (that of block B). They should select the block mined atop [B, C] since minTicket(C) < minTicket(D).
 

--- a/src/algorithms/porep/stacked_drg.md
+++ b/src/algorithms/porep/stacked_drg.md
@@ -218,7 +218,8 @@ The Replication Algorithm  proceeds as follows:
 
 - Calculate `ReplicaID` using `Hash` (SHA256):
 
-`ReplicaID` is a 32-byte array constructed by hashing the concatenation of the following values
+`ReplicaID` is a 32-byte array constructed by hashing the concatenation of the following values:
+
 - `ProverId` is a 32-byte array uniquely identifying a prover.
 - `SectorNumber` is an unsigned 64-bit integer in little-endian encoding represented as an 8-byte array.
 - `RandomSeed` is a 32-byte array of randomness extracted from the chain.

--- a/src/algorithms/post/election_post.md
+++ b/src/algorithms/post/election_post.md
@@ -5,6 +5,7 @@ title: Election PoSt
 This document describes Election-PoSt, the Proof-of-Spacetime used in Filecoin.
 
 At a high-level it marries `ElectionPoSt` with a `SurprisePoSt` fallback:
+
 - By coupling leader election and PoSt, `ElectionPoSt` ensures that miners must do the work to prove their sectors at every round in order to earn block rewards.
 - Small miners may not win on a regular basis however, `SurprisePoSt` thus comes in as a lower-bound to how often miners must PoSt and helps ensure the Power Table does not grow stale for its long-tail of smaller miners.
 

--- a/src/appendix/sharray.md
+++ b/src/appendix/sharray.md
@@ -24,7 +24,8 @@ We use DAG-CBOR for serialization, and blake2b-256 for hashing.
 # Construction
 
 The tree must not be sparse.
-Given an array of size `N` and a fixed width of `W`.
+Given an array of size `N` and a fixed width of `W`:
+
 - The left `floor(N/W)` leaves contain the first `N` items.
 - If `N % W != 0` the final leaf contains the final remainder.
 - The tree is perfectly balanced.

--- a/src/systems/filecoin_blockchain/storage_power_consensus/_index.md
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/_index.md
@@ -88,7 +88,8 @@ While true:
 newRandomness = H(TicketDrawDST || index || Serialization(epoch || pastTicketOutput))
 ```
 
-In english, this means two things:
+In plain language, this means two things:
+
 - Choose the smallest ticket in the Tipset if it contains multiple blocks.
 - When sampling a ticket from an epoch with no blocks, draw the min ticket from the prior epoch with blocks and concatenate it with
     - the wanted epoch number
@@ -151,6 +152,7 @@ The below values are currently placeholders.
 {{% /notice %}}
 
 We currently set:
+
 - `MIN_MINER_SIZE_STOR = 1 << 40 Bytes` (100 TiB)
 - `MIN_MINER_SIZE_TARG = 3
 

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor.md
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor.md
@@ -46,6 +46,7 @@ Conversely, storage faults only lead to power loss once they are detected (up to
 Put another way, power accounting in the SPC is delayed between storage being proven or faulted, and power being updated in the power table (and so for leader election). This ensures fairness over time.
 
 The Miner lifecycle in the power table should be roughly as follows:
+
 - MinerRegistration: A new miner with an associated worker public key and address is registered on the power table by the storage mining subsystem, along with their associated sector size (there is only one per worker).
 - UpdatePower: These power increments and decrements are called by various storage actor (and must thus be verified by every full node on the network). Specifically:
     - Power is incremented to account for a new SectorCommitment at the first PoSt past the first ProvingPeriod.

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor.md
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor.md
@@ -66,5 +66,6 @@ Pledge collateral amount is committed based on power pledged to the system (i.e.
 Pledge Collateral will be slashed when {{<sref consensus_faults>}} are reported to the `StoragePowerActor`'s `ReportConsensusFault` method or when the `CronActor` calls the `StoragePowerActor`'s `ReportUncommittedPowerFault` method.
 
 Pledge Collateral is slashed for any fault affecting storage-power consensus, these include:
+
 - faults to expected consensus in particular (see {{<sref consensus_faults>}}) which will be reported by a slasher to the `StoragePowerActor` in exchange for a reward.
 - faults affecting consensus power more generally, specifically uncommitted power faults (i.e. {{<sref storage_faults>}}) which will be reported by the `CronActor` automatically.

--- a/src/systems/filecoin_files/data_transfer/_index.md
+++ b/src/systems/filecoin_files/data_transfer/_index.md
@@ -8,7 +8,7 @@ _Data Transfer_ is a system for transferring all or part of a `Piece` across the
 
 # Modules
 
-This diagram shows how Data Tranfer and its modules fit into the picture with the Storage and Retrieval Markets.
+This diagram shows how Data Transfer and its modules fit into the picture with the Storage and Retrieval Markets.
 In particular, note how the Data Transfer Request Validators from the markets are plugged into the Data Transfer module,
 but their code belongs in the Markets system.
 

--- a/src/systems/filecoin_mining/storage_proving/_index.md
+++ b/src/systems/filecoin_mining/storage_proving/_index.md
@@ -6,6 +6,6 @@ entries:
 - poster
 ---
 
-Filecoin Poving Subsystem
+Filecoin Proving Subsystem
 
 {{< readfile file="storage_proving_subsystem.id" code="true" lang="go" >}}

--- a/src/systems/filecoin_nodes/repository/key_store/_index.md
+++ b/src/systems/filecoin_nodes/repository/key_store/_index.md
@@ -11,6 +11,7 @@ Node security depends in large part on keeping these keys secure. To that end we
 {{< readfile file="key_store.go" code="true" lang="go" >}}
 
 Filecoin storage miners rely on three main components:
+
 - **The miner address** uniquely assigned to a given storage miner actor upon calling `registerMiner()` in the Storage Power Consensus Subsystem. It is a unique identifier for a given storage miner to which its power and other keys will be associated.
 - **The owner keypair** is provided by the miner ahead of registration and its public key associated to the miner address. Block rewards and other payments are made to the ownerAddress.
 - **The worker keypair** can be chosen and changed by the miner, its public key associated to the miner address. It is used to sign transactions, signatures, etc.


### PR DESCRIPTION
- Fix some spelling errors
- Add blank line before bullet points, so that website renders them correctly (see https://filecoin-project.github.io/specs/#systems__filecoin_nodes__key_store for example of current rendering)