### PR TITLE
Patch/min miner size

### DIFF
--- a/src/algorithms/post/election_post.md
+++ b/src/algorithms/post/election_post.md
@@ -234,7 +234,7 @@ Each reported fault carries a penality with it.
 
 # Miner Onboarding
 
-Storage Power Consensus participants are subject to a {{<sref min_miner_size>}}, meaning miners smaller than `MIN_MINER_SIZE_STOR` of active (or in-deal) storage or whose active storage represents less than `MIN_MINER_SIZE_PERC`% of the network's cannot produce valid electionPoSts. 
+Storage Power Consensus participants are subject to a {{<sref min_miner_size>}}, meaning miners smaller than `MIN_MINER_SIZE_STOR` of active (or in-deal) storage cannot produce valid electionPoSts. 
 
 These miners' power does not count as part of the total network power, nor are they able to sumit electionPoSts but they can still run and transmit SurprisePosts as messages to be added on-chain. These miners can also be faulted as usual for lacking to prove their power after a challenge. 
 

--- a/src/systems/filecoin_blockchain/storage_power_consensus/_index.md
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/_index.md
@@ -133,13 +133,13 @@ Note that a miner may attempt to grind through tickets by incrementing the nonce
 
 In order to secure Storage Power Consensus, the system defines a minimum miner size required to participate in consensus.
 
-Specifically, miners must have either at least `MIN_MINER_SIZE_STOR` of power (i.e. storage power currently used in storage deals) or `MIN_MINER_SIZE_PERC` of the network's active storage power to participate in leader election.
+Specifically, miners must have either at least `MIN_MINER_SIZE_STOR` of power (i.e. storage power currently used in storage deals) in order to participate in leader election. If no miner has `MIN_MINER_SIZE_STOR` power, miners in the top `MIN_MINER_SIZE_TOP` of miners by storage power will be able to participate in leader election.
 
 Miners smaller than this cannot mine blocks and earn block rewards in the network. Their power will not be counted as part of total network power. However, **it is important to note that such miners can still have their power faulted and be penalized accordingly**.
 
 Accordingly, to bootstrap the network, the genesis block must include miners taking part in valid storage deals along with appropriate committed storage.
 
-The `MIN_MINER_SIZE_PERC` condition will not be used in a network with more than `MIN_MINER_SIZE_STOR/MIN_MINER_SIZE_PERC` of power. It is nonetheless defined to ensure liveness in small networks (e.g. close to genesis or after large power drops). Simply, a single miner can maintain network liveness for networks with less than `MIN_MINER_SIZE_STOR/MIN_MINER_SIZE_PERC` of active storage.
+The `MIN_MINER_SIZE_TOP` condition will not be used in a network in which any miner has more than `MIN_MINER_SIZE_STOR` power. It is nonetheless defined to ensure liveness in small networks (e.g. close to genesis or after large power drops).
 
 {{% notice placeholder %}}
 The below values are currently placeholders.
@@ -147,4 +147,4 @@ The below values are currently placeholders.
 
 We currently set:
 - `MIN_MINER_SIZE_STOR = 1 << 40 Bytes` (100 TiB)
-- `MIN_MINER_SIZE_PERC = .33`
+- `MIN_MINER_SIZE_PERC = 3

--- a/src/systems/filecoin_blockchain/storage_power_consensus/_index.md
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/_index.md
@@ -133,13 +133,13 @@ Note that a miner may attempt to grind through tickets by incrementing the nonce
 
 In order to secure Storage Power Consensus, the system defines a minimum miner size required to participate in consensus.
 
-Specifically, miners must have either at least `MIN_MINER_SIZE_STOR` of power (i.e. storage power currently used in storage deals) in order to participate in leader election. If no miner has `MIN_MINER_SIZE_STOR` power, miners in the top `MIN_MINER_SIZE_TOP` of miners by storage power will be able to participate in leader election.
+Specifically, miners must have either at least `MIN_MINER_SIZE_STOR` of power (i.e. storage power currently used in storage deals) in order to participate in leader election. If no miner has `MIN_MINER_SIZE_STOR` power, miners in the top `MIN_MINER_SIZE_TARG` of miners by storage power will be able to participate in leader election.
 
 Miners smaller than this cannot mine blocks and earn block rewards in the network. Their power will not be counted as part of total network power. However, **it is important to note that such miners can still have their power faulted and be penalized accordingly**.
 
 Accordingly, to bootstrap the network, the genesis block must include miners taking part in valid storage deals along with appropriate committed storage.
 
-The `MIN_MINER_SIZE_TOP` condition will not be used in a network in which any miner has more than `MIN_MINER_SIZE_STOR` power. It is nonetheless defined to ensure liveness in small networks (e.g. close to genesis or after large power drops).
+The `MIN_MINER_SIZE_TARG` condition will not be used in a network in which any miner has more than `MIN_MINER_SIZE_STOR` power. It is nonetheless defined to ensure liveness in small networks (e.g. close to genesis or after large power drops).
 
 {{% notice placeholder %}}
 The below values are currently placeholders.
@@ -147,4 +147,8 @@ The below values are currently placeholders.
 
 We currently set:
 - `MIN_MINER_SIZE_STOR = 1 << 40 Bytes` (100 TiB)
-- `MIN_MINER_SIZE_PERC = 3
+- `MIN_MINER_SIZE_TARG = 3
+
+## Network recovery after halting
+
+Placeholder where we will define a means of rebooting network liveness after it halts catastrophically (i.e. empty power table).

--- a/src/systems/filecoin_blockchain/storage_power_consensus/_index.md
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/_index.md
@@ -133,7 +133,7 @@ Note that a miner may attempt to grind through tickets by incrementing the nonce
 
 In order to secure Storage Power Consensus, the system defines a minimum miner size required to participate in consensus.
 
-Specifically, miners must have either at least `MIN_MINER_SIZE_STOR` of power (i.e. storage power currently used in storage deals) in order to participate in leader election. If no miner has `MIN_MINER_SIZE_STOR` power, miners in the top `MIN_MINER_SIZE_TARG` of miners by storage power will be able to participate in leader election.
+Specifically, miners must have either at least `MIN_MINER_SIZE_STOR` of power (i.e. storage power currently used in storage deals) in order to participate in leader election. If no miner has `MIN_MINER_SIZE_STOR` or more power, miners with at least as much power as the smallest miner in the top `MIN_MINER_SIZE_TARG` of miners (sorted by storage power) will be able to participate in leader election. In plain english, take `MIN_MINER_SIZE_TARG = 3` for instance, this means that miners with at least as much power as the 3rd largest miner will be eligible to participate in consensus.
 
 Miners smaller than this cannot mine blocks and earn block rewards in the network. Their power will not be counted as part of total network power. However, **it is important to note that such miners can still have their power faulted and be penalized accordingly**.
 

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor.id
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor.id
@@ -18,8 +18,8 @@ type PowerReport struct {
 type PowerTableHAMT {addr.Address: PowerTableEntry}  // TODO: convert address to ActorID
 
 type StoragePowerActorState struct {
-    PowerTable   PowerTableHAMT
-    EscrowTable  actor.BalanceTableHAMT
+    PowerTable            PowerTableHAMT
+    EscrowTable           actor.BalanceTableHAMT
     _minersLargerThanMin  util.UVarint
 
     _slashPledgeCollateral(rt Runtime, address addr.Address, amount actor.TokenAmount) actor.TokenAmount

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor.id
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor.id
@@ -20,6 +20,7 @@ type PowerTableHAMT {addr.Address: PowerTableEntry}  // TODO: convert address to
 type StoragePowerActorState struct {
     PowerTable   PowerTableHAMT
     EscrowTable  actor.BalanceTableHAMT
+    _minersLargerThanMin  util.UVarint
 
     _slashPledgeCollateral(rt Runtime, address addr.Address, amount actor.TokenAmount) actor.TokenAmount
     _lockPledgeCollateral(rt Runtime, address addr.Address, amount actor.TokenAmount)

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_code.go
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_code.go
@@ -241,6 +241,16 @@ func (a *StoragePowerActorCode_I) ProcessPowerReport(rt Runtime, report PowerRep
 	h, st := a.State(rt)
 
 	powerEntry := st._safeGetPowerEntry(rt, minerID)
+
+	// keep track of miners larger than minimum miner size before updating the PT
+	MIN_MINER_SIZE_STOR := block.StoragePower(0) // TODO: pull in from consts
+	if powerEntry.ActivePower() >= MIN_MINER_SIZE_STOR && report.ActivePower() < MIN_MINER_SIZE_STOR {
+		st.Impl()._minersLargerThanMin_ -= 1
+	}
+	if powerEntry.ActivePower() < MIN_MINER_SIZE_STOR && report.ActivePower() >= MIN_MINER_SIZE_STOR {
+		st.Impl()._minersLargerThanMin_ += 1
+	}
+
 	powerEntry.Impl().ActivePower_ = report.ActivePower()
 	powerEntry.Impl().InactivePower_ = report.InactivePower()
 	st.Impl().PowerTable_[minerID] = powerEntry

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_state.go
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_state.go
@@ -15,13 +15,18 @@ func (st *StoragePowerActorState_I) ActivePowerMeetsConsensusMinimum(minerPower 
 	MIN_MINER_SIZE_STOR := block.StoragePower(0)
 	MIN_MINER_SIZE_TARG := 0
 
-	// if a miner meets min power requirement check whether this one does
+	// if miner is larger than min power requirement, we're set
+	if minerPower >= MIN_MINER_SIZE_STOR {
+		return true
+	}
+
+	// otherwise, if another miner meets min power requirement check whether this one does
 	if st._minersLargerThanMin() > util.UVarint(0) {
 		return minerPower >= MIN_MINER_SIZE_STOR
 	}
 
 	// else check whether in MIN_MINER_SIZE_TARG miners
-	if len(st.PowerTable()) < MIN_MINER_SIZE_TARG {
+	if len(st.PowerTable()) <= MIN_MINER_SIZE_TARG {
 		// miner should pass
 		return true
 	}
@@ -31,7 +36,7 @@ func (st *StoragePowerActorState_I) ActivePowerMeetsConsensusMinimum(minerPower 
 	for _, v := range st.PowerTable() {
 		minerSizes = append(minerSizes, v.ActivePower())
 	}
-	sort.Slice(minerSizes, func(i, j int) bool { return int(i) < int(j) })
+	sort.Slice(minerSizes, func(i, j int) bool { return int(i) > int(j) })
 	return minerPower >= minerSizes[MIN_MINER_SIZE_TARG-1]
 }
 

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_state.go
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_state.go
@@ -20,12 +20,12 @@ func (st *StoragePowerActorState_I) ActivePowerMeetsConsensusMinimum(minerPower 
 		return true
 	}
 
-	// otherwise, if another miner meets min power requirement check whether this one does
+	// otherwise, if another miner meets min power requirement, return false
 	if st._minersLargerThanMin() > util.UVarint(0) {
-		return minerPower >= MIN_MINER_SIZE_STOR
+		return false
 	}
 
-	// else check whether in MIN_MINER_SIZE_TARG miners
+	// else if none do, check whether in MIN_MINER_SIZE_TARG miners
 	if len(st.PowerTable()) <= MIN_MINER_SIZE_TARG {
 		// miner should pass
 		return true

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_state.go
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_state.go
@@ -1,6 +1,8 @@
 package storage_power_consensus
 
 import (
+	"sort"
+
 	filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
 	block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
 	actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
@@ -9,17 +11,28 @@ import (
 )
 
 func (st *StoragePowerActorState_I) ActivePowerMeetsConsensusMinimum(minerPower block.StoragePower) bool {
-	totPower := st._getActivePower()
-
 	// TODO import from consts
 	MIN_MINER_SIZE_STOR := block.StoragePower(0)
-	MIN_MINER_SIZE_PERC := 0
+	MIN_MINER_SIZE_TARG := 0
 
-	// if miner smaller than both min size in bytes and min percentage
-	if (int(minerPower)*MIN_MINER_SIZE_PERC < int(totPower)*100) && minerPower < MIN_MINER_SIZE_STOR {
-		return false
+	// if a miner meets min power requirement check whether this one does
+	if st._minersLargerThanMin() > util.UVarint(0) {
+		return minerPower >= MIN_MINER_SIZE_STOR
 	}
-	return true
+
+	// else check whether in MIN_MINER_SIZE_TARG miners
+	if len(st.PowerTable()) < MIN_MINER_SIZE_TARG {
+		// miner should pass
+		return true
+	}
+
+	// get size of MIN_MINER_SIZE_TARGth largest miner
+	minerSizes := make([]block.StoragePower, 0, len(st.PowerTable()))
+	for _, v := range st.PowerTable() {
+		minerSizes = append(minerSizes, v.ActivePower())
+	}
+	sort.Slice(minerSizes, func(i, j int) bool { return int(i) < int(j) })
+	return minerPower >= minerSizes[MIN_MINER_SIZE_TARG-1]
 }
 
 func (st *StoragePowerActorState_I) _getActivePower() block.StoragePower {

--- a/src/systems/filecoin_mining/storage_mining/constants.go
+++ b/src/systems/filecoin_mining/storage_mining/constants.go
@@ -26,8 +26,8 @@ const EPOST_SAMPLE_RATE_DENOM = 25 // placeholder
 const SPOST_SAMPLE_RATE_NUM = 1    // placeholder
 const SPOST_SAMPLE_RATE_DENOM = 50 // placeholder
 
-const MIN_MINER_SIZE_STOR = 1 << 40 // placeholder
-const MIN_MINER_SIZE_PERC = 33      // placeholder, 100 TB
+const MIN_MINER_SIZE_STOR = 1 << 40 // placeholder, 100 TB
+const MIN_MINER_SIZE_TOP = 3        // placeholder
 
 // FIL deposit per sector precommit in Interactive PoRep
 // refunded after ProveCommit but burned if PreCommit expires

--- a/src/systems/filecoin_mining/storage_mining/constants.go
+++ b/src/systems/filecoin_mining/storage_mining/constants.go
@@ -27,7 +27,7 @@ const SPOST_SAMPLE_RATE_NUM = 1    // placeholder
 const SPOST_SAMPLE_RATE_DENOM = 50 // placeholder
 
 const MIN_MINER_SIZE_STOR = 1 << 40 // placeholder, 100 TB
-const MIN_MINER_SIZE_TOP = 3        // placeholder
+const MIN_MINER_SIZE_TARG = 3       // placeholder
 
 // FIL deposit per sector precommit in Interactive PoRep
 // refunded after ProveCommit but burned if PreCommit expires


### PR DESCRIPTION
- added a note about future solutions to network reboot in case of total loss of liveness
- changed min miner rule to be about largest X miners rather than a percentage

Note that: 
- I don't show impl how to set `_largestMinerSize`
- conversely I do show how to check if miner is in top `MIN_MINER_SIZE_TARG` of the PT

Q: @anorth should I replace the entire body with `IMPL()` to signal that it's impl-choice, or conversely should I show how you set _lMS?