### PR TITLE
Indices touch up

### DIFF
--- a/src/systems/filecoin_blockchain/storage_power_consensus/expected_consensus.go
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/expected_consensus.go
@@ -5,7 +5,6 @@ import (
 
 	block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
 	chain "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/chain"
-	sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 	util "github.com/filecoin-project/specs/util"
 )
 
@@ -59,8 +58,4 @@ func (self *ExpectedConsensus_I) IsWinningChallengeTicket(challengeTicket util.B
 
 	// lhs < rhs?
 	return lhs.Cmp(rhs) == -1
-}
-
-func (self *ExpectedConsensus_I) GetBlockRewards(ePoStInfo sector.OnChainPoStVerifyInfo) util.UVarint {
-	panic("TODO")
 }

--- a/src/systems/filecoin_blockchain/storage_power_consensus/expected_consensus.id
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/expected_consensus.id
@@ -1,6 +1,5 @@
 import block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
 import chain "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/chain"
-import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 
 type ExpectedConsensus struct {
     expectedLeadersPerEpoch  UVarint
@@ -15,10 +14,6 @@ type ExpectedConsensus struct {
         numSectorsSampled  util.UVarint
         numSectorsMiner    util.UVarint
     ) bool
-
-    GetBlockRewards(
-        ePoStInfo sector.OnChainPoStVerifyInfo
-    ) UVarint
 
     log2b(x UVarint) UVarint
     wParams weightFunctionParameters

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor.id
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor.id
@@ -6,13 +6,14 @@ import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 
 type PowerTableEntry struct {
-    ActivePower    block.StoragePower
-    InactivePower  block.StoragePower
+    ActiveSectorWeight    block.SectorWeight
+    InactiveSectorWeight  block.SectorWeight
+    Power                 block.StoragePower
 }
 
 type PowerReport struct {
-    ActivePower    block.StoragePower  // set value
-    InactivePower  block.StoragePower  // set value
+    ActiveSectorWeight    block.SectorWeight  // set value
+    InactiveSectorWeight  block.SectorWeight  // set value
 }
 
 // type PowerTableHAMT {actor.ActorID: PowerTableEntry}
@@ -23,17 +24,15 @@ type StoragePowerActorState struct {
     EscrowTable           actor_util.BalanceTableHAMT
     _minersLargerThanMin  util.UVarint
 
-    ActivePowerMeetsConsensusMinimum(minPower block.StoragePower) bool
-    _getActivePowerForConsensus() block.StoragePower
+    MinerPowerMeetsConsensusMinimum(minPower block.StoragePower) bool
     _slashPledgeCollateral(address addr.Address, amount actor.TokenAmount) actor.TokenAmount
 
-    _getPowerTotalForMiner(minerAddr addr.Address) (
-        activePower    block.StoragePower
-        inactivePower  block.StoragePower
-        ok             bool
+    GetSectorWeightForMiner(minerAddr addr.Address) (
+        activeSectorWeight    block.SectorWeight
+        inactiveSectorWeight  block.SectorWeight
+        ok                    bool
     )
-    _getCurrPledgeForMiner(minerAddr addr.Address) (currPledge actor.TokenAmount, ok bool)
-    _getTotalPower() block.StoragePower
+    GetCurrPledgeForMiner(minerAddr addr.Address) (currPledge actor.TokenAmount, ok bool)
     _selectMinersToSurprise(challengeCount int, randomness util.Randomness) [addr.Address]
     _getStorageFaultSlashPledgePercent(faultType sector.StorageFaultType) int
 }

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_code.go
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor_code.go
@@ -192,7 +192,7 @@ func (a *StoragePowerActorCode_I) ProcessPowerReport(rt Runtime, report PowerRep
 	currPledge, ok := st.GetCurrPledgeForMiner(minerAddr)
 	Assert(ok)
 
-	newPower := inds.BlockReward_StoragePower(report.ActiveSectorWeight(), report.InactiveSectorWeight(), currPledge)
+	newPower := inds.StoragePower(report.ActiveSectorWeight(), report.InactiveSectorWeight(), currPledge)
 
 	// keep track of miners larger than minimum miner size before updating the PT
 	MIN_MINER_SIZE_STOR := block.StoragePower(0) // TODO: pull in from consts

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_consensus_subsystem.go
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_consensus_subsystem.go
@@ -10,6 +10,7 @@ import (
 	sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 	node_base "github.com/filecoin-project/specs/systems/filecoin_nodes/node_base"
 	addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
+	inds "github.com/filecoin-project/specs/systems/filecoin_vm/indices"
 	stateTree "github.com/filecoin-project/specs/systems/filecoin_vm/state_tree"
 	util "github.com/filecoin-project/specs/util"
 )
@@ -40,13 +41,12 @@ func (spc *StoragePowerConsensusSubsystem_I) ComputeChainWeight(tipset chain.Tip
 	return spc.ec().ComputeChainWeight(tipset)
 }
 
-func (spc *StoragePowerConsensusSubsystem_I) IsWinningPartialTicket(stateTree stateTree.StateTree, partialTicket sector.PartialTicket, sectorUtilization block.StoragePower, numSectors util.UVarint) bool {
+func (spc *StoragePowerConsensusSubsystem_I) IsWinningPartialTicket(stateTree stateTree.StateTree, inds inds.Indices, partialTicket sector.PartialTicket, sectorUtilization block.StoragePower, numSectors util.UVarint) bool {
 
 	// finalize the partial ticket
 	challengeTicket := filcrypto.SHA256(partialTicket)
 
-	st := spc._getStoragePowerActorState(stateTree)
-	networkPower := st._getActivePowerForConsensus()
+	networkPower := inds.TotalNetworkEffectivePower()
 
 	// TODO: pull from constants
 	EPOST_SAMPLE_RATE_NUM := util.UVarint(1)

--- a/src/systems/filecoin_blockchain/struct/block/election.id
+++ b/src/systems/filecoin_blockchain/struct/block/election.id
@@ -16,6 +16,7 @@ type Ticket struct {
 
 type BytesAmount UVarint
 type StoragePower BytesAmount
+type SectorWeight BytesAmount
 
 type TicketProductionSeedInput struct {
     PastTicket  util.Randomness

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor.id
@@ -35,7 +35,7 @@ type SectorStateTable struct {
 type SectorOnChainInfo struct {
     SealCommitment  sector.SealCommitment
     State           SectorState
-    Power           block.StoragePower
+    SectorWeight    block.SectorWeight
     Activation      block.ChainEpoch
     Expiration      block.ChainEpoch
 }
@@ -102,9 +102,9 @@ type StorageMinerActorState struct {
     _updateClearSectorAssert(sectorNo sector.SectorNumber)
     _updateActivateSectorAssert(sectorNo sector.SectorNumber)
 
-    _getActivePower()          (block.StoragePower, error)
-    _getInactivePower()        (block.StoragePower, error)
-    _getPreCommitDepositReq()  actor.TokenAmount
+    _getActiveSectorWeight()    (block.SectorWeight, error)
+    _getInactiveSectorWeight()  (block.SectorWeight, error)
+    _getPreCommitDepositReq()   actor.TokenAmount
 
     _getSectorOnChainInfo(sectorNo sector.SectorNumber) (info SectorOnChainInfo, ok bool)
     _getSectorPower(sectorNo sector.SectorNumber) (power block.StoragePower, ok bool)

--- a/src/systems/filecoin_mining/storage_mining/storage_miner_actor_state.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_miner_actor_state.go
@@ -51,22 +51,22 @@ func (st *StorageMinerActorState_I) _processStagedCommittedSectors() {
 	st.Impl().StagedCommittedSectors_ = make(map[sector.SectorNumber]SectorOnChainInfo)
 }
 
-func (st *StorageMinerActorState_I) _getActivePower() (block.StoragePower, error) {
-	activePower := block.StoragePower(0)
+func (st *StorageMinerActorState_I) _getActiveSectorWeight() (block.SectorWeight, error) {
+	activeSectorWeight := block.SectorWeight(0)
 
 	for _, sectorNo := range st.SectorTable().Impl().ActiveSectors_.SectorsOn() {
-		sectorPower, found := st._getSectorPower(sectorNo)
+		sectorWeight, found := st._getSectorWeight(sectorNo)
 		if !found {
 			panic("")
 		}
-		activePower += sectorPower
+		activeSectorWeight += sectorWeight
 	}
 
-	return activePower, nil
+	return activeSectorWeight, nil
 }
 
-func (st *StorageMinerActorState_I) _getInactivePower() (block.StoragePower, error) {
-	var inactivePower = block.StoragePower(0)
+func (st *StorageMinerActorState_I) _getInactiveSectorWeight() (block.SectorWeight, error) {
+	var inactiveSectorWeight = block.SectorWeight(0)
 
 	// iterate over sectorNo in CommittedSectors, RecoveringSectors, and FailingSectors
 	inactiveProvingSet := st.SectorTable().Impl().CommittedSectors_.Extend(st.SectorTable().RecoveringSectors())
@@ -74,14 +74,14 @@ func (st *StorageMinerActorState_I) _getInactivePower() (block.StoragePower, err
 
 	for _, sectorNo := range inactiveSectorSet.SectorsOn() {
 
-		sectorPower, found := st._getSectorPower(sectorNo)
+		sectorWeight, found := st._getSectorWeight(sectorNo)
 		if !found {
 			panic("")
 		}
-		inactivePower += sectorPower
+		inactiveSectorWeight += sectorWeight
 	}
 
-	return inactivePower, nil
+	return inactiveSectorWeight, nil
 }
 
 // move Sector from Active/Failing
@@ -209,12 +209,12 @@ func (st *StorageMinerActorState_I) _getSectorOnChainInfo(sectorNo sector.Sector
 	return sectorInfo, true
 }
 
-func (st *StorageMinerActorState_I) _getSectorPower(sectorNo sector.SectorNumber) (power block.StoragePower, ok bool) {
+func (st *StorageMinerActorState_I) _getSectorWeight(sectorNo sector.SectorNumber) (power block.SectorWeight, ok bool) {
 	sectorInfo, found := st._getSectorOnChainInfo(sectorNo)
 	if !found {
-		return block.StoragePower(0), false
+		return block.SectorWeight(0), false
 	}
-	return sectorInfo.Power(), true
+	return sectorInfo.SectorWeight(), true
 }
 
 func (st *StorageMinerActorState_I) _getSectorDealIDs(sectorNo sector.SectorNumber) (dealIDs deal.DealIDs, ok bool) {

--- a/src/systems/filecoin_mining/storage_mining/storage_mining_subsystem.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_mining_subsystem.go
@@ -15,6 +15,7 @@ import (
 	actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 	addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 	ai "github.com/filecoin-project/specs/systems/filecoin_vm/actor_interfaces"
+	inds "github.com/filecoin-project/specs/systems/filecoin_vm/indices"
 	msg "github.com/filecoin-project/specs/systems/filecoin_vm/message"
 	stateTree "github.com/filecoin-project/specs/systems/filecoin_vm/state_tree"
 	util "github.com/filecoin-project/specs/util"
@@ -248,7 +249,7 @@ func (sms *StorageMiningSubsystem_I) _getStoragePowerActorState(stateTree stateT
 	return st
 }
 
-func (sms *StorageMiningSubsystem_I) VerifyElectionPoSt(header block.BlockHeader, onChainInfo sector.OnChainPoStVerifyInfo) bool {
+func (sms *StorageMiningSubsystem_I) VerifyElectionPoSt(inds inds.Indices, header block.BlockHeader, onChainInfo sector.OnChainPoStVerifyInfo) bool {
 
 	sma := sms._getStorageMinerActorState(header.ParentState(), header.Miner())
 	spa := sms._getStoragePowerActorState(header.ParentState())
@@ -262,13 +263,21 @@ func (sms *StorageMiningSubsystem_I) VerifyElectionPoSt(header block.BlockHeader
 		return false
 	}
 
-	pow, err := sma._getActivePower()
-	if err != nil {
+	activeSectorWeight, inactiveSectorWeight, ok := spa.GetSectorWeightForMiner(header.Miner())
+	if !ok {
 		// TODO: better error handling
 		return false
 	}
 
-	if !spa.ActivePowerMeetsConsensusMinimum(pow) {
+	currPledge, ok := spa.GetCurrPledgeForMiner(header.Miner())
+	if !ok {
+		// TODO: better error handling
+		return false
+	}
+
+	pow := inds.BlockReward_StoragePower(activeSectorWeight, inactiveSectorWeight, currPledge)
+
+	if !spa.MinerPowerMeetsConsensusMinimum(pow) {
 		return false
 	}
 

--- a/src/systems/filecoin_mining/storage_mining/storage_mining_subsystem.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_mining_subsystem.go
@@ -275,7 +275,7 @@ func (sms *StorageMiningSubsystem_I) VerifyElectionPoSt(inds inds.Indices, heade
 		return false
 	}
 
-	pow := inds.BlockReward_StoragePower(activeSectorWeight, inactiveSectorWeight, currPledge)
+	pow := inds.StoragePower(activeSectorWeight, inactiveSectorWeight, currPledge)
 
 	if !spa.MinerPowerMeetsConsensusMinimum(pow) {
 		return false

--- a/src/systems/filecoin_vm/indices/indices.go
+++ b/src/systems/filecoin_vm/indices/indices.go
@@ -97,6 +97,7 @@ func (inds *Indices_I) BlockReward_PledgeCollateralProportion(minerPledgeCollate
 
 func (inds *Indices_I) BlockReward_StoragePower(
 	minerActiveSectorWeight block.SectorWeight,
+	minerInactiveSectorWeight block.SectorWeight,
 	minerPledgeCollateral actor.TokenAmount,
 ) block.StoragePower {
 	// return StoragePower based on inputs

--- a/src/systems/filecoin_vm/indices/indices.go
+++ b/src/systems/filecoin_vm/indices/indices.go
@@ -62,12 +62,12 @@ func (inds *Indices_I) StorageDeal_ClientCollateralBounds(
 	panic("")
 }
 
-func (inds *Indices_I) BlockReward_SectorPower(
+func (inds *Indices_I) BlockReward_SectorWeight(
 	sectorSize sector.SectorSize,
 	startEpoch block.ChainEpoch,
 	endEpoch block.ChainEpoch,
 	dealWeight deal.DealWeight,
-) block.StoragePower {
+) block.SectorWeight {
 	// for every sector, given its size, start, end, and deals within the sector
 	// assign sector power for the duration of its lifetime
 	PARAM_FINISH()
@@ -75,48 +75,55 @@ func (inds *Indices_I) BlockReward_SectorPower(
 }
 
 func (inds *Indices_I) BlockReward_PledgeCollateralReq(
-	minerActiveStoragePower block.StoragePower,
-	minerInactiveStoragePower block.StoragePower,
+	minerActiveSectorWeight block.SectorWeight,
+	minerInactiveSectorWeight block.SectorWeight,
 	minerPledgeCollateral actor.TokenAmount,
 ) actor.TokenAmount {
 	PARAM_FINISH()
 	panic("")
 }
 
-func (inds *Indices_I) BlockReward_StoragePowerProportion(minerActiveStoragePower block.StoragePower) util.BigInt {
-	// return proportion of StoragePower for miner
+func (inds *Indices_I) BlockReward_SectorWeightProportion(minerActiveSectorWeight block.SectorWeight) util.BigInt {
+	// return proportion of SectorWeight for miner
 	PARAM_FINISH()
 	panic("")
 }
 
-func (inds *Indices_I) BlockReward_CollateralPowerProportion(minerPledgeCollateral actor.TokenAmount) util.BigInt {
+func (inds *Indices_I) BlockReward_PledgeCollateralProportion(minerPledgeCollateral actor.TokenAmount) util.BigInt {
 	// return proportion of Pledge Collateral for miner
 	PARAM_FINISH()
 	panic("")
 }
 
-func (inds *Indices_I) BlockReward_EarningPowerProportion(
-	minerActiveStoragePower block.StoragePower,
+func (inds *Indices_I) BlockReward_StoragePower(
+	minerActiveSectorWeight block.SectorWeight,
 	minerPledgeCollateral actor.TokenAmount,
+) block.StoragePower {
+	// return StoragePower based on inputs
+	// StoragePower for miner = func(ActiveSectorWeight for miner, PledgeCollateral for miner, global indices)
+	PARAM_FINISH()
+	panic("")
+}
+
+func (inds *Indices_I) BlockReward_StoragePowerProportion(
+	minerStoragePower block.StoragePower,
 ) util.BigInt {
-	// Earning Power for miner = func(proportion of StoragePower for miner, proportion of CollateralPower for miner)
-	// EarningPowerProportion is a normalized proportion of TotalEarningPower
 	PARAM_FINISH()
 	panic("")
 }
 
 func (inds *Indices_I) BlockReward_CurrEpochReward() actor.TokenAmount {
 	// total block reward allocated for CurrEpoch
-	// each expected winner get a share of this reward
+	// each expected winner get an equal share of this reward
 	// computed as a function of NetworkKPI, LastEpochReward, TotalUnmminedFIL, etc
 	PARAM_FINISH()
 	panic("")
 }
 
 func (inds *Indices_I) BlockReward_GetCurrRewardForMiner(
-	minerActiveStoragePower block.StoragePower,
+	minerStoragePower block.StoragePower,
 	minerPledgeCollateral actor.TokenAmount,
-	// TODO extend
+	// TODO extend or eliminate
 ) actor.TokenAmount {
 	PARAM_FINISH()
 	panic("")
@@ -124,8 +131,8 @@ func (inds *Indices_I) BlockReward_GetCurrRewardForMiner(
 
 func (inds *Indices_I) BlockReward_GetPledgeSlashForStorageFault(
 	affectedPower block.StoragePower,
-	newActivePower block.StoragePower,
-	newInactivePower block.StoragePower,
+	newActiveSectorWeight block.SectorWeight,
+	newInactiveSectorWeight block.SectorWeight,
 	currPledge actor.TokenAmount,
 ) actor.TokenAmount {
 	PARAM_FINISH()

--- a/src/systems/filecoin_vm/indices/indices.go
+++ b/src/systems/filecoin_vm/indices/indices.go
@@ -95,7 +95,7 @@ func (inds *Indices_I) BlockReward_PledgeCollateralProportion(minerPledgeCollate
 	panic("")
 }
 
-func (inds *Indices_I) BlockReward_StoragePower(
+func (inds *Indices_I) StoragePower(
 	minerActiveSectorWeight block.SectorWeight,
 	minerInactiveSectorWeight block.SectorWeight,
 	minerPledgeCollateral actor.TokenAmount,

--- a/src/systems/filecoin_vm/indices/indices.id
+++ b/src/systems/filecoin_vm/indices/indices.id
@@ -9,19 +9,19 @@ import deal "github.com/filecoin-project/specs/systems/filecoin_markets/deal"
 // it is a passive data structure that allows for convenience access to network indices
 // and pure functions in implementing economic policies given states
 type Indices struct {
-
     // these fields are computed from StateTree upon construction
     // they are treated as globally available states
-    Epoch                    block.ChainEpoch
-    NetworkKPI               BigInt
-    TotalNetworkSectorWeight block.SectorWeight
-    TotalPledgeCollateral    actor.TokenAmount
-    TotalNetworkPower  block.StoragePower
+    Epoch                       block.ChainEpoch
+    NetworkKPI                  BigInt
+    TotalNetworkSectorWeight    block.SectorWeight
+    TotalPledgeCollateral       actor.TokenAmount
+    TotalNetworkEffectivePower  block.StoragePower  // power above minimum miner size
+    TotalNetworkPower           block.StoragePower
 
-    TotalMinedFIL            actor.TokenAmount
-    TotalUnminedFIL          actor.TokenAmount
-    TotalBurnedFIL           actor.TokenAmount
-    LastEpochReward          actor.TokenAmount
+    TotalMinedFIL               actor.TokenAmount
+    TotalUnminedFIL             actor.TokenAmount
+    TotalBurnedFIL              actor.TokenAmount
+    LastEpochReward             actor.TokenAmount
 
     // these methods produce policy output based on user state/action
     StorageDeal_DurationBounds(
@@ -75,26 +75,27 @@ type Indices struct {
     ) BigInt
 
     BlockReward_StoragePower(
-        minerActiveSectorWeight block.SectorWeight,
-        minerPledgeCollateral actor.TokenAmount,
+        minerActiveSectorWeight    block.SectorWeight
+        minerInactiveSectorWeight  block.SectorWeight
+        minerPledgeCollateral      actor.TokenAmount
     ) block.StoragePower
 
     BlockReward_StoragePowerProportion(
-        minerStoragePower  block.StoragePower
-        minerPledgeCollateral    actor.TokenAmount
+        minerStoragePower      block.StoragePower
+        minerPledgeCollateral  actor.TokenAmount
     ) BigInt
 
     BlockReward_CurrEpochReward() actor.TokenAmount
 
     BlockReward_GetCurrRewardForMiner(
-        minerStoragePower  block.StoragePower
-        minerPledgeCollateral    actor.TokenAmount
+        minerStoragePower      block.StoragePower
+        minerPledgeCollateral  actor.TokenAmount
     ) actor.TokenAmount
 
     BlockReward_GetPledgeSlashForStorageFault(
-        affectedPower     block.StoragePower
-        newActivePower    block.StoragePower
-        newInactivePower  block.StoragePower
-        currPledge        actor.TokenAmount
+        affectedPower            block.StoragePower
+        newActiveSectorWeight    block.SectorWeight
+        newInactiveSectorWeight  block.SectorWeight
+        currPledge               actor.TokenAmount
     ) actor.TokenAmount
 }

--- a/src/systems/filecoin_vm/indices/indices.id
+++ b/src/systems/filecoin_vm/indices/indices.id
@@ -4,23 +4,26 @@ import piece "github.com/filecoin-project/specs/systems/filecoin_files/piece"
 import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 import deal "github.com/filecoin-project/specs/systems/filecoin_markets/deal"
 
-type CollateralPower block.BytesAmount
-type EarningPower block.BytesAmount
-
 // Data in Indices are populated at instantiation with data from the state tree
 // Indices itself has no state tree or access to the runtime
 // it is a passive data structure that allows for convenience access to network indices
 // and pure functions in implementing economic policies given states
 type Indices struct {
+
+    // these fields are computed from StateTree upon construction
+    // they are treated as globally available states
     Epoch                    block.ChainEpoch
     NetworkKPI               BigInt
-    TotalNetworkActivePower  BigInt
-    TotalPledgeCollateral    BigInt
-    TotalEarningPower        BigInt
-    TotalMinedFIL            BigInt
-    TotalUnminedFIL          BigInt
-    TotalBurnedFIL           BigInt
+    TotalNetworkSectorWeight block.SectorWeight
+    TotalPledgeCollateral    actor.TokenAmount
+    TotalNetworkPower  block.StoragePower
 
+    TotalMinedFIL            actor.TokenAmount
+    TotalUnminedFIL          actor.TokenAmount
+    TotalBurnedFIL           actor.TokenAmount
+    LastEpochReward          actor.TokenAmount
+
+    // these methods produce policy output based on user state/action
     StorageDeal_DurationBounds(
         pieceSize   piece.PieceSize
         startEpoch  block.ChainEpoch
@@ -50,36 +53,41 @@ type Indices struct {
         maxClientCollateral  actor.TokenAmount
     )
 
-    BlockReward_SectorPower(
+    BlockReward_SectorWeight(
         sectorSize  sector.SectorSize
         startEpoch  block.ChainEpoch
         endEpoch    block.ChainEpoch
         dealWeight  deal.DealWeight
-    ) block.StoragePower
+    ) block.SectorWeight
 
     BlockReward_PledgeCollateralReq(
-        minerActiveStoragePower    block.StoragePower
-        minerInactiveStoragePower  block.StoragePower
+        minerActiveSectorWeight    block.SectorWeight
+        minerInactiveSectorWeight  block.SectorWeight
         minerPledgeCollateral      actor.TokenAmount
     ) actor.TokenAmount
 
-    BlockReward_StoragePowerProportion(
-        minerActiveStoragePower block.StoragePower
+    BlockReward_SectorWeightProportion(
+        minerActiveSectorWeight block.SectorWeight
     ) BigInt
 
-    BlockReward_CollateralPowerProportion(
+    BlockReward_PledgeCollateralProportion(
         minerPledgeCollateral actor.TokenAmount
     ) BigInt
 
-    BlockReward_EarningPowerProportion(
-        minerActiveStoragePower  block.StoragePower
+    BlockReward_StoragePower(
+        minerActiveSectorWeight block.SectorWeight,
+        minerPledgeCollateral actor.TokenAmount,
+    ) block.StoragePower
+
+    BlockReward_StoragePowerProportion(
+        minerStoragePower  block.StoragePower
         minerPledgeCollateral    actor.TokenAmount
-    ) EarningPower
+    ) BigInt
 
     BlockReward_CurrEpochReward() actor.TokenAmount
 
     BlockReward_GetCurrRewardForMiner(
-        minerActiveStoragePower  block.StoragePower
+        minerStoragePower  block.StoragePower
         minerPledgeCollateral    actor.TokenAmount
     ) actor.TokenAmount
 

--- a/src/systems/filecoin_vm/indices/indices.id
+++ b/src/systems/filecoin_vm/indices/indices.id
@@ -74,7 +74,7 @@ type Indices struct {
         minerPledgeCollateral actor.TokenAmount
     ) BigInt
 
-    BlockReward_StoragePower(
+    StoragePower(
         minerActiveSectorWeight    block.SectorWeight
         minerInactiveSectorWeight  block.SectorWeight
         minerPledgeCollateral      actor.TokenAmount

--- a/src/systems/filecoin_vm/state_tree/state_tree.go
+++ b/src/systems/filecoin_vm/state_tree/state_tree.go
@@ -8,6 +8,7 @@ import (
 )
 
 var Assert = util.Assert
+var IMPL_TODO = util.IMPL_TODO
 
 func (st *StateTree_I) RootCID() ipld.CID {
 	panic("TODO")

--- a/src/systems/filecoin_vm/sysactors/reward_actor.go
+++ b/src/systems/filecoin_vm/sysactors/reward_actor.go
@@ -16,6 +16,8 @@ import (
 // Boilerplate
 ////////////////////////////////////////////////////////////////////////////////
 
+var TODO = util.TODO
+
 func (a *RewardActorCode_I) State(rt Runtime) (vmr.ActorStateHandle, RewardActorState) {
 	h := rt.AcquireState()
 	stateCID := h.Take()
@@ -44,6 +46,7 @@ func (r *Reward_I) AmountVested(elapsedEpoch block.ChainEpoch) actor.TokenAmount
 	case VestingFunction_None:
 		return r.Value()
 	case VestingFunction_Linear:
+		TODO() // BigInt
 		vestedProportion := math.Max(1.0, float64(elapsedEpoch)/float64(r.StartEpoch()-r.EndEpoch()))
 		return actor.TokenAmount(uint64(r.Value()) * uint64(vestedProportion))
 	default:
@@ -102,10 +105,11 @@ func (a *RewardActorCode_I) AwardBlockReward(
 	inds := rt.CurrIndices()
 	pledgeReq := inds.BlockReward_PledgeCollateralReq(minerActivePower, minerInactivePower, currPledge)
 	currReward := inds.BlockReward_GetCurrRewardForMiner(minerActivePower, currPledge)
+	TODO() // BigInt
 	underPledge := math.Max(float64(actor.TokenAmount(0)), float64(pledgeReq-currPledge)) // 0 if over collateralized
 	rewardToGarnish := math.Min(float64(currReward), float64(underPledge))
 
-	util.TODO()
+	TODO()
 	// handle penalty here
 	// also handle penalty greater than reward
 	actualReward := currReward - actor.TokenAmount(rewardToGarnish)

--- a/src/systems/filecoin_vm/sysactors/reward_actor.go
+++ b/src/systems/filecoin_vm/sysactors/reward_actor.go
@@ -96,16 +96,17 @@ func (a *RewardActorCode_I) AwardBlockReward(
 	rt vmr.Runtime,
 	miner addr.Address,
 	penalty actor.TokenAmount,
-	minerActivePower block.StoragePower,
-	minerInactivePower block.StoragePower,
+	minerStoragePower block.StoragePower,
+	minerActiveSectorWeight block.SectorWeight,
+	minerInactiveSectorWeight block.SectorWeight,
 	currPledge actor.TokenAmount,
 ) {
 	rt.ValidateImmediateCallerIs(addr.SystemActorAddr)
 
 	inds := rt.CurrIndices()
-	pledgeReq := inds.BlockReward_PledgeCollateralReq(minerActivePower, minerInactivePower, currPledge)
-	currReward := inds.BlockReward_GetCurrRewardForMiner(minerActivePower, currPledge)
-	TODO() // BigInt
+	pledgeReq := inds.BlockReward_PledgeCollateralReq(minerActiveSectorWeight, minerInactiveSectorWeight, currPledge)
+	currReward := inds.BlockReward_GetCurrRewardForMiner(minerStoragePower, currPledge)
+	TODO()                                                                                // BigInt
 	underPledge := math.Max(float64(actor.TokenAmount(0)), float64(pledgeReq-currPledge)) // 0 if over collateralized
 	rewardToGarnish := math.Min(float64(currReward), float64(underPledge))
 


### PR DESCRIPTION
- [x] Add BigInt TODOs
- [x] ActivePower -> ActiveSectorWeight
- [x] InactivePower -> InactiveSectorWeight
- [x] SectorWeight is assigned by indices.BlockReward_SectorWeight
- [x] EffectivePower -> StoragePower which is set by indices.BlockReward_StoragePower
- [x] TotalNetworkEffectivePower (network power accounting for miners smaller than minimum miner size)
- [x] CollateralPower -> CollateralProportion
- [x] KPI remains a field in indices instead of method, all fields should be considered as global states and methods return policy output given agent states/actions

Upcoming:
- [ ] touch up ePoSt winning ticket check with @sternhenri 