### PR TITLE
Remove ExitCode from InvocOutput.

### DIFF
--- a/src/systems/filecoin_vm/runtime/runtime.id
+++ b/src/systems/filecoin_vm/runtime/runtime.id
@@ -95,8 +95,7 @@ type InvocInput struct {
 }
 
 type InvocOutput struct {
-    ExitCode     exitcode.ExitCode
-    ReturnValue  Bytes
+    ReturnValue Bytes
 }
 
 type MessageReceipt struct {


### PR DESCRIPTION
This was intended to be removed in #684 but lost in branch wrangling.
See #675.