### PR TITLE
Runtime resolves receiver addresses through InitActor state.

### DIFF
--- a/src/systems/filecoin_vm/interpreter/_index.md
+++ b/src/systems/filecoin_vm/interpreter/_index.md
@@ -87,18 +87,18 @@ A message execution will fail if, in the immediately preceding state:
 - the `From` actor does not exist in the state (miner penalized),
 - the `From` actor is not an account actor (miner penalized),
 - the `CallSeqNum` of the message does not match the `CallSeqNum` of the `From` actor (miner penalized),
-- the `To` actor does not exist in state and the `To` address is not a pubkey-style address (miner penalized),
-- the `To` actor does not exist in state and the message has a non-zero `MethodNum` (miner penalized),
-- the `To` actor exists but does not have a method corresponding to the non-zero `MethodNum`,
-- deserialized `Params` is not an array of length matching the arity of the `To` actor's `MethodNum` method,
-- deserialized `Params` are not valid for the types specified by the `To` actor's `MethodNum` method,
 - the `From` actor does not have sufficient balance to cover the sum of the message `Value` plus the
 maximum gas cost, `GasLimit * GasPrice` (miner penalized),
-- the invoked method consumes more gas than the `GasLimit` allows, or
-- the invoked method exits with a non-zero code (via `Runtime.Abort()`).
+- the `To` actor does not exist in state and the `To` address is not a pubkey-style address,
+- the `To` actor exists (or is implicitly created as an account) but does not have a method corresponding to the non-zero `MethodNum`,
+- deserialized `Params` is not an array of length matching the arity of the `To` actor's `MethodNum` method,
+- deserialized `Params` are not valid for the types specified by the `To` actor's `MethodNum` method,
+- the invoked method consumes more gas than the `GasLimit` allows,
+- the invoked method exits with a non-zero code (via `Runtime.Abort()`), or
+- any inner message sent by the receiver fails for any of the above reasons.
 
 Note that if the `To` actor does not exist in state and the address is a valid `H(pubkey)` address, 
-it will be created as an account actor (only if the message has a MethodNum of zero).
+it will be created as an account actor.
 
 (You can see the _old_ VM interpreter [here](docs/systems/filecoin_vm/vm_interpreter_old) )
 

--- a/src/systems/filecoin_vm/interpreter/vm_interpreter.go
+++ b/src/systems/filecoin_vm/interpreter/vm_interpreter.go
@@ -1,13 +1,13 @@
 package interpreter
 
 import (
-	"github.com/filecoin-project/specs/libraries/ipld"
-	"github.com/filecoin-project/specs/systems/filecoin_mining/storage_mining"
-	"github.com/filecoin-project/specs/systems/filecoin_vm/actor"
+	ipld "github.com/filecoin-project/specs/libraries/ipld"
+	storage_mining "github.com/filecoin-project/specs/systems/filecoin_mining/storage_mining"
+	actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 	addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 	msg "github.com/filecoin-project/specs/systems/filecoin_vm/message"
 	vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
-	"github.com/filecoin-project/specs/systems/filecoin_vm/runtime/exitcode"
+	exitcode "github.com/filecoin-project/specs/systems/filecoin_vm/runtime/exitcode"
 	gascost "github.com/filecoin-project/specs/systems/filecoin_vm/runtime/gascost"
 	vmri "github.com/filecoin-project/specs/systems/filecoin_vm/runtime/impl"
 	st "github.com/filecoin-project/specs/systems/filecoin_vm/state_tree"

--- a/src/systems/filecoin_vm/interpreter/vm_interpreter.go
+++ b/src/systems/filecoin_vm/interpreter/vm_interpreter.go
@@ -1,13 +1,13 @@
 package interpreter
 
 import (
-	ipld "github.com/filecoin-project/specs/libraries/ipld"
-	storage_mining "github.com/filecoin-project/specs/systems/filecoin_mining/storage_mining"
-	actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
+	"github.com/filecoin-project/specs/libraries/ipld"
+	"github.com/filecoin-project/specs/systems/filecoin_mining/storage_mining"
+	"github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 	addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 	msg "github.com/filecoin-project/specs/systems/filecoin_vm/message"
 	vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
-	exitcode "github.com/filecoin-project/specs/systems/filecoin_vm/runtime/exitcode"
+	"github.com/filecoin-project/specs/systems/filecoin_vm/runtime/exitcode"
 	gascost "github.com/filecoin-project/specs/systems/filecoin_vm/runtime/gascost"
 	vmri "github.com/filecoin-project/specs/systems/filecoin_vm/runtime/impl"
 	st "github.com/filecoin-project/specs/systems/filecoin_vm/state_tree"
@@ -76,11 +76,6 @@ func (vmi *VMInterpreter_I) ApplyTipSetMessages(inTree st.StateTree, msgs TipSet
 	}
 
 	// Invoke cron tick, attributing it to the miner of the first block.
-
-	TODO()
-	// TODO: miners shouldn't be able to trigger cron by sending messages;
-	// use ControlActor instead (https://github.com/filecoin-project/specs/issues/665)
-
 	firstMiner := msgs.Blocks()[0].Miner()
 	cronMessage := _makeCronTickMessage(outTree, firstMiner)
 	outTree = _applyMessageBuiltinAssert(outTree, cronMessage, firstMiner)
@@ -158,6 +153,7 @@ func (vmi *VMInterpreter_I) ApplyMessage(
 		return
 	}
 
+	// TODO: From() must be resolved to an ID-address via the init actor.
 	fromActor, ok := inTree.GetActor(message.From())
 	if !ok {
 		// Execution error; sender does not exist at time of message execution.
@@ -180,25 +176,11 @@ func (vmi *VMInterpreter_I) ApplyMessage(
 		return
 	}
 
-	// Check receiving actor and method exists, possibly creating an account actor.
-	// If this succeeds, compTreePreSend will become a state snapshot which includes
-	// implicit receiver creation, the sender (rather than miner) paying gas, and the sender's
-	// CallSeqNum being incremented; at least that much state change will be persisted even if the
+	// At this point, construct compTreePreSend as a state snapshot which includes
+	// the sender paying gas, and the sender's CallSeqNum being incremented;
+	// at least that much state change will be persisted even if the
 	// method invocation subsequently fails.
-	compTreePreSend, ok := _ensureReceiver(inTree, message)
-	if !ok {
-		// Execution error; receiver actor does not exist (and could not be implicitly created)
-		// at time of message execution.
-		_applyError(inTree, exitcode.ActorNotFound, SenderResolveSpec_Invalid)
-		return
-	}
-
-	// Deduct gas limit funds from sender.
-	// (This should always succeed, due to the sender balance check above.)
-	compTreePreSend = _withTransferFundsAssert(
-		compTreePreSend, message.From(), addr.BurntFundsActorAddr, gasLimitCost)
-
-	// Increment sender CallSeqNum.
+	compTreePreSend := _withTransferFundsAssert(inTree, message.From(), addr.BurntFundsActorAddr, gasLimitCost)
 	compTreePreSend = compTreePreSend.Impl().WithIncrementedCallSeqNum_Assert(message.From())
 
 	sendRet, compTreePostSend := _applyMessageInternal(compTreePreSend, message, vmiGasRemaining, minerAddr)
@@ -226,31 +208,12 @@ func (vmi *VMInterpreter_I) ApplyMessage(
 	return
 }
 
-// Ensures a messages's receiving actor exists in the state tree.
-// If it doesn't, and the message is a simple value send to a pubkey-style address,
-// creates the receiver as an account actor in the returned state.
-func _ensureReceiver(tree st.StateTree, message msg.UnsignedMessage) (st.StateTree, bool) {
-	_, found := tree.GetActor(message.To())
-
-	if found {
-		return tree, true
-	}
-	if !message.To().IsKeyType() {
-		// Don't implicitly create an account actor for an address without an associated key.
-		return tree, false
-	}
-	if message.Method() != actor.MethodSend {
-		// Don't implicitly create account actor if message was expecting to invoke a method.
-		return tree, false
-	}
-	// TODO Create a new account actor via the InitActor, which will receive a new ID address
-	// and be placed in the state tree under that address.
-	// The init actor will maintain a map from pubkey address to ID address.
-	return tree, true
-}
-
 func _applyMessageBuiltinAssert(tree st.StateTree, message msg.UnsignedMessage, topLevelBlockWinner addr.Address) st.StateTree {
 	Assert(message.From().Equals(addr.SystemActorAddr))
+	// Note: this message CallSeqNum is never checked (b/c it's created in this file), but probably should be.
+	// Since it changes state, we should be sure about the state transition.
+	// Alternatively we could special-case the system actor and declare that its CallSeqNumber
+	// never changes (saving us the state-change overhead).
 	tree = tree.Impl().WithIncrementedCallSeqNum_Assert(message.From())
 
 	retReceipt, retTree := _applyMessageInternal(tree, message, message.GasLimit(), topLevelBlockWinner)

--- a/src/systems/filecoin_vm/sysactors/account_actor.go
+++ b/src/systems/filecoin_vm/sysactors/account_actor.go
@@ -2,6 +2,7 @@ package sysactors
 
 import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 import exitcode "github.com/filecoin-project/specs/systems/filecoin_vm/runtime/exitcode"
+import ipld "github.com/filecoin-project/specs/libraries/ipld"
 import vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
 
 func (a *AccountActorCode_I) Constructor(rt vmr.Runtime) InvocOutput {
@@ -20,4 +21,8 @@ func (a *AccountActorCode_I) InvokeMethod(rt vmr.Runtime, method actor.MethodNum
 		rt.Abort(exitcode.SystemError(exitcode.InvalidMethod), "Invalid method")
 		panic("")
 	}
+}
+
+func (st *AccountActorState_I) CID() ipld.CID {
+	panic("TODO")
 }

--- a/src/systems/filecoin_vm/sysactors/init_actor.id
+++ b/src/systems/filecoin_vm/sysactors/init_actor.id
@@ -4,11 +4,14 @@ import vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
 
 type InitActorState struct {
     // responsible for create new actors
-    AddressMap       {addr.Address: addr.ActorID}
-    NextID           addr.ActorID
-    NetworkName      string
+    AddressMap   {addr.Address: addr.ActorID}
+    NextID       addr.ActorID
+    NetworkName  string
 
-    _assignNextID()  addr.ActorID
+    // Allocates a new ID and maps another address to it. Returns the ID-address.
+    MapAddressToNewID(address addr.Address) addr.Address
+    // Resolves an address to an ID-address, if possible. Returns the argument if un-mapped.
+    ResolveAddress(address addr.Address) addr.Address
 }
 
 type InitActorCode struct {


### PR DESCRIPTION
Implicitly created account actors are now also correctly mapped to ID by InitActor.

Note that this changed the behaviour when:
- the `To` actor does not exist and is not a pubkey address, or
- the `To` actor is implicitly created but the message has a non-zero MethodID
 
the caller now pays gas for a failed message, rather than the miner be penalized.

The rationale for this change is to unify the behaviour between top-level and nested sends (if we get to a nested send, the sender is definitely paying gas). It's pretty reasonable for senders to be confident the receiver exists and is of the right type before sending a message.

Follow-on work is to map sender addresses through InitActor too.

FYI @jzimmerman 