### PR TITLE
Add IPLDStore placehold interface in runtime impl and make Runtime.IpldGet perform deserialization

### DIFF
--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_boilerplate.go
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_boilerplate.go
@@ -29,13 +29,12 @@ var TODO = util.TODO
 
 func (a *StoragePowerActorCode_I) State(rt Runtime) (vmr.ActorStateHandle, StoragePowerActorState) {
 	h := rt.AcquireState()
-	stateCID := h.Take()
-	stateBytes := rt.IpldGet(ipld.CID(stateCID))
-	if stateBytes.Which() != vmr.Runtime_IpldGet_FunRet_Case_Bytes {
-		rt.AbortAPI("IPLD lookup error")
+	stateCID := ipld.CID(h.Take())
+	var state StoragePowerActorState_I
+	if !rt.IpldGet(stateCID, &state) {
+		rt.AbortAPI("state not found")
 	}
-	state := DeserializeState(stateBytes.As_Bytes())
-	return h, state
+	return h, &state
 }
 func Release(rt Runtime, h vmr.ActorStateHandle, st StoragePowerActorState) {
 	checkCID := actor.ActorSubstateCID(rt.IpldPut(st.Impl()))

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_state.go
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_state.go
@@ -117,7 +117,7 @@ func (st *StoragePowerActorState_I) GetCurrPledgeForMiner(minerAddr addr.Address
 	return actor_util.BalanceTable_GetEntry(st.EscrowTable(), minerAddr)
 }
 
-func _getStorageFaultSlashPledgePercent(faultType sector.StorageFaultType) int {
+func (st *StoragePowerActorState_I) _getStorageFaultSlashPledgePercent(faultType sector.StorageFaultType) int {
 	PARAM_FINISH() // TODO: instantiate these placeholders
 	panic("")
 

--- a/src/systems/filecoin_markets/storage_market/storage_market_actor_boilerplate.go
+++ b/src/systems/filecoin_markets/storage_market/storage_market_actor_boilerplate.go
@@ -28,13 +28,12 @@ var IMPL_TODO = util.IMPL_TODO
 
 func (a *StorageMarketActorCode_I) State(rt Runtime) (vmr.ActorStateHandle, StorageMarketActorState) {
 	h := rt.AcquireState()
-	stateCID := h.Take()
-	stateBytes := rt.IpldGet(ipld.CID(stateCID))
-	if stateBytes.Which() != vmr.Runtime_IpldGet_FunRet_Case_Bytes {
-		rt.AbortAPI("IPLD lookup error")
+	var state StorageMarketActorState_I
+	stateCID := ipld.CID(h.Take())
+	if !rt.IpldGet(stateCID, &state) {
+		rt.AbortAPI("state not found")
 	}
-	state := Deserialize_StorageMarketActorState_Assert(stateBytes.As_Bytes())
-	return h, state
+	return h, &state
 }
 func Release(rt Runtime, h vmr.ActorStateHandle, st StorageMarketActorState) {
 	checkCID := actor.ActorSubstateCID(rt.IpldPut(st.Impl()))

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
@@ -152,13 +152,15 @@ type MinerInfo struct {
     // Account that owns this miner.
     // - Income and returned collateral are paid to this address.
     // - This address is also allowed to change the worker address for the miner.
-    Owner                   address.Address
+    Owner                   address.Address  // Must be an ID-address.
+    OwnerKey                filcrypto.VRFPublicKey
 
     // Worker account for this miner.
     // This will be the key that is used to sign blocks created by this miner, and
     // sign messages sent on behalf of this miner to commit sectors, submit PoSts, and
     // other day to day miner activities.
-    Worker                  address.Address
+    Worker                  address.Address  // Must be an ID-address.
+    WorkerKey               filcrypto.VRFPublicKey
 
     // Libp2p identity that should be used when connecting to this miner.
     PeerId                  libp2p.PeerID

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor_boilerplate.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor_boilerplate.go
@@ -20,13 +20,12 @@ var TODO = util.TODO
 
 func (a *StorageMinerActorCode_I) State(rt Runtime) (vmr.ActorStateHandle, StorageMinerActorState) {
 	h := rt.AcquireState()
-	stateCID := h.Take()
-	stateBytes := rt.IpldGet(ipld.CID(stateCID))
-	if stateBytes.Which() != vmr.Runtime_IpldGet_FunRet_Case_Bytes {
-		rt.AbortAPI("IPLD lookup error")
+	stateCID := ipld.CID(h.Take())
+	var state StorageMinerActorState_I
+	if !rt.IpldGet(stateCID, &state) {
+		rt.AbortAPI("state not found")
 	}
-	state := DeserializeState(stateBytes.As_Bytes())
-	return h, state
+	return h, &state
 }
 func Release(rt Runtime, h vmr.ActorStateHandle, st StorageMinerActorState) {
 	checkCID := actor.ActorSubstateCID(rt.IpldPut(st.Impl()))

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor_code.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor_code.go
@@ -25,7 +25,6 @@ func (a *StorageMinerActorCode_I) OnCronTickEnd(rt Runtime) InvocOutput {
 	a._checkSurprisePoStSubmissionHappened(rt)
 
 	return rt.SuccessReturn()
-
 }
 
 // Surprise PoSt

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor_state.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor_state.go
@@ -217,6 +217,11 @@ func (st *StorageMinerActorState_I) _getSectorWeight(sectorNo sector.SectorNumbe
 	return sectorInfo.SectorWeight(), true
 }
 
+func (st *StorageMinerActorState_I) _getSectorPower(sectorNo sector.SectorNumber) (power block.StoragePower, ok bool) {
+	TODO()
+	panic("")
+}
+
 func (st *StorageMinerActorState_I) _getSectorDealIDs(sectorNo sector.SectorNumber) (dealIDs deal.DealIDs, ok bool) {
 	sectorInfo, found := st._getSectorOnChainInfo(sectorNo)
 	if !found {

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor_state.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor_state.go
@@ -5,24 +5,10 @@ import (
 	deal "github.com/filecoin-project/specs/systems/filecoin_markets/deal"
 	sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 	actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
-	addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
-	st "github.com/filecoin-project/specs/systems/filecoin_vm/state_tree"
 	util "github.com/filecoin-project/specs/util"
 )
 
 var Assert = util.Assert
-
-// Get the owner account address associated to a given miner actor.
-func GetMinerOwnerAddress(tree st.StateTree, minerAddr addr.Address) (addr.Address, error) {
-	panic("TODO")
-}
-
-// Get the owner account address associated to a given miner actor.
-func GetMinerOwnerAddress_Assert(tree st.StateTree, a addr.Address) addr.Address {
-	ret, err := GetMinerOwnerAddress(tree, a)
-	Assert(err == nil)
-	return ret
-}
 
 func (st *StorageMinerActorState_I) _isChallenged() bool {
 	return st.ChallengeStatus().IsChallenged()

--- a/src/systems/filecoin_vm/interpreter/vm_interpreter.go
+++ b/src/systems/filecoin_vm/interpreter/vm_interpreter.go
@@ -29,6 +29,9 @@ const (
 	SenderResolveSpec_Invalid
 )
 
+// Placeholder for an IPLD tree store which is provided to the interpreter.
+var store vmri.IPLDStore
+
 // Applies all the message in a tipset, along with implicit block- and tipset-specific state
 // transitions.
 func (vmi *VMInterpreter_I) ApplyTipSetMessages(inTree st.StateTree, msgs TipSetMessages) (outTree st.StateTree, receipts []vmr.MessageReceipt) {
@@ -233,6 +236,7 @@ func _applyMessageInternal(
 	Assert(ok)
 
 	rt := vmri.VMContext_Make(
+		store,
 		message.From(),
 		topLevelBlockWinner,
 		fromActor.CallSeqNum(),

--- a/src/systems/filecoin_vm/runtime/impl/runtime.go
+++ b/src/systems/filecoin_vm/runtime/impl/runtime.go
@@ -168,6 +168,9 @@ func (rt *VMContext) CreateActor(codeID actor.CodeID, address addr.Address) {
 	if !rt._actorAddress.Equals(addr.InitActorAddr) {
 		rt.AbortAPI("Only InitActor may call rt.CreateActor")
 	}
+	if !address.IsIDType() {
+		rt.AbortAPI("New actor adddress must be an ID-address")
+	}
 
 	rt._createActor(codeID, address)
 }

--- a/src/systems/filecoin_vm/runtime/runtime.id
+++ b/src/systems/filecoin_vm/runtime/runtime.id
@@ -105,7 +105,9 @@ type Runtime interface {
         address  addr.Address
     )
 
-    IpldGet(c ipld.CID) union {Bytes, error}
+    // Retrieves and deserializes an object from the store into o. Returns whether successful.
+    IpldGet(c ipld.CID, o ipld.Object) bool
+    // Serializes and stores an object, returning its CID.
     IpldPut(x ipld.Object) ipld.CID
 }
 

--- a/src/systems/filecoin_vm/runtime/runtime.id
+++ b/src/systems/filecoin_vm/runtime/runtime.id
@@ -14,8 +14,9 @@ type Runtime interface {
     // Randomness returns a (pseudo)random stream (indexed by offset) for the current epoch.
     Randomness(e block.ChainEpoch, offset UInt) util.Randomness
 
-    // Note: This is the _immediate_ caller.
+    // The address of the immediate calling actor.
     // Not necessarily the actor in the From field of the initial on-chain Message.
+    // Always an ID-address.
     ImmediateCaller() addr.Address
     ValidateImmediateCallerIs(caller addr.Address)
     ValidateImmediateCallerInSet(callers [addr.Address])
@@ -24,10 +25,11 @@ type Runtime interface {
     ValidateImmediateCallerAcceptAny()
     ValidateImmediateCallerMatches(CallerPattern)
 
-    // The address of the actor receiving the message.
+    // The address of the actor receiving the message. Always an ID-address.
     CurrReceiver()         addr.Address
 
     // The actor who mined the block in which the initial on-chain message appears.
+    // Always an ID-address.
     ToplevelBlockWinner()  addr.Address
 
     AcquireState()         ActorStateHandle
@@ -95,13 +97,14 @@ type Runtime interface {
     // Computes an address for a new actor. The returned address is intended to uniquely refer to
     // the actor even in the event of a chain re-org (whereas an ID-address might refer to a
     // different actor after messages are re-ordered).
+    // Always an ActorExec address.
     NewActorAddress() addr.Address
 
     // Creates an actor in the state tree, with empty state. May only be called by InitActor.
     CreateActor(
         // The new actor's code identifier.
         codeId   actor.CodeID
-        // Address under which the new actor's state will be stored.
+        // Address under which the new actor's state will be stored. Must be an ID-address.
         address  addr.Address
     )
 

--- a/src/systems/filecoin_vm/sysactors/reward_actor.go
+++ b/src/systems/filecoin_vm/sysactors/reward_actor.go
@@ -20,22 +20,18 @@ var TODO = util.TODO
 
 func (a *RewardActorCode_I) State(rt Runtime) (vmr.ActorStateHandle, RewardActorState) {
 	h := rt.AcquireState()
-	stateCID := h.Take()
-	stateBytes := rt.IpldGet(ipld.CID(stateCID))
-	if stateBytes.Which() != vmr.Runtime_IpldGet_FunRet_Case_Bytes {
-		rt.AbortAPI("IPLD lookup error")
+	stateCID := ipld.CID(h.Take())
+	var state RewardActorState_I
+	if !rt.IpldGet(stateCID, &state) {
+		rt.AbortAPI("state not found")
 	}
-	state := DeserializeState(stateBytes.As_Bytes())
-	return h, state
+	return h, &state
 }
 func UpdateReleaseRewardActorState(rt Runtime, h vmr.ActorStateHandle, st RewardActorState) {
 	newCID := actor.ActorSubstateCID(rt.IpldPut(st.Impl()))
 	h.UpdateRelease(newCID)
 }
 func (st *RewardActorState_I) CID() ipld.CID {
-	panic("TODO")
-}
-func DeserializeState(x Bytes) RewardActorState {
 	panic("TODO")
 }
 

--- a/src/systems/filecoin_vm/sysactors/sysactors_boilerplate.go
+++ b/src/systems/filecoin_vm/sysactors/sysactors_boilerplate.go
@@ -32,18 +32,11 @@ var ArgEnd = actor_util.ArgEnd
 func _loadState(rt Runtime) (vmr.ActorStateHandle, InitActorState) {
 	h := rt.AcquireState()
 	stateCID := ipld.CID(h.Take())
-	if ipld.CID_Equals(stateCID, ipld.EmptyCID()) {
-		rt.AbortAPI("Actor state not initialized")
+	var state InitActorState_I
+	if !rt.IpldGet(stateCID, &state) {
+		rt.AbortAPI("state not found")
 	}
-	stateBytes := rt.IpldGet(ipld.CID(stateCID))
-	if stateBytes.Which() != vmr.Runtime_IpldGet_FunRet_Case_Bytes {
-		rt.AbortAPI("IPLD lookup error")
-	}
-	state, err := Deserialize_InitActorState(Serialization(stateBytes.As_Bytes()))
-	if err != nil {
-		rt.AbortAPI("State deserialization error")
-	}
-	return h, state
+	return h, &state
 }
 func Release(rt Runtime, h vmr.ActorStateHandle, st InitActorState) {
 	checkCID := actor.ActorSubstateCID(rt.IpldPut(st.Impl()))


### PR DESCRIPTION
IpldGet is now symmetric with IpldPut in performing de/serialization, and more useful.
Cleaned up a bunch of IPLD access, which revealed a few un-checked incompatibilities
between actor state structure definitions and their code. The new methods with `panic("TODO")` are added just to satisfy the compiler, but obviously they need implementing later.

The motivation for this is to make the IPLD store accessible in the VM runtime so that I can look up the init actor state for address resolution.

FYI @zixuanzh 