### PR TITLE
Patch/surprise target

### DIFF
--- a/src/algorithms/post/election_post.md
+++ b/src/algorithms/post/election_post.md
@@ -20,15 +20,13 @@ The Election-PoSt construction includes a Surprise PoSt cleanup which will rando
 
 ## ElectionPoSt
 
-To enable short PoSt response time, miners are required submit a PoSt when they are elected to mine a block, hence PoSt on election or ElectionPoSt. When miners win a block, they need to immediately generate a PoStProof and submit that along with the winning PartialTickets. Both the PartialTickets and PoStProof are checked at Block Validation by `StoragePowerConsenusSubsystem`. When a block is included, a special message is added that calls `SubmitElectionPoSt` which will process sector updates in the same way as successful `SubmitSurprisePoSt` do.
+To enable short PoSt response time, miners are required submit a PoSt when they are elected to mine a block, hence PoSt on election or ElectionPoSt. When miners win a block, they need to immediately generate a PoStProof and submit that in the block header along with the winning PartialTickets. Both the PartialTickets and PoStProof are checked at Block Validation by `StoragePowerConsenusSubsystem`. When a block is included, a special message is added that calls `SubmitElectionPoSt` which will process sector updates in the same way as successful `SubmitSurprisePoSt` do.
 
 ## SurprisePoSt Cleanup
 
-In the absence of a posted `ElectionPoSt`, the chain randomly challenges a miner to submit a `SurprisePoSt` once per `ProvingPeriod` on expectation to ensure their storage is still accounted for.
+In the absence of a posted `ElectionPoSt`, the chain randomly challenges a miner to submit a `SurprisePoSt` once per `ProvingPeriod` on expectation to ensure their storage is still accounted for. The process is largely the same as for `ElectionPoSt` but a successful `SurprisePoSt` does not entitle a miner to generate a blocks and gains them no reward. It allows them to maintain power in the power table. 
 
 For every miner challenged, a `NotifyOfPoStSurpriseChallenge` is issued and sent as an on-chain message to the chosen `StorageMinerActor`.
-
-The ensuing `SurprisePoSt` does not entitle a miner to generate a blocks and gains them no reward but allows them to maintain power in the power table. 
 `PoStSurprise` will frequently be used by small miners who do not win blocks, and by miners as they are onboarding power to the network (since they will not be able to win ElectionPoSts to start).
 
 # In Detail
@@ -151,22 +149,22 @@ There is no requirement to persist the witnesses (list of merkle proofs) for fai
 
 But while this means a miner will never win blocks from faked power, they won’t be penalized either when storage is lost. How do we ensure that the Power Table is accurate? Likewise, how do we onboard new power since it will not win a block unless it has at least X TB or Y % of the network.
 
-This is why we need PoSt surprise: 
+This is why we need PoSt surprise. The process is largely the same as ElectionPoSt save for a few differences:
 
-Atop ElectionPost, a miner will be surprised with a PoSt challenge in every ProvingPeriod (~2 days). The ProvingPeriod resets whenever the miner publishes a PoSt (election or surprise). 
-This SurprisePoSt will use a challenge drawn from the chain at the start of this recovery period. Its PoStProof must be a proof over the PartialTickets for all sectors a miner is storing (i.e. a miner must submit a PoStProof made up of all partialTickets for all sectors in the `ProvingSet`, not just the winning ones on sampled sectors). For this reason a miner is incentivized to declare faults in order to successfully generate this PoStProof.)
+- A miner will only be surprised if they have not submitted a PoSt in some time (more than `SURPRISE_NO_CHALLENGE_PERIOD` epochs)
+- A miner will have `CHALLENGE_DURATION` epochs to reply
+- The PoSt will be submitted as a message on chain rather than part of the block header
+- After being challenged, a miner will no longer be eligible to submit an ElectionPoSt
 
-Upon receiving a PoSt surprise challenge, a miner has a given ChallengePeriod (~2 hours) past which they, they will lose all their power and a portion of their pledge collateral if they have not submitted a PoSt on chain. This is considered a `DetectedFault` and all sectors in the `ProvingSet` will be marked as `Failing`. No deal collateral will be slashed if miners can recover within the next three proving periods. Note that the exact amount of slashed pledge collateral and pledge collateral function itself are subject to change.
+If a miner fails to respond to the challenge past the `CHALLENGE_DURATION`, they will lose all their power and a portion of their pledge collateral. This is considered a `DetectedFault` and all sectors in the `ProvingSet` will be marked as `Failing`. No deal collateral will be slashed if miners can recover within the next three proving periods. Note that the exact amount of slashed pledge collateral and pledge collateral function itself are subject to change.
 
 Thereafter, the miner will have three more ProvingPeriods (specifically three challenges, so three ProvingPeriods on expectation) to recover their power by submitting a SurprisePoSt. If the miner does not do so, their sectors are permanently terminated and their storage deal collateral slashed (see the StorageMinerActor in the spec).
 
 ## PoStSurprise Challenge
 
-In the absence of an ElectionPost, a miner will be surprised with a PoSt challenge every ProvingPeriod (~2 days) on expectation. This SurprisePoSt will use a challenge drawn from the chain.
+Miners are selected at random to be challenged at every clockTick by the storage power actor (with `_selectMinersToSurprise`), with `len(PowerTable)/ProvingPeriod` miners selected per round (for one challenge per miner per proving period on expectation).
 
-Specifically, miners are selected at random to be challenged at every clockTick by the storage power actor (with `_selectMinersToSurprise`), with `len(PowerTable)/ProvingPeriod` miners selected per round (for one challenge per miner per proving period on expectation).
-If the chosen `StorageMinerActor` is already challenged (`IsChallenged` is True) or they've submitted a post (election or surprise) in the last `SURPRISE_NO_CHALLENGE_PERIOD` epochs, they will not be challenged again.
-That is if `ShouldChallenge` is False, then the PoSt surprise notification will be ignored and return success. 
+If the chosen `StorageMinerActor` is already challenged (`IsChallenged` is True) or they've submitted a post (election or surprise) in the last `SURPRISE_NO_CHALLENGE_PERIOD` epochs, they will not be challenged again. That is if `ShouldChallenge` is False, then the SurprisePoSt notification will be ignored and return success. 
 
 Sampling which miners to surprise works as follows:
 ```text
@@ -193,13 +191,26 @@ The surprise process described above is triggered by the cron actor in the `Stor
 - they are not already selected for a challenge this round,
 - their last PoSt (election or surprise) is older than `SURPRISE_NO_CHALLENGE_PERIOD` epochs.
 
+Once issued a surprise, a miner will have to challenge the sectors in their `ProvingSet`, generating a number of partial tickets determined by a sampling rate (`SPOST_SAMPLE_RATE`). In the system here, we use the same system calls as above:
+
+- `GenerateCandidates` which takes in the miner's sectors and a wanted number of Challenge Tickets and generates a number of inclusion proofs for a number of challenged sectors chosen randomly in proportion to the requested number of challenged tickets.
+- `GeneratePoSt` takes a set of ChallengeTickets and generates a __*Proof of Spacetime*__ for them, proving the miner storage as a whole.
+
 ## PoStSurprise Response
 
-Upon receiving a PoSt surprise challenge, a miner has a given `CHALLENGE_DURATION` (~2 hours) to respond.
+The miner's response must be a PoSt proof over the PartialTickets generated by the challenge which clear a given target `SURPRISE_TARGET` to be defined.
 
-The miner's response must be a PoSt proof over the PartialTickets for a  sectors that miner is storing (i.e. unlike with ElectionPoSt a miner must submit a PoStProof made up of all `PartialTickets` for a portion of their sectors in the `ProvingSet` proportional with `SPoStSampleRate` (not just the winning ones on sampled sectors).
+```
+submitSurpriseTickets(partialTickets):
+    eligibleTickets = []
+    for tix in partialTickets:
+        challTix = H(tix) // finalization
+        if challTix / 2^len(H) < surprise_target:
+            eligibleTickets += tix
+    return eligibleTickets
+```
 
-If the miner responds to the challenge with a SurprisePoSt, they will keep/recover their power.
+If the miner responds to the challenge with a SurprisePoSt within `CHALLENGE_DURATION` epochs, they will keep/recover their power.
 
 ## Faults
 

--- a/src/systems/filecoin_blockchain/storage_power_consensus/_index.md
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/_index.md
@@ -9,8 +9,10 @@ entries:
 The Storage Power Consensus subsystem is the main interface which enables Filecoin nodes to agree on the state of the system. SPC accounts for individual storage miners' effective power over consensus in given chains in its {{<sref power_table>}}. It also runs {{<sref expected_consensus>}} (the underlying consensus algorithm in use by Filecoin), enabling storage miners to run leader election and generate new blocks updating the state of the Filecoin system.
 
 Succinctly, the SPC subsystem offers the following services:
+
 - Access to the {{<sref power_table>}} for every subchain, accounting for individual storage miner power and total power on-chain.
 - Access to {{<sref expected_consensus>}} for individual storage miners, enabling:
+
     - Access to verifiable randomness {{<sref tickets>}} as needed in the rest of the protocol.
     - Running  {{<sref leader_election>}} to produce new blocks.
     - Running {{<sref chain_selection>}} across subchains using EC's weighting function.
@@ -23,6 +25,7 @@ Much of the Storage Power Consensus' subsystem functionality is detailed in the 
 ## Distinguishing between storage miners and block miners
 
 There are two ways to earn Filecoin tokens in the Filecoin network:
+
 - By participating in the {{<sref storage_market>}} as a storage provider and being paid by clients for file storage deals.
 - By mining new blocks on the network, helping modify system state and secure the Filecoin consensus mechanism.
 
@@ -36,6 +39,7 @@ However, given Filecoin's "useful Proof-of-Work" is achieved through file storag
 Per the above, we also clearly distinguish putting storage on-chain from gaining power in consensus (sometimes called "Storage Power") as follows:
 
 Consensus power in Filecoin is defined as the intersection between:
+
 - Proven Storage as of the PoSts verification (i.e. storage in the `Proving Set` since it will all be active by the time the PoSt is computed)
 - In-deal storage.
 Put another way **consensus power is in-deal storage in the Proving Set**. For instance, if a miner had two 32GB sector, each with 20 GB of in-deal storage; the miner would have 40GB worth of storage power for SPC.
@@ -46,6 +50,7 @@ Read more in {{<sref storage_mining_subsystem>}}.
 ## Tickets
 
 Tickets are used across the Filecoin protocol as sources of randomness:
+
 - The {{<sref sector_sealer>}} uses tickets as SealSeeds to bind sector commitments to a given subchain.
 - The {{<sref post_generator>}} likewise uses tickets as PoStChallenges to prove sectors remain committed as of a given block.
 - They are drawn by the Storage Power subsystem as randomness in {{<sref leader_election>}} to determine their eligibility to mine a block

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_state.go
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_state.go
@@ -45,6 +45,7 @@ func (st *StoragePowerActorState_I) _getActivePower() block.StoragePower {
 
 	for _, miner := range st.PowerTable() {
 		// only count miner power if they are larger than MIN_MINER_SIZE
+		// (need to use either condition) in case no one meets MIN_MINER_SIZE_STOR
 		if st.ActivePowerMeetsConsensusMinimum(miner.ActivePower()) {
 			activePower = activePower + miner.ActivePower()
 		}

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
@@ -118,10 +118,12 @@ type StorageMinerActorCode struct {
     PreCommitSector(rt Runtime, info sector.SectorPreCommitInfo)  // TODO: check with Magik on sizes
     ProveCommitSector(rt Runtime, info sector.SectorProveCommitInfo)
 
-    ProcessVerifiedSurprisePoSt(rt Runtime)
+    ProcessSurprisePoSt(rt Runtime)
     ProcessVerifiedElectionPoSt(rt Runtime)
 
     _checkSurprisePoStSubmissionHappened(rt Runtime)
+    _verifySurprisePoSt(rt Runtime, onChainInfo sector.OnChainPoStVerifyInfo) bool
+    _verifySurprisePoStMeetsTargetReq(rt Runtime) bool
 
     DeclareFaults(rt Runtime, failingSet sector.CompactSectorSet)
     RecoverFaults(rt Runtime, recoveringSet sector.CompactSectorSet)

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
@@ -7,6 +7,7 @@ import block "github.com/filecoin-project/specs/systems/filecoin_blockchain/stru
 import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 import stateTree "github.com/filecoin-project/specs/systems/filecoin_vm/state_tree"
 import spc "github.com/filecoin-project/specs/systems/filecoin_blockchain/storage_power_consensus"
+import filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
 
 type SectorExpirationQueueItem struct {
     SectorNumber  sector.SectorNumber
@@ -113,6 +114,8 @@ type StorageMinerActorState struct {
 }
 
 type StorageMinerActorCode struct {
+    GetOwnerKey(rt Runtime) filcrypto.VRFPublicKey
+    GetWorkerKey(rt Runtime) filcrypto.VRFPublicKey
     NotifyOfSurprisePoStChallenge(rt Runtime)
 
     PreCommitSector(rt Runtime, info sector.SectorPreCommitInfo)  // TODO: check with Magik on sizes
@@ -161,12 +164,14 @@ type MinerInfo struct {
     // - Income and returned collateral are paid to this address.
     // - This address is also allowed to change the worker address for the miner.
     Owner                   address.Address
+    OwnerKey                filcrypto.VRFPublicKey
 
     // Worker account for this miner.
     // This will be the key that is used to sign blocks created by this miner, and
     // sign messages sent on behalf of this miner to commit sectors, submit PoSts, and
     // other day to day miner activities.
     Worker                  address.Address
+    WorkerKey               filcrypto.VRFPublicKey
 
     // Libp2p identity that should be used when connecting to this miner.
     PeerId                  libp2p.PeerID

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor_code.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor_code.go
@@ -1,6 +1,7 @@
 package storage_mining
 
 import (
+	filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
 	filproofs "github.com/filecoin-project/specs/libraries/filcrypto/filproofs"
 	ipld "github.com/filecoin-project/specs/libraries/ipld"
 	spc "github.com/filecoin-project/specs/systems/filecoin_blockchain/storage_power_consensus"
@@ -348,19 +349,6 @@ func (a *StorageMinerActorCode_I) _onSuccessfulPoSt(rt Runtime) InvocOutput {
 	return rt.SuccessReturn()
 }
 
-// called by verifier to update miner state on successful surprise post
-// after it has been verified in the storage_mining_subsystem
-func (a *StorageMinerActorCode_I) ProcessVerifiedSurprisePoSt(rt Runtime) InvocOutput {
-	TODO() // TODO: validate caller
-
-	// Ensure pledge collateral satisfied
-	// otherwise, abort ProcessVerifiedSurprisePoSt
-	a._ensurePledgeCollateralSatisfied(rt)
-
-	return a._onSuccessfulPoSt(rt)
-
-}
-
 // Called by StoragePowerConsensus subsystem after verifying the Election proof
 // and verifying the PoSt proof in the block header.
 // Assume ElectionPoSt has already been successfully verified (both proof and partial ticket
@@ -379,6 +367,103 @@ func (a *StorageMinerActorCode_I) ProcessVerifiedElectionPoSt(rt Runtime) InvocO
 
 	// the following will update last challenge response time
 	return a._onSuccessfulPoSt(rt)
+}
+
+// called by verifier to update miner state on successful surprise post
+// after it has been verified in the storage_mining_subsystem
+func (a *StorageMinerActorCode_I) ProcessSurprisePoSt(rt Runtime, onChainInfo sector.OnChainPoStVerifyInfo) InvocOutput {
+	TODO() // TODO: validate caller
+
+	if !a._verifySurprisePoSt(rt, onChainInfo) {
+		rt.Abort(
+			exitcode.UserDefinedError(exitcode.PoStVerificationFailed),
+			"PoSt verification failed")
+	}
+
+	// Ensure pledge collateral satisfied
+	// otherwise, abort ProcessVerifiedSurprisePoSt
+	a._ensurePledgeCollateralSatisfied(rt)
+
+	return a._onSuccessfulPoSt(rt)
+
+}
+
+func (a *StorageMinerActorCode_I) GetWorkerKeyByMinerAddress(minerAddr addr.Address) filcrypto.VRFPublicKey {
+	panic("TODO")
+}
+
+func (a *StorageMinerActorCode_I) _verifySurprisePoSt(rt Runtime, onChainInfo sector.OnChainPoStVerifyInfo) bool {
+	h, st := a.State(rt)
+	info := st.Info()
+
+	// 1. Check that the miner in question is currently being challenged
+	if !st._isChallenged() {
+		// TODO: determine proper error here and error-handling machinery
+		// rt.Abort("cannot SubmitSurprisePoSt when not challenged")
+		rt.AbortStateMsg("Invalid Surprise PoSt. Miner not challenged.")
+	}
+
+	// 2. Check that the challenge has not expired
+	// Check that miner can still submit (i.e. that the challenge window has not passed)
+	// This will prevent miner from submitting a Surprise PoSt past the challenge period
+	if st._challengeHasExpired(rt.CurrEpoch()) {
+		rt.AbortStateMsg("Invalid Surprise PoSt. Challenge has expired.")
+	}
+
+	// 3. Verify the partialTicket values
+	if !a._verifySurprisePoStMeetsTargetReq(rt) {
+		rt.AbortStateMsg("Invalid Surprise PoSt. Tickets do not meet target.")
+	}
+
+	// verify the partialTickets themselves
+	// 4. Verify appropriate randomness
+
+	// pull from consts
+	SPC_LOOKBACK_POST := uint64(0)
+	randomnessEpoch := st.ChallengeStatus().LastChallengeEpoch()
+	randomness := rt.Randomness(randomnessEpoch, SPC_LOOKBACK_POST)
+	panic(randomness)                       // ignore circular dependency
+	var postRandomnessInput util.Randomness // sms.PreparePoStChallengeSeed(randomness, actorAddr)
+
+	postRand := &filcrypto.VRFResult_I{
+		Output_: onChainInfo.Randomness(),
+	}
+
+	// TODO: get worker key from minerAddr
+	var workerKey filcrypto.VRFPublicKey
+
+	if !postRand.Verify(postRandomnessInput, workerKey) {
+		rt.AbortStateMsg("Invalid Surprise PoSt. Invalid randomness.")
+	}
+
+	UpdateRelease(rt, h, st)
+
+	// 5. Get public inputs
+	sectorSize := info.SectorSize()
+
+	postCfg := sector.PoStCfg_I{
+		Type_:        sector.PoStType_SurprisePoSt,
+		SectorSize_:  sectorSize,
+		WindowCount_: info.WindowCount(),
+		Partitions_:  info.SurprisePoStPartitions(),
+	}
+
+	pvInfo := sector.PoStVerifyInfo_I{
+		OnChain_:    onChainInfo,
+		PoStCfg_:    &postCfg,
+		Randomness_: onChainInfo.Randomness(),
+	}
+
+	sdr := filproofs.WinSDRParams(&filproofs.SDRCfg_I{SurprisePoStCfg_: &postCfg})
+
+	// 6. Verify the PoSt Proof
+	return sdr.VerifySurprisePoSt(&pvInfo)
+}
+
+// todo: define target
+func (a *StorageMinerActorCode_I) _verifySurprisePoStMeetsTargetReq(rt Runtime) bool {
+	util.TODO()
+	return false
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/systems/filecoin_mining/storage_mining/storage_mining_subsystem.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_mining_subsystem.go
@@ -231,8 +231,9 @@ func (sms *StorageMiningSubsystem_I) VerifyElectionPoSt(header block.BlockHeader
 		Output_: onChainInfo.Randomness(),
 	}
 
-	// TODO: get worker key from minerAddr
-	var workerKey filcrypto.VRFPublicKey
+	// get worker key from minerAddr
+	workerKey := sma.Info().WorkerKey()
+
 	if !postRand.Verify(postRandomnessInput, workerKey) {
 		return false
 	}

--- a/src/systems/filecoin_mining/storage_mining/storage_mining_subsystem.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_mining_subsystem.go
@@ -68,7 +68,7 @@ func (sms *StorageMiningSubsystem_I) _tryLeaderElection() {
 	// Randomness for ElectionPoSt
 	randomnessK := sms._consensus().GetPoStChallengeRand(sms._blockchain().BestChain(), sms._blockchain().LatestEpoch())
 
-	input := sms._preparePoStChallengeSeed(randomnessK, sms._keyStore().MinerAddress())
+	input := sms.PreparePoStChallengeSeed(randomnessK, sms._keyStore().MinerAddress())
 	postRandomness := sms._keyStore().WorkerKey().Impl().Generate(input).Output()
 
 	// TODO: add how sectors are actually stored in the SMS proving set
@@ -114,7 +114,7 @@ func (sms *StorageMiningSubsystem_I) _tryLeaderElection() {
 	sms._blockProducer().GenerateBlock(postProof, winningCandidates, newTicket, chainHead, sms._keyStore().MinerAddress())
 }
 
-func (sms *StorageMiningSubsystem_I) _preparePoStChallengeSeed(randomness util.Randomness, minerAddr addr.Address) util.Randomness {
+func (sms *StorageMiningSubsystem_I) PreparePoStChallengeSeed(randomness util.Randomness, minerAddr addr.Address) util.Randomness {
 
 	randInput := Serialize_PoStChallengeSeedInput(&PoStChallengeSeedInput_I{
 		ticket_:    randomness,
@@ -192,10 +192,6 @@ func (sms *StorageMiningSubsystem_I) _getStoragePowerActorState(stateTree stateT
 	return st
 }
 
-func (sms *StorageMiningSubsystem_I) GetWorkerKeyByMinerAddress(minerAddr addr.Address) filcrypto.VRFPublicKey {
-	panic("TODO")
-}
-
 func (sms *StorageMiningSubsystem_I) VerifyElectionPoSt(header block.BlockHeader, onChainInfo sector.OnChainPoStVerifyInfo) bool {
 
 	sma := sms._getStorageMinerActorState(header.ParentState(), header.Miner())
@@ -229,13 +225,15 @@ func (sms *StorageMiningSubsystem_I) VerifyElectionPoSt(header block.BlockHeader
 	// 3. Verify appropriate randomness
 	// TODO: fix away from BestChain()... every block should track its own chain up to its own production.
 	randomness := sms._consensus().GetPoStChallengeRand(sms._blockchain().BestChain(), header.Epoch())
-	postRandomnessInput := sector.PoStRandomness(sms._preparePoStChallengeSeed(randomness, header.Miner()))
+	postRandomnessInput := sector.PoStRandomness(sms.PreparePoStChallengeSeed(randomness, header.Miner()))
 
 	postRand := &filcrypto.VRFResult_I{
 		Output_: onChainInfo.Randomness(),
 	}
 
-	if !postRand.Verify(postRandomnessInput, sms.GetWorkerKeyByMinerAddress(header.Miner())) {
+	// TODO: get worker key from minerAddr
+	var workerKey filcrypto.VRFPublicKey
+	if !postRand.Verify(postRandomnessInput, workerKey) {
 		return false
 	}
 
@@ -264,68 +262,6 @@ func (sms *StorageMiningSubsystem_I) VerifyElectionPoSt(header block.BlockHeader
 	return isPoStVerified
 }
 
-func (sms *StorageMiningSubsystem_I) VerifySurprisePoSt(header block.BlockHeader, onChainInfo sector.OnChainPoStVerifyInfo, posterAddr addr.Address) bool {
-
-	st := sms._getStorageMinerActorState(header.ParentState(), header.Miner())
-
-	// 1. Check that the miner in question is currently being challenged
-	if !st._isChallenged() {
-		// TODO: determine proper error here and error-handling machinery
-		// rt.Abort("cannot SubmitSurprisePoSt when not challenged")
-		return false
-	}
-
-	// 2. Check that the challenge has not expired
-	// Check that miner can still submit (i.e. that the challenge window has not passed)
-	// This will prevent miner from submitting a Surprise PoSt past the challenge period
-	if st._challengeHasExpired(header.Epoch()) {
-		return false
-	}
-
-	// 3. Verify the partialTicket values
-	if !sms._verifySurprisePoStMeetsTargetReq(header, onChainInfo) {
-		return false
-	}
-
-	// verify the partialTickets themselves
-	// 4. Verify appropriate randomness
-	randomnessEpoch := st.ChallengeStatus().LastChallengeEpoch()
-	// TODO: fix away from BestChain()... every block should track its own chain up to its own production.
-	randomness := sms._consensus().GetPoStChallengeRand(sms._blockchain().BestChain(), randomnessEpoch)
-	postRandomnessInput := sms._preparePoStChallengeSeed(randomness, posterAddr)
-
-	postRand := &filcrypto.VRFResult_I{
-		Output_: onChainInfo.Randomness(),
-	}
-
-	if !postRand.Verify(postRandomnessInput, sms.GetWorkerKeyByMinerAddress(posterAddr)) {
-		return false
-	}
-
-	// 5. Get public inputs
-	info := st.Info()
-	sectorSize := info.SectorSize()
-
-	postCfg := sector.PoStCfg_I{
-		Type_:        sector.PoStType_SurprisePoSt,
-		SectorSize_:  sectorSize,
-		WindowCount_: info.WindowCount(),
-		Partitions_:  info.SurprisePoStPartitions(),
-	}
-
-	pvInfo := sector.PoStVerifyInfo_I{
-		OnChain_:    onChainInfo,
-		PoStCfg_:    &postCfg,
-		Randomness_: onChainInfo.Randomness(),
-	}
-
-	sdr := filproofs.WinSDRParams(&filproofs.SDRCfg_I{SurprisePoStCfg_: &postCfg})
-
-	// 6. Verify the PoSt Proof
-	isPoStVerified := sdr.VerifySurprisePoSt(&pvInfo)
-	return isPoStVerified
-}
-
 func (sms *StorageMiningSubsystem_I) _verifyElection(header block.BlockHeader, onChainInfo sector.OnChainPoStVerifyInfo) bool {
 	st := sms._getStorageMinerActorState(header.ParentState(), header.Miner())
 	numMinerSectors := uint64(len(st.SectorTable().Impl().ActiveSectors_.SectorsOn()))
@@ -342,12 +278,6 @@ func (sms *StorageMiningSubsystem_I) _verifyElection(header block.BlockHeader, o
 		}
 	}
 	return true
-}
-
-// todo: define target
-func (sms *StorageMiningSubsystem_I) _verifySurprisePoStMeetsTargetReq(header block.BlockHeader, onChainInfo sector.OnChainPoStVerifyInfo) bool {
-	util.TODO()
-	return false
 }
 
 // func (sms *StorageMiningSubsystem_I) submitPoStMessage(postSubmission poster.PoStSubmission) error {

--- a/src/systems/filecoin_mining/storage_mining/storage_mining_subsystem.id
+++ b/src/systems/filecoin_mining/storage_mining/storage_mining_subsystem.id
@@ -86,7 +86,15 @@ type StorageMiningSubsystem struct {
         header       block.BlockHeader
         onChainInfo  sector.OnChainPoStVerifyInfo
     ) bool
-    IsValidElection(onChainInfo sector.OnChainPoStVerifyInfo) bool
+
+    _verifyElection(
+        header       block.BlockHeader
+        onChainInfo  sector.OnChainPoStVerifyInfo
+    ) bool
+    _verifySurprisePoStMeetsTargetReq(
+        header       block.BlockHeader
+        onChainInfo  sector.OnChainPoStVerifyInfo
+    ) bool
 }
 
 type PoStChallengeSeedInput struct {

--- a/src/systems/filecoin_mining/storage_mining/storage_mining_subsystem.id
+++ b/src/systems/filecoin_mining/storage_mining/storage_mining_subsystem.id
@@ -49,9 +49,6 @@ type StorageMiningSubsystem struct {
         pledgeAmt     actor.TokenAmount
     )
 
-    // get miner key by address
-    GetWorkerKeyByMinerAddress(minerAddr addr.Address) filcrypto.PublicKey
-
     // call by StorageMarket.StorageProvider at the start of a deal.
     // Triggers AddNewDeal on SectorIndexer
     // StorageDeal contains DealCID
@@ -66,7 +63,7 @@ type StorageMiningSubsystem struct {
         minerAddr   addr.Address
     ) block.Ticket
 
-    _preparePoStChallengeSeed(randomness util.Randomness, minerAddr addr.Address) util.Randomness
+    PreparePoStChallengeSeed(randomness util.Randomness, minerAddr addr.Address) util.Randomness
     _getStorageMinerActorState(stateTree stateTree.StateTree, minerAddr addr.Address) StorageMinerActorState
 
     // call by BlockChain when a new block is produced
@@ -82,16 +79,8 @@ type StorageMiningSubsystem struct {
         header       block.BlockHeader
         onChainInfo  sector.OnChainPoStVerifyInfo
     ) bool
-    VerifySurprisePoSt(
-        header       block.BlockHeader
-        onChainInfo  sector.OnChainPoStVerifyInfo
-    ) bool
 
     _verifyElection(
-        header       block.BlockHeader
-        onChainInfo  sector.OnChainPoStVerifyInfo
-    ) bool
-    _verifySurprisePoStMeetsTargetReq(
         header       block.BlockHeader
         onChainInfo  sector.OnChainPoStVerifyInfo
     ) bool

--- a/src/systems/filecoin_vm/runtime/exitcode/vm_exitcodes.go
+++ b/src/systems/filecoin_vm/runtime/exitcode/vm_exitcodes.go
@@ -2,9 +2,9 @@ package exitcode
 
 import (
 	"fmt"
-)
 
-import util "github.com/filecoin-project/specs/util"
+	util "github.com/filecoin-project/specs/util"
+)
 
 type SystemErrorCode int
 type UserDefinedErrorCode int
@@ -69,6 +69,7 @@ const (
 
 	InvalidSectorPacking
 	SealVerificationFailed
+	PoStVerificationFailed
 	DeadlineExceeded
 	InsufficientPledgeCollateral
 )


### PR DESCRIPTION
**In this PR**:
- placeholder for using a target with SurprisePoSt (TBD in research)
- moved surprise PoSt verif to the actor > subsystem

**Needed in future PR**:
- Randomness from RT
- Pulling miner actor address easily
- Getting worker public keys from miner actor address as a facility in VM