### PR TITLE
remove sector utilization

### DIFF
--- a/src/systems/filecoin_markets/deal/deal.go
+++ b/src/systems/filecoin_markets/deal/deal.go
@@ -47,28 +47,3 @@ func (p *StorageDealProposal_I) CID() ProposalCID {
 	var cid ProposalCID
 	return cid
 }
-
-func (amt *DealExpirationAMT_I) Size() int {
-	return 0
-}
-
-func (amt *DealExpirationAMT_I) Add(key block.ChainEpoch, value DealExpirationValue) {
-	// helper function to add entry into the AMT
-}
-
-func (amt *DealExpirationAMT_I) ActiveDealIDs() []DealID {
-	ret := make([]DealID, 0)
-	return ret
-}
-
-// return last item in the expiration amt
-func (q *DealExpirationAMT_I) LastDealExpiration() block.ChainEpoch {
-	ret := block.ChainEpoch(0)
-	return ret
-}
-
-// return deal IDs expiring in epoch range
-func (q *DealExpirationAMT_I) ExpiredDealsInRange(start block.ChainEpoch, end block.ChainEpoch) []DealExpirationValue {
-	ret := make([]DealExpirationValue, 0)
-	return ret
-}

--- a/src/systems/filecoin_markets/deal/deal.id
+++ b/src/systems/filecoin_markets/deal/deal.id
@@ -57,19 +57,6 @@ type OnChainDeal struct {
     ID                DealID
 }
 
-// AMT from expiration epoch to dealID and to sectorNumber
-// defined as struct to specify helpers
-// effectively an AMT of the form DealExpirationAMT[Expiration][DealID] = PayloadPower
-type DealExpirationAMT struct {
-    Expiration  block.ChainEpoch  // key
-    Value       DealExpirationValue  // value
-}
-
-type DealExpirationValue struct {
-    ID     DealID  // key
-    Power  block.StoragePower  // value
-}
-
 type RetrievalDealProposal struct {}  // TODO
 type RetrievalDeal struct {
     Proposal          RetrievalDealProposal

--- a/src/systems/filecoin_markets/storage_market/storage_market_actor.id
+++ b/src/systems/filecoin_markets/storage_market/storage_market_actor.id
@@ -43,10 +43,17 @@ type StorageMarketActorState struct {
     _lockFundsForStorageDeal(rt Runtime, deal deal.StorageDeal)
 
     _safeGetOnChainDeal(rt Runtime, dealID deal.DealID) deal.OnChainDeal
+    _getOnChainDeal(dealID deal.DealID) (deal deal.OnChainDeal, ok bool)
     _safeGetBalance(rt Runtime, participant addr.Address) StorageParticipantBalance
     _assertPublishedDealState(rt Runtime, dealID deal.DealID)
     _assertActiveDealState(rt Runtime, dealID deal.DealID)
+    _assertEpochEqual(rt Runtime, epoch1 block.ChainEpoch, epoch2 block.ChainEpoch)
     _activateDeal(rt Runtime, deal deal.OnChainDeal) deal.OnChainDeal
+    _getSectorPowerFromDeals(
+        sectorDuration  block.ChainEpoch
+        sectorSize      block.StoragePower
+        dealPs          [deal.StorageDealProposal]
+    ) block.StoragePower
 
     _getStorageFeeSinceLastPayment(
         rt               Runtime
@@ -59,6 +66,8 @@ type StorageMarketActorState struct {
         rt      Runtime
         amount  actor.TokenAmount
     ) actor.TokenAmount
+
+    _refundStartedDeals(rt Runtime, dealIDs [deal.DealID])
 }
 
 type StorageMarketActorCode struct {

--- a/src/systems/filecoin_markets/storage_market/storage_market_actor_state.go
+++ b/src/systems/filecoin_markets/storage_market/storage_market_actor_state.go
@@ -108,7 +108,7 @@ func (st *StorageMarketActorState_I) _assertDealExpireAfterMaxProveCommitWindow(
 
 }
 
-// Call by PublishStorageDeals and GetInitialUtilization (consider remove this)
+// Call by PublishStorageDeals
 // This is the check before a StorageDeal appears onchain
 // It checks the following:
 //   - verify deal did not expire when it is signed
@@ -189,8 +189,16 @@ func (st *StorageMarketActorState_I) _lockFundsForStorageDeal(rt Runtime, deal d
 	st._lockBalance(rt, p.Provider(), p.ProviderBalanceRequirement())
 }
 
-func (st *StorageMarketActorState_I) _safeGetOnChainDeal(rt Runtime, dealID deal.DealID) deal.OnChainDeal {
+func (st *StorageMarketActorState_I) _getOnchainDeal(dealID deal.DealID) (deal deal.OnChainDeal, ok bool) {
 	deal, found := st.Deals()[dealID]
+	if !found {
+		return nil, false
+	}
+	return deal, true
+}
+
+func (st *StorageMarketActorState_I) _safeGetOnChainDeal(rt Runtime, dealID deal.DealID) deal.OnChainDeal {
+	deal, found := st._getOnchainDeal(dealID)
 	if !found {
 		rt.AbortStateMsg("sm._safeGetOnChainDeal: dealID not found in Deals.")
 	}
@@ -286,4 +294,17 @@ func (st *StorageMarketActorState_I) _terminateDeal(rt Runtime, dealID deal.Deal
 	st._unlockBalance(rt, dealP.Client(), clientCollateral+lockedFee)
 
 	return st._slashDealCollateral(rt, dealP)
+}
+
+func (st *StorageMarketActorState_I) _assertEpochEqual(rt Runtime, epoch1 block.ChainEpoch, epoch2 block.ChainEpoch) {
+	if epoch1 != epoch2 {
+		rt.AbortArgMsg("sm._assertEpochEqual: different epochs")
+	}
+}
+
+func (st *StorageMarketActorState_I) _getSectorPowerFromDeals(sectorDuration block.ChainEpoch, sectorSize block.StoragePower, dealPs []deal.StorageDealProposal) block.StoragePower {
+	TODO()
+
+	ret := block.StoragePower(0)
+	return ret
 }

--- a/src/systems/filecoin_mining/sector/sealing.id
+++ b/src/systems/filecoin_mining/sector/sealing.id
@@ -62,6 +62,7 @@ type SectorProveCommitInfo struct {
     SectorNumber
     Proof             SealProof
     InteractiveEpoch  block.ChainEpoch
+    Expiration        block.ChainEpoch
 }
 
 // PersistentProofAux is meta data required to generate certain proofs

--- a/src/systems/filecoin_mining/sector/sector.id
+++ b/src/systems/filecoin_mining/sector/sector.id
@@ -2,7 +2,6 @@ import piece "github.com/filecoin-project/specs/systems/filecoin_files/piece"
 import ipld "github.com/filecoin-project/specs/libraries/ipld"
 import deal "github.com/filecoin-project/specs/systems/filecoin_markets/deal"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
-import block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
 
 type Bytes32 Bytes
 type MinerID addr.Address
@@ -16,12 +15,6 @@ type SectorNumber UInt
 
 type FaultSet CompactSectorSet
 type StorageFaultType int
-
-type SectorUtilizationInfo struct {
-    DealExpirationAMT  deal.DealExpirationAMT
-    MaxUtilization     block.StoragePower
-    CurrUtilization    block.StoragePower
-}
 
 // SectorSize indicates one of a set of possible sizes in the network.
 type SectorSize UInt

--- a/src/systems/filecoin_mining/storage_mining/challenge_status.go
+++ b/src/systems/filecoin_mining/storage_mining/challenge_status.go
@@ -27,6 +27,10 @@ func (cs *ChallengeStatus_I) LastPoStResponseEpoch() block.ChainEpoch {
 	return block.ChainEpoch(math.Max(float64(cs._lastPoStSuccessEpoch()), float64(cs._lastPoStFailureEpoch())))
 }
 
+func (cs *ChallengeStatus_I) LastPoStSuccessEpoch() block.ChainEpoch {
+	return cs._lastPoStSuccessEpoch()
+}
+
 func (cs *ChallengeStatus_I) IsChallenged() bool {
 	// true if most recent challenge has gone unanswered (with a PoSt or a failure)
 	return cs.LastChallengeEpoch() > cs.LastPoStResponseEpoch()

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
@@ -1,9 +1,9 @@
 import libp2p "github.com/filecoin-project/specs/libraries/libp2p"
 import sealing "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
+import deal "github.com/filecoin-project/specs/systems/filecoin_markets/deal"
 import address "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
-import deal "github.com/filecoin-project/specs/systems/filecoin_markets/deal"
 import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 import stateTree "github.com/filecoin-project/specs/systems/filecoin_vm/state_tree"
 import spc "github.com/filecoin-project/specs/systems/filecoin_blockchain/storage_power_consensus"
@@ -20,7 +20,7 @@ type SectorExpirationQueue struct {
     Remove(n sector.SectorNumber)
 }
 
-type SectorTable struct {
+type SectorStateTable struct {
     SectorSize         sector.SectorSize
     ActiveSectors      sector.CompactSectorSet
     CommittedSectors   sector.CompactSectorSet
@@ -31,14 +31,12 @@ type SectorTable struct {
     TerminatedFaults   sector.CompactSectorSet
 }
 
-type StagedCommittedSectorInfo struct {
-    Sector       SectorOnChainInfo
-    Utilization  sector.SectorUtilizationInfo
-}
-
 type SectorOnChainInfo struct {
     SealCommitment  sector.SealCommitment
     State           SectorState
+    Power           block.StoragePower
+    Activation      block.ChainEpoch
+    Expiration      block.ChainEpoch
 }
 
 type ChallengeStatus struct {
@@ -50,6 +48,7 @@ type ChallengeStatus struct {
 
     OnNewChallenge(currEpoch block.ChainEpoch)
     LastPoStResponseEpoch() block.ChainEpoch
+    LastPoStSuccessEpoch() block.ChainEpoch
     OnPoStSuccess(currEpoch block.ChainEpoch)
     OnPoStFailure(currEpoch block.ChainEpoch)
 
@@ -67,21 +66,17 @@ type PreCommittedSector struct {
 }
 
 type PreCommittedSectorsAMT {sector.SectorNumber: PreCommittedSector}
-type StagedCommittedSectorAMT {sector.SectorNumber: StagedCommittedSectorInfo}
+type StagedCommittedSectorAMT {sector.SectorNumber: SectorOnChainInfo}
 type SectorsAMT {sector.SectorNumber: SectorOnChainInfo}
-
-// map from SectorNumber to amout of storage in active deals
-type SectorUtilizationAMT {sector.SectorNumber: sector.SectorUtilizationInfo}
 
 // Balance of a StorageMinerActor should equal exactly the sum of PreCommit deposits that are not yet returned or burned
 type StorageMinerActorState struct {
     PreCommittedSectors     PreCommittedSectorsAMT
     StagedCommittedSectors  StagedCommittedSectorAMT
     Sectors                 SectorsAMT
-    SectorUtilization       SectorUtilizationAMT
     ProvingSet              sector.CompactSectorSet
 
-    SectorTable
+    SectorTable             SectorStateTable
     SectorExpirationQueue
     ChallengeStatus
 
@@ -104,17 +99,17 @@ type StorageMinerActorState struct {
         sectorNo             sector.SectorNumber
         incrementFaultCount  bool
     )
-    _updateExpireSectors(rt Runtime)
+    _updateExpireSectors(rt Runtime) [sector.SectorNumber]
     _updateClearSector(rt Runtime, sectorNo sector.SectorNumber)
     _updateActivateSector(rt Runtime, sectorNo sector.SectorNumber)
-    _updateSectorUtilization(rt Runtime, lastPoStResponse block.ChainEpoch) [deal.DealID]
-    _initializeUtilizationInfo(rt Runtime, deals [deal.OnChainDeal]) sector.SectorUtilizationInfo
 
     _getActivePower()    (block.StoragePower, error)
     _getInactivePower()  (block.StoragePower, error)
-    _safeGetUtilizationInfo(rt Runtime, sectorNo sector.SectorNumber) sector.SectorUtilizationInfo
-    _getUtilizationInfo(sectorNo sector.SectorNumber) (sector.SectorUtilizationInfo, error)
     _getPreCommitDepositReq(rt Runtime) actor.TokenAmount
+
+    _getSectorOnChainInfo(sectorNo sector.SectorNumber) (info SectorOnChainInfo, ok bool)
+    _getSectorPower(sectorNo sector.SectorNumber) (power block.StoragePower, ok bool)
+    _getSectorDealIDs(sectorNo sector.SectorNumber) (dealIDs [deal.DealID], ok bool)
 }
 
 type StorageMinerActorCode struct {
@@ -148,8 +143,13 @@ type StorageMinerActorCode struct {
         faultType      sector.StorageFaultType
     )
 
-    _claimDealPayments(rt Runtime)
+    ClaimDealPaymentsForSector(
+        rt        Runtime
+        sectorNo  sector.SectorNumber
+        lastPoSt  block.ChainEpoch
+    )
     _submitPowerReport(rt Runtime, lastPoSt block.ChainEpoch)
+    _expireSectors(rt Runtime)
     _expirePreCommittedSectors(rt Runtime)
     _ensurePledgeCollateralSatisfied(rt Runtime)
 }

--- a/src/systems/filecoin_mining/storage_mining/storage_mining_subsystem.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_mining_subsystem.go
@@ -90,12 +90,11 @@ func (sms *StorageMiningSubsystem_I) _tryLeaderElection() {
 	numMinerSectors := uint64(len(st.SectorTable().Impl().ActiveSectors_.SectorsOn()))
 	for _, candidate := range candidates {
 		sectorNum := candidate.SectorID().Number()
-		utilInfo, err := st._getUtilizationInfo(sectorNum)
-		if err != nil {
+		sectorPower, ok := st._getSectorPower(sectorNum)
+		if !ok {
 			// panic(err)
 			return
 		}
-		sectorPower := utilInfo.CurrUtilization()
 		if sms._consensus().IsWinningPartialTicket(currState, candidate.PartialTicket(), sectorPower, numMinerSectors) {
 			winningCandidates = append(winningCandidates, candidate)
 		}
@@ -323,12 +322,11 @@ func (sms *StorageMiningSubsystem_I) VerifyElection(header block.BlockHeader, on
 
 	for _, info := range onChainInfo.Candidates() {
 		sectorNum := info.SectorID().Number()
-		utilInfo, err := st._getUtilizationInfo(sectorNum)
-		if err != nil {
+		sectorPower, ok := st._getSectorPower(sectorNum)
+		if !ok {
 			// panic(err)
 			return false
 		}
-		sectorPower := utilInfo.CurrUtilization()
 		if !sms._consensus().IsWinningPartialTicket(header.ParentState(), info.PartialTicket(), sectorPower, numMinerSectors) {
 			return false
 		}


### PR DESCRIPTION
**In this PR**
- [x] Every sector now contains an Activation epoch (when ProveCommit hits the chain) and an Expiration epoch (when the last deal in the sector expires)
- [x] Every sector is assigned a power that remains constant throughout its life time, this power is a function of duration of the sector, size of the sector, and deals' start and end times within the sector
- [x] Remove SectorUtilization from StorageMiner and DealExpirationAMT from Deal

**EDIT: In future PR:**
- [ ] Deal payments and expiration are evaluated lazily but remaining payment and expiration will be done at sector expiration  (still need some work)