### PR TITLE
Charge gas for state updates in implicit actor creation, plus method invocation.

### DIFF
--- a/src/systems/filecoin_vm/runtime/gascost/vm_gascosts.go
+++ b/src/systems/filecoin_vm/runtime/gascost/vm_gascosts.go
@@ -22,6 +22,9 @@ var (
 	// Gas cost charged to the originator of an on-chain message (regardless of
 	// whether it succeeds or fails in application) is given by:
 	//   OnChainMessageBase + len(serialized message)*OnChainMessagePerByte
+	// Together, these account for the cost of message propagation and validation,
+	// up to but excluding any actual processing by the VM.
+	// This is the cost a block producer burns when including an invalid message.
 	OnChainMessageBase    = GasAmountPlaceholder
 	OnChainMessagePerByte = GasAmountPlaceholder
 
@@ -30,13 +33,23 @@ var (
 	//   len(return value)*OnChainReturnValuePerByte
 	OnChainReturnValuePerByte = GasAmountPlaceholder
 
-	// Gas cost for any method invocation (including the original one initiated
-	// by an on-chain message).
-	InvokeMethodBase = GasAmountPlaceholder
+	// Gas cost for any message send execution(including the top-level one
+	// initiated by an on-chain message).
+	// This accounts for the cost of loading sender and receiver actors and
+	// (for top-level messages) incrementing the sender's sequence number.
+	// Load and store of actor sub-state is charged separately.
+	SendBase = GasAmountPlaceholder
 
-	// Gas cost charged, in addition to InvokeMethodBase, if a method invocation
+	// Gas cost charged, in addition to SendBase, if a message send
 	// is accompanied by any nonzero currency amount.
-	InvokeMethodTransferFunds = GasAmountPlaceholder_UpdateStateTree
+	// Accounts for writing receiver's new balance (the sender's state is
+	// already accounted for).
+	SendTransferFunds = GasAmountPlaceholder
+
+	// Gas cost charged, in addition to SendBase, if a message invokes
+	// a method on the receiver.
+	// Accounts for the cost of loading receiver code and method dispatch.
+	SendInvokeMethod = GasAmountPlaceholder
 
 	// Gas cost (Base + len*PerByte) for any Get operation to the IPLD store
 	// in the runtime VM context.
@@ -53,9 +66,11 @@ var (
 	IpldPutPerByte = GasAmountPlaceholder
 
 	// Gas cost for updating an actor's substate (i.e., UpdateRelease).
+	// This is in addition to a per-byte fee for the state as for IPLD Get/Put.
 	UpdateActorSubstate = GasAmountPlaceholder_UpdateStateTree
 
 	// Gas cost for creating a new actor (via InitActor's Exec method).
+	// Actor sub-state is charged separately.
 	ExecNewActor = GasAmountPlaceholder
 
 	///////////////////////////////////////////////////////////////////////////
@@ -88,12 +103,13 @@ func IpldPut(dataSize int) msg.GasAmount {
 	return msg.GasAmount_Affine(IpldPutBase, dataSize, IpldPutPerByte)
 }
 
-func InvokeMethod(valueSent actor.TokenAmount) msg.GasAmount {
-	ret := InvokeMethodBase
-
-	TODO() // TODO: BigInt
-	if valueSent > actor.TokenAmount(0) {
-		ret = ret.Add(InvokeMethodTransferFunds)
+func InvokeMethod(value actor.TokenAmount, method actor.MethodNum) msg.GasAmount {
+	ret := SendBase
+	if value != actor.TokenAmount(0) {
+		ret = ret.Add(SendTransferFunds)
+	}
+	if method != actor.MethodSend {
+		ret = ret.Add(SendInvokeMethod)
 	}
 	return ret
 }


### PR DESCRIPTION
Also more commentary for gas cost primitives.

For follow-up:
There's something not quite right in the costs for send, transfer, and substate update. I think they're operating at slightly too high a level of abstraction. E.g., when an actor receives value and mutates its state, the new actor state is written just once, but we charge twice. Similarly the sender's value and CallSeqNum are written together.

I think we might want to rearrange the gascost units to have one just for actor state update, and charge it just once when we actually commit that update, be it for CallSeqNum, balance, or substate CID. The actor-substate is being charged per byte, which is correct but undocumented, so I'm not sure if it was intentional.