### PR TITLE
Reserved ranges for actors and methods

### DIFF
--- a/src/actors/builtin/cron/cron_actor.go
+++ b/src/actors/builtin/cron/cron_actor.go
@@ -4,16 +4,15 @@ import (
 	abi "github.com/filecoin-project/specs/actors/abi"
 	builtin "github.com/filecoin-project/specs/actors/builtin"
 	vmr "github.com/filecoin-project/specs/actors/runtime"
-	actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 )
 
-func (a *CronActorCode_I) Constructor(rt vmr.Runtime) InvocOutput {
+func (a *CronActorCode_I) Constructor(rt vmr.Runtime) vmr.InvocOutput {
 	// Nothing. intentionally left blank.
 	rt.ValidateImmediateCallerIs(builtin.SystemActorAddr)
 	return rt.SuccessReturn()
 }
 
-func (a *CronActorCode_I) EpochTick(rt vmr.Runtime) InvocOutput {
+func (a *CronActorCode_I) EpochTick(rt vmr.Runtime) vmr.InvocOutput {
 	rt.ValidateImmediateCallerIs(builtin.SystemActorAddr)
 
 	// a.Entries is basically a static registry for now, loaded

--- a/src/actors/builtin/cron/cron_actor.go
+++ b/src/actors/builtin/cron/cron_actor.go
@@ -7,13 +7,6 @@ import (
 	actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 )
 
-const (
-	Method_CronActor_EpochTick = actor.MethodPlaceholder + iota
-)
-
-type InvocOutput = vmr.InvocOutput
-type Runtime = vmr.Runtime
-
 func (a *CronActorCode_I) Constructor(rt vmr.Runtime) InvocOutput {
 	// Nothing. intentionally left blank.
 	rt.ValidateImmediateCallerIs(builtin.SystemActorAddr)

--- a/src/listings/_index.md
+++ b/src/listings/_index.md
@@ -2,7 +2,7 @@
 title: Listings
 entries:
   - actors
-  - listings
+  - reserved_ranges
   - data_structures
   - system_map
   - libp2p_protocols

--- a/src/listings/_index.md
+++ b/src/listings/_index.md
@@ -2,6 +2,7 @@
 title: Listings
 entries:
   - actors
+  - listings
   - data_structures
   - system_map
   - libp2p_protocols

--- a/src/listings/reserved_ranges.md
+++ b/src/listings/reserved_ranges.md
@@ -2,7 +2,7 @@
 title: "Reserved Ranges"
 ---
 
-# Actor Reserved Ranges
+# Actor ID Reserved Ranges
 
 | Actor                | ID |
 |---|---|

--- a/src/listings/reserved_ranges.md
+++ b/src/listings/reserved_ranges.md
@@ -1,0 +1,10 @@
+---
+title: "Reserved Ranges"
+---
+
+# Actor Reserved Ranges
+
+# Method Reserved Ranges
+
+# Error Codes
+

--- a/src/listings/reserved_ranges.md
+++ b/src/listings/reserved_ranges.md
@@ -6,88 +6,24 @@ title: "Reserved Ranges"
 
 | Actor                | ID |
 |---|---|
-| SystemActor          | 1 |
-| InitActor            | 2 |
+| SystemActor          | 0 |
+| InitActor            | 1 |
+| RewardActor          | 2 |
 | CronActor            | 3 |
-| AccountActor         | 4 |
-| StoragePowerActor    | 5 |
-| StorageMinerActor    | 6 |
-| StorageMarketActor   | 7 |
-| PaymentChannelActor  | 8 |
+| StoragePowerActor    | 4 |
+| StorageMarketActor   | 5 |
+| BurnFundsActor       | 99 |
+
+All values below 100 are reserved for singleton actors. The first non-singleton actor starts at 100.
 
 # Method Reserved Ranges
 
-## InitActor Methods
-| Method                                    | ID |
+| Method               | ID |
 |---|---|
-| Method_InitActor_Exec                     | 1 |
-| Method_InitActor_GetActorIDForAddress     | 2 |
+| value send           | 0 |
+| constructor          | 1 |
 
-## RewardActor Methods
-| Method                                    | ID |
-|---|---|
-| Method_RewardActor_AwardBlockReward       | 1 |
-
-## MultiSigActor Methods
-| Method                                            | ID |
-|---|---|
-| Method_MultiSigActor_Propose                      | 1 |
-| Method_MultiSigActor_Approve                      | 2 |
-|	Method_MultiSigActor_AddAuthorizedParty           | 3 |
-|	Method_MultiSigActor_RemoveAuthorizedParty        | 4 |
-|	Method_MultiSigActor_SwapAuthorizedParty          | 5 |
-|	Method_MultiSigActor_ChangeNumApprovalsThreshold  | 6 |
-
-## StorageMinerActor Methods
-| Method                                              | ID |
-|---|---|
-| Method_StorageMinerActor_OnDeferredCronEvent        | # |
-|	Method_StorageMinerActor_PreCommitSector            | # |
-|	Method_StorageMinerActor_ProveCommitSector          | # |
-|	Method_StorageMinerActor_DeclareTemporaryFaults     | # |
-|	Method_StorageMinerActor_RecoverTemporaryFaults     | # |
-|	Method_StorageMinerActor_ExtendSectorExpiration     | # |
-|	Method_StorageMinerActor_TerminateSector            | # |
-|	Method_StorageMinerActor_SubmitSurprisePoStResponse | # |
-|	Method_StorageMinerActor_OnVerifiedElectionPoSt     | # |
-|	Method_StorageMinerActor_OnSurprisePoStChallenge    | # |
-|	Method_StorageMinerActor_GetPoStState               | # |
-|	Method_StorageMinerActor_GetOwnerAddr               | # |
-|	Method_StorageMinerActor_GetWorkerAddr              | # |
-|	Method_StorageMinerActor_GetWorkerVRFKey            | # |
-
-## StorageMarketActor Methods
-| Method                                                                  | ID |
-|---|---|
-| Method_StorageMarketActor_OnEpochTickEnd                                | 1 |
-| Method_StorageMarketActor_AddBalance                                    | 2 |
-|	Method_StorageMarketActor_WithdrawBalance                               | 3 |
-|	Method_StorageMarketActor_PublishStorageDeals                           | 4 |
-|	Method_StorageMarketActor_OnMinerSectorPreCommit_VerifyDealsOrAbort     | 5 |
-|	Method_StorageMarketActor_OnMinerSectorProveCommit_VerifyDealsOrAbort   | 6 |
-|	Method_StorageMarketActor_OnMinerSectorsTerminate                       | 7 |
-|	Method_StorageMarketActor_GetPieceInfosForDealIDs                       | 8 |
-|	Method_StorageMarketActor_GetWeightForDealSet                           | 9 |
-
-## StoragePowerActor Methods
-| Method                                                        | ID |
-|---|---|
-|	Method_StoragePowerActor_OnEpochTickEnd                       | 1 |
-|	Method_StoragePowerActor_AddBalance                           | 2 |
-|	Method_StoragePowerActor_WithdrawBalance                      | 3 |
-|	Method_StoragePowerActor_CreateMiner                          | 4 |
-|	Method_StoragePowerActor_DeleteMiner                          | 5 |
-|	Method_StoragePowerActor_ReportConsensusFault                 | 6 |
-|	Method_StoragePowerActor_OnSectorProveCommit                  | 7 |
-|	Method_StoragePowerActor_OnSectorTemporaryFaultEffectiveBegin | 8 |
-|	Method_StoragePowerActor_OnSectorTemporaryFaultEffectiveEnd   | 9 |
-|	Method_StoragePowerActor_OnSectorModifyWeightDesc             | 10 |
-|	Method_StoragePowerActor_OnSectorTerminate                    | 11 |
-|	Method_StoragePowerActor_OnMinerSurprisePoStSuccess           | 12 |
-|	Method_StoragePowerActor_OnMinerSurprisePoStFailure           | 13 |
-|	Method_StoragePowerActor_OnMinerEnrollCronEvent               | 14 |
-|	Method_StoragePowerActor_GetMinerConsensusPower               | 15 |
-|	Method_StoragePowerActor_GetMinerUnmetPledgeCollateralRequirement | 16 |
+All other positive values are free for actors to use. For the canonical list, see TODO LINK TO ACTOR CODE WHEN DONE.
 
 # Error Codes
 

--- a/src/listings/reserved_ranges.md
+++ b/src/listings/reserved_ranges.md
@@ -17,5 +17,78 @@ title: "Reserved Ranges"
 
 # Method Reserved Ranges
 
+## InitActor Methods
+| Method                                    | ID |
+|---|---|
+| Method_InitActor_Exec                     | 1 |
+| Method_InitActor_GetActorIDForAddress     | 2 |
+
+## RewardActor Methods
+| Method                                    | ID |
+|---|---|
+| Method_RewardActor_AwardBlockReward       | 1 |
+
+## MultiSigActor Methods
+| Method                                            | ID |
+|---|---|
+| Method_MultiSigActor_Propose                      | 1 |
+| Method_MultiSigActor_Approve                      | 2 |
+|	Method_MultiSigActor_AddAuthorizedParty           | 3 |
+|	Method_MultiSigActor_RemoveAuthorizedParty        | 4 |
+|	Method_MultiSigActor_SwapAuthorizedParty          | 5 |
+|	Method_MultiSigActor_ChangeNumApprovalsThreshold  | 6 |
+
+## StorageMinerActor Methods
+| Method                                              | ID |
+|---|---|
+| Method_StorageMinerActor_OnDeferredCronEvent        | # |
+|	Method_StorageMinerActor_PreCommitSector            | # |
+|	Method_StorageMinerActor_ProveCommitSector          | # |
+|	Method_StorageMinerActor_DeclareTemporaryFaults     | # |
+|	Method_StorageMinerActor_RecoverTemporaryFaults     | # |
+|	Method_StorageMinerActor_ExtendSectorExpiration     | # |
+|	Method_StorageMinerActor_TerminateSector            | # |
+|	Method_StorageMinerActor_SubmitSurprisePoStResponse | # |
+|	Method_StorageMinerActor_OnVerifiedElectionPoSt     | # |
+|	Method_StorageMinerActor_OnSurprisePoStChallenge    | # |
+|	Method_StorageMinerActor_GetPoStState               | # |
+|	Method_StorageMinerActor_GetOwnerAddr               | # |
+|	Method_StorageMinerActor_GetWorkerAddr              | # |
+|	Method_StorageMinerActor_GetWorkerVRFKey            | # |
+
+## StorageMarketActor Methods
+| Method                                                                  | ID |
+|---|---|
+| Method_StorageMarketActor_OnEpochTickEnd                                | 1 |
+| Method_StorageMarketActor_AddBalance                                    | 2 |
+|	Method_StorageMarketActor_WithdrawBalance                               | 3 |
+|	Method_StorageMarketActor_PublishStorageDeals                           | 4 |
+|	Method_StorageMarketActor_OnMinerSectorPreCommit_VerifyDealsOrAbort     | 5 |
+|	Method_StorageMarketActor_OnMinerSectorProveCommit_VerifyDealsOrAbort   | 6 |
+|	Method_StorageMarketActor_OnMinerSectorsTerminate                       | 7 |
+|	Method_StorageMarketActor_GetPieceInfosForDealIDs                       | 8 |
+|	Method_StorageMarketActor_GetWeightForDealSet                           | 9 |
+
+## StoragePowerActor Methods
+| Method                                                        | ID |
+|---|---|
+|	Method_StoragePowerActor_OnEpochTickEnd                       | 1 |
+|	Method_StoragePowerActor_AddBalance                           | 2 |
+|	Method_StoragePowerActor_WithdrawBalance                      | 3 |
+|	Method_StoragePowerActor_CreateMiner                          | 4 |
+|	Method_StoragePowerActor_DeleteMiner                          | 5 |
+|	Method_StoragePowerActor_ReportConsensusFault                 | 6 |
+|	Method_StoragePowerActor_OnSectorProveCommit                  | 7 |
+|	Method_StoragePowerActor_OnSectorTemporaryFaultEffectiveBegin | 8 |
+|	Method_StoragePowerActor_OnSectorTemporaryFaultEffectiveEnd   | 9 |
+|	Method_StoragePowerActor_OnSectorModifyWeightDesc             | 10 |
+|	Method_StoragePowerActor_OnSectorTerminate                    | 11 |
+|	Method_StoragePowerActor_OnMinerSurprisePoStSuccess           | 12 |
+|	Method_StoragePowerActor_OnMinerSurprisePoStFailure           | 13 |
+|	Method_StoragePowerActor_OnMinerEnrollCronEvent               | 14 |
+|	Method_StoragePowerActor_GetMinerConsensusPower               | 15 |
+|	Method_StoragePowerActor_GetMinerUnmetPledgeCollateralRequirement | 16 |
+
 # Error Codes
 
+TODO

--- a/src/listings/reserved_ranges.md
+++ b/src/listings/reserved_ranges.md
@@ -4,6 +4,17 @@ title: "Reserved Ranges"
 
 # Actor Reserved Ranges
 
+| Actor                | ID |
+|---|---|
+| SystemActor          | 1 |
+| InitActor            | 2 |
+| CronActor            | 3 |
+| AccountActor         | 4 |
+| StoragePowerActor    | 5 |
+| StorageMinerActor    | 6 |
+| StorageMarketActor   | 7 |
+| PaymentChannelActor  | 8 |
+
 # Method Reserved Ranges
 
 # Error Codes

--- a/src/systems/filecoin_vm/actor_interfaces/methods.go
+++ b/src/systems/filecoin_vm/actor_interfaces/methods.go
@@ -10,6 +10,10 @@ const (
 )
 
 const (
+	Method_CronActor_EpochTick = actor.MethodPlaceholder + iota
+)
+
+const (
 	Method_RewardActor_AwardBlockReward = actor.MethodPlaceholder + iota
 )
 

--- a/src/systems/filecoin_vm/interpreter/vm_interpreter.go
+++ b/src/systems/filecoin_vm/interpreter/vm_interpreter.go
@@ -4,7 +4,6 @@ import (
 	addr "github.com/filecoin-project/go-address"
 	abi "github.com/filecoin-project/specs/actors/abi"
 	builtin "github.com/filecoin-project/specs/actors/builtin"
-	cronact "github.com/filecoin-project/specs/actors/builtin/cron"
 	initact "github.com/filecoin-project/specs/actors/builtin/init"
 	sminact "github.com/filecoin-project/specs/actors/builtin/storage_miner"
 	vmr "github.com/filecoin-project/specs/actors/runtime"
@@ -361,7 +360,7 @@ func _makeCronTickMessage(state st.StateTree) msg.UnsignedMessage {
 	return &msg.UnsignedMessage_I{
 		From_:       builtin.SystemActorAddr,
 		To_:         builtin.CronActorAddr,
-		Method_:     cronact.Method_CronActor_EpochTick,
+		Method_:     ai.Method_CronActor_EpochTick,
 		Params_:     nil,
 		CallSeqNum_: sysActor.CallSeqNum(),
 		Value_:      0,


### PR DESCRIPTION
This PR covers:
- Stub out the listings sections for actors, methods, and errors
- Add Actors and Methods listings, based on [vm_registry.go](https://github.com/filecoin-project/specs/blob/master/src/systems/filecoin_vm/interpreter/vm_registry.go) and [methods.go](https://github.com/filecoin-project/specs/blob/7d174209c2a7afda755e524f760a04923bbf7b14/src/systems/filecoin_vm/actor_interfaces/methods.go)
- Move an errant `EpochTick` method from `sysactors/cron_actor.go` to `actor_interfaces/methods.go` as suggested by @sternhenri 

Error codes will be done in a future PR.

Questions for reviewers:
1. Can the "[Filecoin VM Actors](https://filecoin-project.github.io/specs/#listings__actors)" section be deleted, or was something else planned for it? 
2. For methods, removing the prefix might be cleaner. Thoughts? i.e. `Method_MultiSigActor_AddAuthorizedParty` -> `AddAuthorizedParty`
3. Missing actors/missing methods. See [comment](https://github.com/filecoin-project/specs/pull/785#issuecomment-572291348) below.