### PR TITLE
Remove ValidateImmediateCallerAcceptAnyOfType and all caller-type checks.

### DIFF
--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor.id
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor.id
@@ -42,8 +42,8 @@ type StoragePowerActorState struct {
 }
 
 type StoragePowerActorCode struct {
-    AddBalance(rt Runtime)
-    WithdrawBalance(rt Runtime, amount actor.TokenAmount)
+    AddBalance(rt Runtime, miner addr.Address)
+    WithdrawBalance(rt Runtime, miner addr.Address, amount actor.TokenAmount)
 
     // call by StorageMiningSubsytem on miner creation
     CreateStorageMiner(

--- a/src/systems/filecoin_markets/storage_market/storage_market_actor.id
+++ b/src/systems/filecoin_markets/storage_market/storage_market_actor.id
@@ -76,8 +76,8 @@ type StorageMarketActorState struct {
 }
 
 type StorageMarketActorCode struct {
-    WithdrawBalance(rt Runtime, balance actor.TokenAmount)
-    AddBalance(rt Runtime)  // amount is in the message
+    WithdrawBalance(rt Runtime, miner addr.Address, balance actor.TokenAmount)
+    AddBalance(rt Runtime, miner addr.Address)  // amount is in the message
 
     // call by StorageMiningSubsystem before PreCommitSector
     // a StorageDeal is only published on chain when it passes _validateNewStorageDeal

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
@@ -113,6 +113,9 @@ type StorageMinerActorState struct {
 }
 
 type StorageMinerActorCode struct {
+    GetOwner(rt Runtime) address.Address
+    GetWorker(rt Runtime) address.Address
+
     NotifyOfSurprisePoStChallenge(rt Runtime)
 
     PreCommitSector(rt Runtime, info sector.SectorPreCommitInfo)  // TODO: check with Magik on sizes

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor_code.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor_code.go
@@ -17,7 +17,9 @@ import (
 )
 
 const (
-	Method_StorageMinerActor_ProcessVerifiedSurprisePoSt = actor.MethodPlaceholder + iota
+	Method_StorageMinerActor_GetOwner = actor.MethodPlaceholder + iota
+	Method_StorageMinerActor_GetWorker
+	Method_StorageMinerActor_ProcessVerifiedSurprisePoSt
 	Method_StorageMinerActor_ProcessVerifiedElectionPoSt
 	Method_StorageMinerActor_NotifyOfSurprisePoStChallenge
 )
@@ -60,6 +62,20 @@ func DeserializeState(x Bytes) State {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+
+func (a *StorageMinerActorCode_I) GetOwner(rt Runtime) addr.Address {
+	h, st := a.State(rt)
+	ret := st.Info().Owner()
+	Release(rt, h, st)
+	return ret
+}
+
+func (a *StorageMinerActorCode_I) GetWorker(rt Runtime) addr.Address {
+	h, st := a.State(rt)
+	ret := st.Info().Worker()
+	Release(rt, h, st)
+	return ret
+}
 
 func (a *StorageMinerActorCode_I) _isChallenged(rt Runtime) bool {
 	h, st := a.State(rt)

--- a/src/systems/filecoin_vm/runtime/impl/runtime.go
+++ b/src/systems/filecoin_vm/runtime/impl/runtime.go
@@ -265,10 +265,6 @@ func (rt *VMContext) ValidateImmediateCallerIs(callerExpected addr.Address) {
 	rt.ValidateImmediateCallerMatches(CallerPattern_MakeSingleton(callerExpected))
 }
 
-func (rt *VMContext) ValidateImmediateCallerAcceptAnyOfType(type_ actor.BuiltinActorID) {
-	rt.ValidateImmediateCallerMatches(CallerPattern_MakeAcceptAnyOfType(rt, type_))
-}
-
 func (rt *VMContext) ValidateImmediateCallerAcceptAny() {
 	rt.ValidateImmediateCallerMatches(CallerPattern_MakeAcceptAny())
 }

--- a/src/systems/filecoin_vm/runtime/runtime.id
+++ b/src/systems/filecoin_vm/runtime/runtime.id
@@ -17,7 +17,6 @@ type Runtime interface {
     // Not necessarily the actor in the From field of the initial on-chain Message.
     ImmediateCaller() addr.Address
     ValidateImmediateCallerIs(caller addr.Address)
-    ValidateImmediateCallerAcceptAnyOfType(type_ actor.BuiltinActorID)
     ValidateImmediateCallerAcceptAny()
     ValidateImmediateCallerMatches(CallerPattern)
 


### PR DESCRIPTION
The checks for account-type actors are flawed because they make multi-sig actors
unable to act as accounts, e.g. miner owners. The others are unnecessary and similarly restrictive of future design space.

In general, objects and functions that make assertions about who uses them an how are very brittle, since the developer cannot predict all the useful ways something might be used. IMO objects should define clear semantics and invariants about their behaviour, and be unopinionated about how they might be composed into a larger system.

There is follow-up work to change `_code.go` methods to not panic when a key is not found: they should return an error and the actor code can abort.

FYI @sternhenri 