### PR TITLE
Separate Runtime interface depended on by actors from its implementation.

### DIFF
--- a/src/systems/filecoin_vm/interpreter/vm_interpreter.go
+++ b/src/systems/filecoin_vm/interpreter/vm_interpreter.go
@@ -9,6 +9,7 @@ import (
 	vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
 	exitcode "github.com/filecoin-project/specs/systems/filecoin_vm/runtime/exitcode"
 	gascost "github.com/filecoin-project/specs/systems/filecoin_vm/runtime/gascost"
+	vmri "github.com/filecoin-project/specs/systems/filecoin_vm/runtime/impl"
 	st "github.com/filecoin-project/specs/systems/filecoin_vm/state_tree"
 	sysactors "github.com/filecoin-project/specs/systems/filecoin_vm/sysactors"
 	util "github.com/filecoin-project/specs/util"
@@ -267,7 +268,7 @@ func _applyMessageInternal(
 	fromActor, ok := tree.GetActor(message.From())
 	Assert(ok)
 
-	rt := vmr.VMContext_Make(
+	rt := vmri.VMContext_Make(
 		message.From(),
 		topLevelBlockWinner,
 		fromActor.CallSeqNum(),

--- a/src/systems/filecoin_vm/runtime/impl/codeload.go
+++ b/src/systems/filecoin_vm/runtime/impl/codeload.go
@@ -1,8 +1,11 @@
-package runtime
+package impl
 
-import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
+import (
+	actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
+	vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
+)
 
-func loadActorCode(codeID actor.CodeID) (ActorCode, error) {
+func loadActorCode(codeID actor.CodeID) (vmr.ActorCode, error) {
 
 	panic("TODO")
 	// TODO: resolve circular dependency

--- a/src/systems/filecoin_vm/runtime/impl/runtime_compute.go
+++ b/src/systems/filecoin_vm/runtime/impl/runtime_compute.go
@@ -1,14 +1,14 @@
-package runtime
+package impl
 
 import filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
 import gascost "github.com/filecoin-project/specs/systems/filecoin_vm/runtime/gascost"
 import msg "github.com/filecoin-project/specs/systems/filecoin_vm/message"
 import util "github.com/filecoin-project/specs/util"
+import vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
 
 type Any = util.Any
 type Int = util.Int
-
-type ComputeFunctionID Int
+type ComputeFunctionID = vmr.ComputeFunctionID
 
 const (
 	// TODO: remove once canonical IDs are assigned

--- a/src/systems/filecoin_vm/runtime/rtutil.go
+++ b/src/systems/filecoin_vm/runtime/rtutil.go
@@ -1,0 +1,57 @@
+package runtime
+
+import (
+	actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
+	addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
+	msg "github.com/filecoin-project/specs/systems/filecoin_vm/message"
+	exitcode "github.com/filecoin-project/specs/systems/filecoin_vm/runtime/exitcode"
+	util "github.com/filecoin-project/specs/util"
+)
+
+// Name should be set per unique filecoin network
+var Name = "mainnet"
+
+func NetworkName() string {
+	return Name
+}
+
+// ActorCode is the interface that all actor code types should satisfy.
+// It is merely a method dispatch interface.
+type ActorCode interface {
+	InvokeMethod(rt Runtime, method actor.MethodNum, params actor.MethodParams) InvocOutput
+}
+
+type CallerPattern struct {
+	Matches func(addr.Address) bool
+}
+
+func InvocInput_Make(to addr.Address, method actor.MethodNum, params actor.MethodParams, value actor.TokenAmount) InvocInput {
+	return &InvocInput_I{
+		To_:     to,
+		Method_: method,
+		Params_: params,
+		Value_:  value,
+	}
+}
+
+func InvocOutput_Make(returnValue util.Bytes) InvocOutput {
+	return &InvocOutput_I{
+		ReturnValue_: returnValue,
+	}
+}
+
+func MessageReceipt_Make(output InvocOutput, exitCode exitcode.ExitCode, gasUsed msg.GasAmount) MessageReceipt {
+	return &MessageReceipt_I{
+		ExitCode_:    exitCode,
+		ReturnValue_: output.ReturnValue(),
+		GasUsed_:     gasUsed,
+	}
+}
+
+func MessageReceipt_MakeSystemError(errCode exitcode.SystemErrorCode, gasUsed msg.GasAmount) MessageReceipt {
+	return MessageReceipt_Make(
+		nil,
+		exitcode.SystemError(errCode),
+		gasUsed,
+	)
+}

--- a/src/systems/filecoin_vm/runtime/runtime.id
+++ b/src/systems/filecoin_vm/runtime/runtime.id
@@ -61,7 +61,7 @@ type Runtime interface {
     // Run a (pure function) computation, consuming the gas cost associated with that function.
     // This mechanism is intended to capture the notion of an ABI between the VM and native
     // functions, and should be used for any function whose computation is expensive.
-    Compute(ComputeFunctionID, args [Any]) Any
+    Compute(ComputeFunctionID, args [util.Any]) util.Any
 
     // Sends a message to another actor.
     // If the invoked method does not return successfully, this caller will be aborted too.
@@ -105,8 +105,10 @@ type MessageReceipt struct {
     GasUsed      msg.GasAmount
 }  // representation tuple
 
-type ActorExecAddressSeed struct {
-    creator             addr.Address
-    toplevelCallSeqNum  actor.CallSeqNum
-    internalCallSeqNum  actor.CallSeqNum
+type ActorStateHandle interface {
+    UpdateRelease(newStateCID actor.ActorSubstateCID)
+    Release(checkStateCID actor.ActorSubstateCID)
+    Take() actor.ActorSubstateCID
 }
+
+type ComputeFunctionID Int


### PR DESCRIPTION
This separation is necessary so that the vm/runtime implementation can depend on the
InitActor for address lookup, without a circular dependency from the init actor
back on the Runtime interface which all actors consume.

The implementations already do something like that (and consumer-defined interfaces (e.g. if the Runtime interface was in the actor package) is canonical Go).

FYI @jzimmerman 