### PR TITLE
Break some dependencies from actors on other spec code.

### DIFF
--- a/src/actors/builtin/account/account_actor.go
+++ b/src/actors/builtin/account/account_actor.go
@@ -2,10 +2,8 @@ package account
 
 import (
 	ipld "github.com/filecoin-project/specs/libraries/ipld"
-	actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 	addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 	vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
-	exitcode "github.com/filecoin-project/specs/systems/filecoin_vm/runtime/exitcode"
 )
 
 type InvocOutput = vmr.InvocOutput
@@ -14,19 +12,6 @@ func (a *AccountActorCode_I) Constructor(rt vmr.Runtime) InvocOutput {
 	// Nothing. intentionally left blank.
 	rt.ValidateImmediateCallerIs(addr.SystemActorAddr)
 	return rt.SuccessReturn()
-}
-
-func (a *AccountActorCode_I) InvokeMethod(rt vmr.Runtime, method actor.MethodNum, params actor.MethodParams) InvocOutput {
-	switch method {
-	case actor.MethodConstructor:
-		rt.Assert(len(params) == 0)
-		return a.Constructor(rt)
-
-	default:
-		// AccountActor has no methods.
-		rt.Abort(exitcode.SystemError(exitcode.InvalidMethod), "Invalid method")
-		panic("")
-	}
 }
 
 func (st *AccountActorState_I) CID() ipld.CID {

--- a/src/actors/builtin/cron/cron_actor.go
+++ b/src/actors/builtin/cron/cron_actor.go
@@ -1,9 +1,8 @@
 package cron
 
 import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
+import actors "github.com/filecoin-project/specs/actors"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
-import exitcode "github.com/filecoin-project/specs/systems/filecoin_vm/runtime/exitcode"
-import util "github.com/filecoin-project/specs/util"
 import vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
 
 const (
@@ -28,26 +27,10 @@ func (a *CronActorCode_I) EpochTick(rt vmr.Runtime) InvocOutput {
 		rt.SendCatchingErrors(&vmr.InvocInput_I{
 			To_:     entry.ToAddr(),
 			Method_: entry.MethodNum(),
-			Params_: []util.Serialization{},
-			Value_:  actor.TokenAmount(0),
+			Params_: nil,
+			Value_:  actors.TokenAmount(0),
 		})
 	}
 
 	return rt.SuccessReturn()
-}
-
-func (a *CronActorCode_I) InvokeMethod(rt Runtime, method actor.MethodNum, params actor.MethodParams) InvocOutput {
-	switch method {
-	case actor.MethodConstructor:
-		rt.Assert(len(params) == 0)
-		return a.Constructor(rt)
-
-	case Method_CronActor_EpochTick:
-		rt.Assert(len(params) == 0)
-		return a.EpochTick(rt)
-
-	default:
-		rt.Abort(exitcode.SystemError(exitcode.InvalidMethod), "Invalid method")
-		panic("")
-	}
 }

--- a/src/actors/builtin/cron/cron_actor.id
+++ b/src/actors/builtin/cron/cron_actor.id
@@ -1,4 +1,4 @@
-import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
+import actors "github.com/filecoin-project/specs/actors"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
 
@@ -8,7 +8,7 @@ type CronActorState struct {
 
 type CronTableEntry struct {
     ToAddr     addr.Address
-    MethodNum  actor.MethodNum
+    MethodNum  actors.MethodNum
 }
 
 type CronActorCode struct {

--- a/src/actors/builtin/init/init_actor.id
+++ b/src/actors/builtin/init/init_actor.id
@@ -1,5 +1,6 @@
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
+import actors "github.com/filecoin-project/specs/actors"
 import vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
 
 type InitActorState struct {
@@ -16,7 +17,7 @@ type InitActorState struct {
 
 type InitActorCode struct {
     Constructor(r vmr.Runtime, networkName string)
-    Exec(r vmr.Runtime, code actor.CodeID, params actor.MethodParams) addr.Address
+    Exec(r vmr.Runtime, code actor.CodeID, params actors.MethodParams) addr.Address
 
     // This method is disabled until proven necessary.
     //GetActorIDForAddress(r vmr.Runtime, address addr.Address) addr.ActorID

--- a/src/actors/builtin/multisig/multisig_actor.go
+++ b/src/actors/builtin/multisig/multisig_actor.go
@@ -1,22 +1,20 @@
 package multisig
 
 import (
-	actor_util "github.com/filecoin-project/specs/actors/util"
+	autil "github.com/filecoin-project/specs/actors/util"
 	ipld "github.com/filecoin-project/specs/libraries/ipld"
 	actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 	addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 	vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
-	util "github.com/filecoin-project/specs/util"
 )
 
 type InvocOutput = vmr.InvocOutput
 type Runtime = vmr.Runtime
-type Bytes = util.Bytes
 
-var Assert = util.Assert
-var IMPL_FINISH = util.IMPL_FINISH
-var IMPL_TODO = util.IMPL_TODO
-var TODO = util.TODO
+var AssertMsg = autil.AssertMsg
+var IMPL_FINISH = autil.IMPL_FINISH
+var IMPL_TODO = autil.IMPL_TODO
+var TODO = autil.TODO
 
 ////////////////////////////////////////////////////////////////////////////////
 // Actor methods
@@ -31,7 +29,7 @@ func (a *MultiSigActorCode_I) Propose(rt vmr.Runtime, txn MultiSigTransaction) T
 	txnID := st.NextTxnID()
 	st.Impl().NextTxnID_ += 1
 	st.PendingTxns()[txnID] = txn
-	st.PendingApprovals()[txnID] = actor_util.ActorIDSetHAMT_Empty()
+	st.PendingApprovals()[txnID] = autil.ActorIDSetHAMT_Empty()
 	UpdateRelease_MultiSig(rt, h, st)
 
 	// Proposal implicitly includes approval of a transaction.
@@ -112,7 +110,7 @@ func (a *MultiSigActorCode_I) ChangeNumApprovalsThreshold(rt vmr.Runtime, newThr
 }
 
 func (a *MultiSigActorCode_I) Constructor(
-	rt vmr.Runtime, authorizedParties actor_util.ActorIDSetHAMT, numApprovalsThreshold int) {
+	rt vmr.Runtime, authorizedParties autil.ActorIDSetHAMT, numApprovalsThreshold int) {
 
 	rt.ValidateImmediateCallerIs(addr.InitActorAddr)
 	h := rt.AcquireState()
@@ -152,8 +150,7 @@ func (a *MultiSigActorCode_I) _rtApproveTransactionOrAbort(
 		// Could potentially amortize cost of cleanup via Cron.
 	}
 
-	IMPL_TODO() // Make sure we enforce this invariant in the runtime.
-	Assert(callerAddr.Data().Is_ID())
+	AssertMsg(callerAddr.Data().Is_ID(), "caller address does not have ID")
 	actorID := callerAddr.Data().As_ID()
 
 	st.PendingApprovals()[txnID][actorID] = true
@@ -181,8 +178,7 @@ func (a *MultiSigActorCode_I) _rtDeletePendingTransaction(rt Runtime, txnID TxnI
 }
 
 func (a *MultiSigActorCode_I) _rtValidateAuthorizedPartyOrAbort(rt Runtime, addr addr.Address) {
-	IMPL_TODO() // Make sure we enforce this invariant in the runtime.
-	Assert(addr.Data().Is_ID())
+	AssertMsg(addr.Data().Is_ID(), "caller address does not have ID")
 	actorID := addr.Data().As_ID()
 
 	h, st := a.State(rt)
@@ -214,11 +210,6 @@ func MultiSigApprovalSetHAMT_Empty() MultiSigApprovalSetHAMT {
 ////////////////////////////////////////////////////////////////////////////////
 // Boilerplate
 ////////////////////////////////////////////////////////////////////////////////
-
-func (a *MultiSigActorCode_I) InvokeMethod(rt Runtime, method actor.MethodNum, params actor.MethodParams) InvocOutput {
-	IMPL_FINISH()
-	panic("")
-}
 
 func (a *MultiSigActorCode_I) State(rt Runtime) (vmr.ActorStateHandle, MultiSigActorState) {
 	h := rt.AcquireState()

--- a/src/actors/builtin/multisig/multisig_actor.id
+++ b/src/actors/builtin/multisig/multisig_actor.id
@@ -1,5 +1,5 @@
-import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
-import actor_util "github.com/filecoin-project/specs/actors/util"
+import actors "github.com/filecoin-project/specs/actors"
+import autil "github.com/filecoin-project/specs/actors/util"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
 
@@ -10,18 +10,18 @@ type MultiSigTransaction struct {
     Expiration  block.ChainEpoch
 
     To          addr.Address
-    Method      actor.MethodNum
-    Params      actor.MethodParams
-    Value       actor.TokenAmount
+    Method      actors.MethodNum
+    Params      actors.MethodParams
+    Value       actors.TokenAmount
 
     Equals(MultiSigTransaction) bool
 }
 
 type MultiSigTransactionHAMT {TxnID: MultiSigTransaction}
-type MultiSigApprovalSetHAMT {TxnID: actor_util.ActorIDSetHAMT}
+type MultiSigApprovalSetHAMT {TxnID: autil.ActorIDSetHAMT}
 
 type MultiSigActorState struct {
-    AuthorizedParties      actor_util.ActorIDSetHAMT
+    AuthorizedParties      autil.ActorIDSetHAMT
     NumApprovalsThreshold  int
     NextTxnID              TxnID
     PendingTxns            MultiSigTransactionHAMT

--- a/src/actors/builtin/reward/reward_actor.id
+++ b/src/actors/builtin/reward/reward_actor.id
@@ -1,5 +1,5 @@
 import vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
-import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
+import actors "github.com/filecoin-project/specs/actors"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
 
@@ -16,10 +16,10 @@ type Reward struct {
     VestingFunction
     StartEpoch       block.ChainEpoch
     EndEpoch         block.ChainEpoch
-    Value            actor.TokenAmount
-    AmountWithdrawn  actor.TokenAmount
+    Value            actors.TokenAmount
+    AmountWithdrawn  actors.TokenAmount
 
-    AmountVested(elapsedEpoch block.ChainEpoch) actor.TokenAmount
+    AmountVested(elapsedEpoch block.ChainEpoch) actors.TokenAmount
 }
 
 // ownerAddr to a collection of Reward
@@ -28,7 +28,7 @@ type RewardBalanceAMT {addr.Address: [Reward]}
 type RewardActorState struct {
     RewardMap RewardBalanceAMT
 
-    _withdrawReward(rt vmr.Runtime, ownerAddr addr.Address) actor.TokenAmount
+    _withdrawReward(rt vmr.Runtime, ownerAddr addr.Address) actors.TokenAmount
 }
 
 type RewardActorCode struct {
@@ -37,7 +37,7 @@ type RewardActorCode struct {
     // Allocates a block reward to the owner of a miner, less
     // - penalty, which is burnt
     // - any amount of pledge collateral shortfall, which is transferred to storage power actor
-    AwardBlockReward(rt vmr.Runtime, miner addr.Address, penalty actor.TokenAmount)
+    AwardBlockReward(rt vmr.Runtime, miner addr.Address, penalty actors.TokenAmount)
 
     // withdraw available funds from RewardMap
     WithdrawReward(rt vmr.Runtime)

--- a/src/actors/builtin/storage_market/storage_market_actor.id
+++ b/src/actors/builtin/storage_market/storage_market_actor.id
@@ -1,4 +1,4 @@
-import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
+import actors "github.com/filecoin-project/specs/actors"
 import actor_util "github.com/filecoin-project/specs/actors/util"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
@@ -31,21 +31,21 @@ type StorageMarketActorState struct {
     CurrEpochNumDealsPublished      int
 
     _rtAbortIfAddressEntryDoesNotExist(rt Runtime, entryAddr addr.Address)
-    _rtUpdatePendingDealStatesForParty(rt Runtime, addr addr.Address) (amountSlashedTotal actor.TokenAmount)
+    _rtUpdatePendingDealStatesForParty(rt Runtime, addr addr.Address) (amountSlashedTotal actors.TokenAmount)
     _rtGetOnChainDealOrAbort(rt Runtime, dealID deal.DealID) (deal deal.OnChainDeal, dealP deal.StorageDealProposal)
-    _rtLockBalanceOrAbort(rt Runtime, addr addr.Address, amount actor.TokenAmount)
+    _rtLockBalanceOrAbort(rt Runtime, addr addr.Address, amount actors.TokenAmount)
 
-    _updatePendingDealStates(dealIDs [deal.DealID], epoch block.ChainEpoch) (amountSlashedTotal actor.TokenAmount)
-    _updatePendingDealState(dealID deal.DealID, epoch block.ChainEpoch) (amountSlashed actor.TokenAmount)
+    _updatePendingDealStates(dealIDs [deal.DealID], epoch block.ChainEpoch) (amountSlashedTotal actors.TokenAmount)
+    _updatePendingDealState(dealID deal.DealID, epoch block.ChainEpoch) (amountSlashed actors.TokenAmount)
     _processDealPaymentEpochsElapsed(dealID deal.DealID, numEpochsElapsed block.ChainEpoch)
-    _processDealSlashed(dealID deal.DealID) (amountSlashed actor.TokenAmount)
-    _processDealInitTimedOut(dealID deal.DealID) (amountSlashed actor.TokenAmount)
+    _processDealSlashed(dealID deal.DealID) (amountSlashed actors.TokenAmount)
+    _processDealInitTimedOut(dealID deal.DealID) (amountSlashed actors.TokenAmount)
     _processDealExpired(dealID deal.DealID)
     _generateStorageDealID(storageDeal deal.StorageDeal) deal.DealID
 
-    _getLockedReqBalanceInternal(a addr.Address) actor.TokenAmount
-    _lockBalanceMaybe(addr addr.Address, amount actor.TokenAmount) (lockBalanceOK bool)
-    _unlockBalance(addr addr.Address, unlockAmountRequested actor.TokenAmount)
+    _getLockedReqBalanceInternal(a addr.Address) actors.TokenAmount
+    _lockBalanceMaybe(addr addr.Address, amount actors.TokenAmount) (lockBalanceOK bool)
+    _unlockBalance(addr addr.Address, unlockAmountRequested actors.TokenAmount)
 
     _getOnChainDeal(dealID deal.DealID) (deal deal.OnChainDeal, dealP deal.StorageDealProposal, ok bool)
     _getOnChainDealAssert(dealID deal.DealID) (deal deal.OnChainDeal, dealP deal.StorageDealProposal)
@@ -59,7 +59,7 @@ type StorageMarketActorCode struct {
 
     // Attempt to withdraw the specified amount from the balance held in escrow.
     // If less than the specified amount is available, yields the entire available balance.
-    WithdrawBalance(rt Runtime, amount actor.TokenAmount)
+    WithdrawBalance(rt Runtime, amount actors.TokenAmount)
 
     // Publish a new set of storage deals (not yet included in a sector).
     PublishStorageDeals(rt Runtime, deals [deal.StorageDeal])

--- a/src/actors/builtin/storage_market/storage_market_actor_boilerplate.go
+++ b/src/actors/builtin/storage_market/storage_market_actor_boilerplate.go
@@ -1,15 +1,15 @@
 package storage_market
 
 import (
-	actor_util "github.com/filecoin-project/specs/actors/util"
+	actors "github.com/filecoin-project/specs/actors"
+	autil "github.com/filecoin-project/specs/actors/util"
 	ipld "github.com/filecoin-project/specs/libraries/ipld"
 	actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 	vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
-	util "github.com/filecoin-project/specs/util"
 )
 
-type BalanceTableHAMT = actor_util.BalanceTableHAMT
-type DealIDQueue = actor_util.DealIDQueue
+type BalanceTableHAMT = autil.BalanceTableHAMT
+type DealIDQueue = autil.DealIDQueue
 
 var RT_MinerEntry_ValidateCaller_DetermineFundsLocation = vmr.RT_MinerEntry_ValidateCaller_DetermineFundsLocation
 var RT_ValidateImmediateCallerIsSignable = vmr.RT_ValidateImmediateCallerIsSignable
@@ -24,12 +24,12 @@ var RT_ValidateImmediateCallerIsSignable = vmr.RT_ValidateImmediateCallerIsSigna
 
 type InvocOutput = vmr.InvocOutput
 type Runtime = vmr.Runtime
-type Bytes = util.Bytes
+type Bytes = actors.Bytes
 
-var Assert = util.Assert
-var IMPL_FINISH = util.IMPL_FINISH
-var IMPL_TODO = util.IMPL_TODO
-var TODO = util.TODO
+var Assert = autil.Assert
+var IMPL_FINISH = autil.IMPL_FINISH
+var IMPL_TODO = autil.IMPL_TODO
+var TODO = autil.TODO
 
 func (a *StorageMarketActorCode_I) State(rt Runtime) (vmr.ActorStateHandle, StorageMarketActorState) {
 	h := rt.AcquireState()

--- a/src/actors/builtin/storage_market/storage_market_actor_code.go
+++ b/src/actors/builtin/storage_market/storage_market_actor_code.go
@@ -1,6 +1,7 @@
 package storage_market
 
 import (
+	actors "github.com/filecoin-project/specs/actors"
 	actor_util "github.com/filecoin-project/specs/actors/util"
 	block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
 	deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
@@ -8,16 +9,15 @@ import (
 	actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 	addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 	vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
-	util "github.com/filecoin-project/specs/util"
 )
 
 ////////////////////////////////////////////////////////////////////////////////
 // Actor methods
 ////////////////////////////////////////////////////////////////////////////////
 
-func (a *StorageMarketActorCode_I) WithdrawBalance(rt Runtime, entryAddr addr.Address, amountRequested actor.TokenAmount) {
+func (a *StorageMarketActorCode_I) WithdrawBalance(rt Runtime, entryAddr addr.Address, amountRequested actors.TokenAmount) {
 	IMPL_FINISH() // BigInt arithmetic
-	amountSlashedTotal := actor.TokenAmount(0)
+	amountSlashedTotal := actors.TokenAmount(0)
 
 	if amountRequested < 0 {
 		rt.AbortArgMsg("Negative amount.")
@@ -67,7 +67,7 @@ func (a *StorageMarketActorCode_I) AddBalance(rt Runtime, entryAddr addr.Address
 
 func (a *StorageMarketActorCode_I) PublishStorageDeals(rt Runtime, newStorageDeals []deal.StorageDeal) {
 	IMPL_FINISH() // BigInt arithmetic
-	amountSlashedTotal := actor.TokenAmount(0)
+	amountSlashedTotal := actors.TokenAmount(0)
 
 	// Deal message must have a From field identical to the provider of all the deals.
 	// This allows us to retain and verify only the client's signature in each deal proposal itself.
@@ -161,7 +161,7 @@ func (a *StorageMarketActorCode_I) GetPieceInfosForDealIDs(rt Runtime, dealIDs d
 		_, dealP := st._rtGetOnChainDealOrAbort(rt, dealID)
 		ret = append(ret, sector.PieceInfo_I{
 			PieceCID_: dealP.PieceCID(),
-			Size_:     util.UInt(dealP.PieceSize().Total()),
+			Size_:     uint64(dealP.PieceSize().Total()),
 		}.Ref())
 	}
 
@@ -308,7 +308,7 @@ func (a *StorageMarketActorCode_I) Constructor(rt Runtime) {
 ////////////////////////////////////////////////////////////////////////////////
 
 func (st *StorageMarketActorState_I) _rtUpdatePendingDealStatesForParty(rt Runtime, addr addr.Address) (
-	amountSlashedTotal actor.TokenAmount) {
+	amountSlashedTotal actors.TokenAmount) {
 
 	// For consistency with OnEpochTickEnd, only process updates up to the end of the _previous_ epoch.
 	epoch := rt.CurrEpoch() - 1
@@ -417,7 +417,7 @@ func (st *StorageMarketActorState_I) _rtGetOnChainDealOrAbort(rt Runtime, dealID
 	return
 }
 
-func (st *StorageMarketActorState_I) _rtLockBalanceOrAbort(rt Runtime, addr addr.Address, amount actor.TokenAmount) {
+func (st *StorageMarketActorState_I) _rtLockBalanceOrAbort(rt Runtime, addr addr.Address, amount actors.TokenAmount) {
 	if amount < 0 {
 		rt.AbortArgMsg("Negative amount")
 	}
@@ -429,13 +429,4 @@ func (st *StorageMarketActorState_I) _rtLockBalanceOrAbort(rt Runtime, addr addr
 	if !ok {
 		rt.AbortFundsMsg("Insufficient funds available to lock.")
 	}
-}
-
-////////////////////////////////////////////////////////////////////////////////
-// Dispatch table
-////////////////////////////////////////////////////////////////////////////////
-
-func (a *StorageMarketActorCode_I) InvokeMethod(rt Runtime, method actor.MethodNum, params actor.MethodParams) InvocOutput {
-	IMPL_FINISH()
-	panic("")
 }

--- a/src/actors/builtin/storage_market/storage_market_actor_state.go
+++ b/src/actors/builtin/storage_market/storage_market_actor_state.go
@@ -1,11 +1,11 @@
 package storage_market
 
 import (
+	actors "github.com/filecoin-project/specs/actors"
 	actor_util "github.com/filecoin-project/specs/actors/util"
 	filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
 	block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
 	deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
-	actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 	addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 	indices "github.com/filecoin-project/specs/systems/filecoin_vm/indices"
 	vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
@@ -16,7 +16,7 @@ import (
 ////////////////////////////////////////////////////////////////////////////////
 
 func (st *StorageMarketActorState_I) _updatePendingDealStates(dealIDs []deal.DealID, epoch block.ChainEpoch) (
-	amountSlashedTotal actor.TokenAmount) {
+	amountSlashedTotal actors.TokenAmount) {
 
 	IMPL_FINISH() // BigInt arithmetic
 	amountSlashedTotal = 0
@@ -30,7 +30,7 @@ func (st *StorageMarketActorState_I) _updatePendingDealStates(dealIDs []deal.Dea
 }
 
 func (st *StorageMarketActorState_I) _updatePendingDealState(dealID deal.DealID, epoch block.ChainEpoch) (
-	amountSlashed actor.TokenAmount) {
+	amountSlashed actors.TokenAmount) {
 
 	IMPL_FINISH() // BigInt arithmetic
 	amountSlashed = 0
@@ -103,10 +103,10 @@ func (st *StorageMarketActorState_I) _processDealPaymentEpochsElapsed(dealID dea
 	// Process deal payment for the elapsed epochs.
 	IMPL_FINISH() // BigInt arithmetic
 	totalPayment := int(numEpochsElapsed) * int(dealP.StoragePricePerEpoch())
-	st._transferBalance(dealP.Client(), dealP.Provider(), actor.TokenAmount(totalPayment))
+	st._transferBalance(dealP.Client(), dealP.Provider(), actors.TokenAmount(totalPayment))
 }
 
-func (st *StorageMarketActorState_I) _processDealSlashed(dealID deal.DealID) (amountSlashed actor.TokenAmount) {
+func (st *StorageMarketActorState_I) _processDealSlashed(dealID deal.DealID) (amountSlashed actors.TokenAmount) {
 	deal, dealP := st._getOnChainDealAssert(dealID)
 	Assert(deal.SectorStartEpoch() != block.ChainEpoch_None)
 
@@ -129,7 +129,7 @@ func (st *StorageMarketActorState_I) _processDealSlashed(dealID deal.DealID) (am
 // Deal start deadline elapsed without appearing in a proven sector.
 // Delete deal, slash a portion of provider's collateral, and unlock remaining collaterals
 // for both provider and client.
-func (st *StorageMarketActorState_I) _processDealInitTimedOut(dealID deal.DealID) (amountSlashed actor.TokenAmount) {
+func (st *StorageMarketActorState_I) _processDealInitTimedOut(dealID deal.DealID) (amountSlashed actors.TokenAmount) {
 	deal, dealP := st._getOnChainDealAssert(dealID)
 	Assert(deal.SectorStartEpoch() == block.ChainEpoch_None)
 
@@ -176,21 +176,21 @@ func (st *StorageMarketActorState_I) _addressEntryExists(address addr.Address) b
 	return foundEscrow
 }
 
-func (st *StorageMarketActorState_I) _getTotalEscrowBalanceInternal(a addr.Address) actor.TokenAmount {
+func (st *StorageMarketActorState_I) _getTotalEscrowBalanceInternal(a addr.Address) actors.TokenAmount {
 	Assert(st._addressEntryExists(a))
 	ret, ok := actor_util.BalanceTable_GetEntry(st.EscrowTable(), a)
 	Assert(ok)
 	return ret
 }
 
-func (st *StorageMarketActorState_I) _getLockedReqBalanceInternal(a addr.Address) actor.TokenAmount {
+func (st *StorageMarketActorState_I) _getLockedReqBalanceInternal(a addr.Address) actors.TokenAmount {
 	Assert(st._addressEntryExists(a))
 	ret, ok := actor_util.BalanceTable_GetEntry(st.LockedReqTable(), a)
 	Assert(ok)
 	return ret
 }
 
-func (st *StorageMarketActorState_I) _lockBalanceMaybe(addr addr.Address, amount actor.TokenAmount) (
+func (st *StorageMarketActorState_I) _lockBalanceMaybe(addr addr.Address, amount actors.TokenAmount) (
 	lockBalanceOK bool) {
 
 	Assert(amount >= 0)
@@ -211,7 +211,7 @@ func (st *StorageMarketActorState_I) _lockBalanceMaybe(addr addr.Address, amount
 }
 
 func (st *StorageMarketActorState_I) _unlockBalance(
-	addr addr.Address, unlockAmountRequested actor.TokenAmount) {
+	addr addr.Address, unlockAmountRequested actors.TokenAmount) {
 
 	Assert(unlockAmountRequested >= 0)
 	Assert(st._addressEntryExists(addr))
@@ -220,7 +220,7 @@ func (st *StorageMarketActorState_I) _unlockBalance(
 }
 
 func (st *StorageMarketActorState_I) _tableWithAddBalance(
-	table actor_util.BalanceTableHAMT, toAddr addr.Address, amountToAdd actor.TokenAmount) actor_util.BalanceTableHAMT {
+	table actor_util.BalanceTableHAMT, toAddr addr.Address, amountToAdd actors.TokenAmount) actor_util.BalanceTableHAMT {
 
 	Assert(amountToAdd >= 0)
 
@@ -230,7 +230,7 @@ func (st *StorageMarketActorState_I) _tableWithAddBalance(
 }
 
 func (st *StorageMarketActorState_I) _tableWithDeductBalanceExact(
-	table actor_util.BalanceTableHAMT, fromAddr addr.Address, amountRequested actor.TokenAmount) actor_util.BalanceTableHAMT {
+	table actor_util.BalanceTableHAMT, fromAddr addr.Address, amountRequested actors.TokenAmount) actor_util.BalanceTableHAMT {
 
 	Assert(amountRequested >= 0)
 
@@ -243,7 +243,7 @@ func (st *StorageMarketActorState_I) _tableWithDeductBalanceExact(
 
 // move funds from locked in client to available in provider
 func (st *StorageMarketActorState_I) _transferBalance(
-	fromAddr addr.Address, toAddr addr.Address, transferAmountRequested actor.TokenAmount) {
+	fromAddr addr.Address, toAddr addr.Address, transferAmountRequested actors.TokenAmount) {
 
 	Assert(transferAmountRequested >= 0)
 	Assert(st._addressEntryExists(fromAddr))
@@ -254,7 +254,7 @@ func (st *StorageMarketActorState_I) _transferBalance(
 	st.Impl().EscrowTable_ = st._tableWithAddBalance(st.EscrowTable(), toAddr, transferAmountRequested)
 }
 
-func (st *StorageMarketActorState_I) _slashBalance(addr addr.Address, slashAmount actor.TokenAmount) {
+func (st *StorageMarketActorState_I) _slashBalance(addr addr.Address, slashAmount actors.TokenAmount) {
 	Assert(st._addressEntryExists(addr))
 	Assert(slashAmount >= 0)
 
@@ -294,7 +294,7 @@ func _rtDealProposalIsInternallyValid(rt Runtime, dealP deal.StorageDealProposal
 	return true
 }
 
-func _dealGetPaymentRemaining(deal deal.OnChainDeal, epoch block.ChainEpoch) actor.TokenAmount {
+func _dealGetPaymentRemaining(deal deal.OnChainDeal, epoch block.ChainEpoch) actors.TokenAmount {
 	dealP := deal.Deal().Proposal()
 	Assert(epoch <= dealP.EndEpoch())
 
@@ -302,7 +302,7 @@ func _dealGetPaymentRemaining(deal deal.OnChainDeal, epoch block.ChainEpoch) act
 	Assert(durationRemaining > 0)
 
 	IMPL_FINISH() // BigInt arithmetic
-	return actor.TokenAmount(int(durationRemaining) * int(dealP.StoragePricePerEpoch()))
+	return actors.TokenAmount(int(durationRemaining) * int(dealP.StoragePricePerEpoch()))
 }
 
 func (st *StorageMarketActorState_I) _getOnChainDeal(dealID deal.DealID) (

--- a/src/actors/builtin/storage_miner/storage_miner_actor.id
+++ b/src/actors/builtin/storage_miner/storage_miner_actor.id
@@ -1,5 +1,5 @@
-import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
-import actor_util "github.com/filecoin-project/specs/actors/util"
+import actors "github.com/filecoin-project/specs/actors"
+import autil "github.com/filecoin-project/specs/actors/util"
 import address "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
 import deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
@@ -41,7 +41,7 @@ type SectorState enum {
 type SectorOnChainInfo struct {
     State                       SectorState
     Info                        sealing.SectorPreCommitInfo  // Also contains Expiration field.
-    PreCommitDeposit            actor.TokenAmount
+    PreCommitDeposit            actors.TokenAmount
     PreCommitEpoch              block.ChainEpoch
     ActivationEpoch             block.ChainEpoch  // -1 if still in PreCommit state.
     DeclaredFaultEpoch          block.ChainEpoch  // -1 if not currently declared faulted.
@@ -68,9 +68,9 @@ type StorageMinerActorState struct {
     ProvingSet  SectorNumberSetHAMT
     Info        MinerInfo
 
-    GetStorageWeightDescForSectorMaybe(sectorNumber sector.SectorNumber) (ret actor_util.SectorStorageWeightDesc, ok bool)
-    _getStorageWeightDescForSector(sectorNumber sector.SectorNumber) actor_util.SectorStorageWeightDesc
-    _getStorageWeightDescsForSectors(sectorNumbers [sector.SectorNumber]) [actor_util.SectorStorageWeightDesc]
+    GetStorageWeightDescForSectorMaybe(sectorNumber sector.SectorNumber) (ret autil.SectorStorageWeightDesc, ok bool)
+    _getStorageWeightDescForSector(sectorNumber sector.SectorNumber) autil.SectorStorageWeightDesc
+    _getStorageWeightDescsForSectors(sectorNumbers [sector.SectorNumber]) [autil.SectorStorageWeightDesc]
 
     _getSectorDealIDsAssert(sectorNumber sector.SectorNumber) deal.DealIDs
 

--- a/src/actors/builtin/storage_miner/storage_miner_actor_boilerplate.go
+++ b/src/actors/builtin/storage_miner/storage_miner_actor_boilerplate.go
@@ -1,15 +1,14 @@
 package storage_miner
 
 import (
-	actor_util "github.com/filecoin-project/specs/actors/util"
+	autil "github.com/filecoin-project/specs/actors/util"
 	ipld "github.com/filecoin-project/specs/libraries/ipld"
 	actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 	vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
-	util "github.com/filecoin-project/specs/util"
 )
 
-type SectorStorageWeightDesc = actor_util.SectorStorageWeightDesc
-type SectorTerminationType = actor_util.SectorTerminationType
+type SectorStorageWeightDesc = autil.SectorStorageWeightDesc
+type SectorTerminationType = autil.SectorTerminationType
 
 var RT_ConfirmFundsReceiptOrAbort_RefundRemainder = vmr.RT_ConfirmFundsReceiptOrAbort_RefundRemainder
 
@@ -23,12 +22,11 @@ var RT_ConfirmFundsReceiptOrAbort_RefundRemainder = vmr.RT_ConfirmFundsReceiptOr
 
 type InvocOutput = vmr.InvocOutput
 type Runtime = vmr.Runtime
-type Bytes = util.Bytes
 
-var Assert = util.Assert
-var IMPL_FINISH = util.IMPL_FINISH
-var IMPL_TODO = util.IMPL_TODO
-var TODO = util.TODO
+var Assert = autil.Assert
+var IMPL_FINISH = autil.IMPL_FINISH
+var IMPL_TODO = autil.IMPL_TODO
+var TODO = autil.TODO
 
 func (a *StorageMinerActorCode_I) State(rt Runtime) (vmr.ActorStateHandle, StorageMinerActorState) {
 	h := rt.AcquireState()
@@ -48,8 +46,5 @@ func UpdateRelease(rt Runtime, h vmr.ActorStateHandle, st StorageMinerActorState
 	h.UpdateRelease(newCID)
 }
 func (st *StorageMinerActorState_I) CID() ipld.CID {
-	panic("TODO")
-}
-func DeserializeState(x Bytes) StorageMinerActorState {
 	panic("TODO")
 }

--- a/src/actors/builtin/storage_power/storage_power_actor.id
+++ b/src/actors/builtin/storage_power/storage_power_actor.id
@@ -1,7 +1,7 @@
 import actor_util "github.com/filecoin-project/specs/actors/util"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
-import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
+import actors "github.com/filecoin-project/specs/actors"
 
 type PowerTableHAMT {addr.Address: block.StoragePower}  // TODO: convert address to ActorID
 
@@ -20,7 +20,7 @@ type StoragePowerActorState struct {
     NominalPower              PowerTableHAMT
     NumMinersMeetingMinPower  int
 
-    _slashPledgeCollateral(address addr.Address, amount actor.TokenAmount) actor.TokenAmount
+    _slashPledgeCollateral(address addr.Address, amount actors.TokenAmount) actors.TokenAmount
     _selectMinersToSurprise(challengeCount int, randomness util.Randomness) [addr.Address]
 
     _addClaimedPowerForSector(

--- a/src/actors/builtin/storage_power/storage_power_actor_boilerplate.go
+++ b/src/actors/builtin/storage_power/storage_power_actor_boilerplate.go
@@ -1,18 +1,17 @@
 package storage_power
 
 import (
-	actor_util "github.com/filecoin-project/specs/actors/util"
+	autil "github.com/filecoin-project/specs/actors/util"
 	ipld "github.com/filecoin-project/specs/libraries/ipld"
 	actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 	vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
-	util "github.com/filecoin-project/specs/util"
 )
 
-type BalanceTableHAMT = actor_util.BalanceTableHAMT
-type SectorStorageWeightDesc = actor_util.SectorStorageWeightDesc
-type SectorTerminationType = actor_util.SectorTerminationType
+type BalanceTableHAMT = autil.BalanceTableHAMT
+type SectorStorageWeightDesc = autil.SectorStorageWeightDesc
+type SectorTerminationType = autil.SectorTerminationType
 
-var SectorTerminationType_NormalExpiration = actor_util.SectorTerminationType_NormalExpiration
+var SectorTerminationType_NormalExpiration = autil.SectorTerminationType_NormalExpiration
 
 var RT_MinerEntry_ValidateCaller_DetermineFundsLocation = vmr.RT_MinerEntry_ValidateCaller_DetermineFundsLocation
 
@@ -26,13 +25,11 @@ var RT_MinerEntry_ValidateCaller_DetermineFundsLocation = vmr.RT_MinerEntry_Vali
 
 type InvocOutput = vmr.InvocOutput
 type Runtime = vmr.Runtime
-type Bytes = util.Bytes
 
-var Assert = util.Assert
-var IMPL_FINISH = util.IMPL_FINISH
-var IMPL_TODO = util.IMPL_TODO
-var PARAM_FINISH = util.PARAM_FINISH
-var TODO = util.TODO
+var Assert = autil.Assert
+var IMPL_FINISH = autil.IMPL_FINISH
+var IMPL_TODO = autil.IMPL_TODO
+var TODO = autil.TODO
 
 func (a *StoragePowerActorCode_I) State(rt Runtime) (vmr.ActorStateHandle, StoragePowerActorState) {
 	h := rt.AcquireState()
@@ -52,8 +49,5 @@ func UpdateRelease(rt Runtime, h vmr.ActorStateHandle, st StoragePowerActorState
 	h.UpdateRelease(newCID)
 }
 func (st *StoragePowerActorState_I) CID() ipld.CID {
-	panic("TODO")
-}
-func DeserializeState(x Bytes) StoragePowerActorState {
 	panic("TODO")
 }

--- a/src/actors/builtin/storage_power/storage_power_actor_state.go
+++ b/src/actors/builtin/storage_power/storage_power_actor_state.go
@@ -3,10 +3,10 @@ package storage_power
 import (
 	"sort"
 
-	actor_util "github.com/filecoin-project/specs/actors/util"
+	actors "github.com/filecoin-project/specs/actors"
+	autil "github.com/filecoin-project/specs/actors/util"
 	filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
 	block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
-	actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 	addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 	indices "github.com/filecoin-project/specs/systems/filecoin_vm/indices"
 	util "github.com/filecoin-project/specs/util"
@@ -43,11 +43,11 @@ func (st *StoragePowerActorState_I) _minerNominalPowerMeetsConsensusMinimum(mine
 }
 
 func (st *StoragePowerActorState_I) _slashPledgeCollateral(
-	minerAddr addr.Address, slashAmountRequested actor.TokenAmount) actor.TokenAmount {
+	minerAddr addr.Address, slashAmountRequested actors.TokenAmount) actors.TokenAmount {
 
-	Assert(slashAmountRequested >= actor.TokenAmount(0))
+	Assert(slashAmountRequested >= actors.TokenAmount(0))
 
-	newTable, amountSlashed, ok := actor_util.BalanceTable_WithSubtractPreservingNonnegative(
+	newTable, amountSlashed, ok := autil.BalanceTable_WithSubtractPreservingNonnegative(
 		st.EscrowTable(), minerAddr, slashAmountRequested)
 	Assert(ok)
 	st.Impl().EscrowTable_ = newTable
@@ -110,8 +110,8 @@ func (st *StoragePowerActorState_I) _getPowerTotalForMiner(minerAddr addr.Addres
 	return minerPower, true
 }
 
-func (st *StoragePowerActorState_I) _getCurrPledgeForMiner(minerAddr addr.Address) (currPledge actor.TokenAmount, ok bool) {
-	return actor_util.BalanceTable_GetEntry(st.EscrowTable(), minerAddr)
+func (st *StoragePowerActorState_I) _getCurrPledgeForMiner(minerAddr addr.Address) (currPledge actors.TokenAmount, ok bool) {
+	return autil.BalanceTable_GetEntry(st.EscrowTable(), minerAddr)
 }
 
 func (st *StoragePowerActorState_I) _addClaimedPowerForSector(minerAddr addr.Address, storageWeightDesc SectorStorageWeightDesc) {

--- a/src/actors/serde/serialization.go
+++ b/src/actors/serde/serialization.go
@@ -1,0 +1,26 @@
+package serde
+
+import autil "github.com/filecoin-project/specs/actors/util"
+
+// Serializes a structure or value to CBOR.
+func Serialize(o interface{}) ([]byte, error) {
+	autil.TODO("CBOR-serialization")
+	return nil, nil
+}
+
+func MustSerialize(o interface{}) []byte {
+	s, err := Serialize(o)
+	autil.AssertMsg(err == nil, "serialization failed")
+	return s
+}
+
+// Serializes an array of method invocation params.
+func MustSerializeParams(o ...interface{}) []byte {
+	return MustSerialize(o)
+}
+
+// Deserializes a structure or value from CBOR.
+func Deserialize(b []byte, out interface{}) error {
+	autil.TODO("CBOR-deseriaization")
+	return nil
+}

--- a/src/actors/types.go
+++ b/src/actors/types.go
@@ -1,0 +1,31 @@
+package actors
+
+// MethodNum is an integer that represents a particular method
+// in an actor's function table. These numbers are used to compress
+// invocation of actor code, and to decouple human language concerns
+// about method names from the ability to uniquely refer to a particular
+// method.
+//
+// Consider MethodNum numbers to be similar in concerns as for
+// offsets in function tables (in programming languages), and for
+// tags in ProtocolBuffer fields. Tags in ProtocolBuffers recommend
+// assigning a unique tag to a field and never reusing that tag.
+// If a field is no longer used, the field name may change but should
+// still remain defined in the code to ensure the tag number is not
+// reused accidentally. The same should apply to the MethodNum
+// associated with methods in Filecoin VM Actors.
+type MethodNum uint64
+
+// Method params are the CBOR-serialization of a heterogenous array of values.
+type MethodParams []byte
+
+// TODO: remove this alias after actor types are realized from .id files.
+type Bytes []byte
+
+// TokenAmount is an amount of Filecoin tokens. This type is used within
+// the VM in message execution, to account movement of tokens, payment
+// of VM gas, and more.
+type TokenAmount uint64 // Should be bigint
+
+// Randomness is a string of random bytes
+type Randomness []byte

--- a/src/actors/util/actor_util.go
+++ b/src/actors/util/actor_util.go
@@ -1,48 +1,14 @@
 package util
 
 import (
+	actors "github.com/filecoin-project/specs/actors"
 	deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
-	actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 	addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
-	st "github.com/filecoin-project/specs/systems/filecoin_vm/state_tree"
-	util "github.com/filecoin-project/specs/util"
 )
-
-type MethodParams = actor.MethodParams
-type TokenAmount = actor.TokenAmount
-
-type Serialization = util.Serialization
-
-var Assert = util.Assert
-var TODO = util.TODO
-var IMPL_FINISH = util.IMPL_FINISH
-var IMPL_TODO = util.IMPL_TODO
-
-// Interface for runtime/VMContext functionality (to avoid circular dependency in Go imports)
-type Has_AbortArg interface {
-	AbortArg()
-}
-
-func CheckArgs(params *MethodParams, rt Has_AbortArg, cond bool) {
-	if !cond {
-		rt.AbortArg()
-	}
-}
-
-func ArgPop(params *MethodParams, rt Has_AbortArg) Serialization {
-	CheckArgs(params, rt, len(*params) > 0)
-	ret := (*params)[0]
-	*params = (*params)[1:]
-	return ret
-}
-
-func ArgEnd(params *MethodParams, rt Has_AbortArg) {
-	CheckArgs(params, rt, len(*params) == 0)
-}
 
 // Create a new entry in the balance table, with the specified initial balance.
 // May fail if the specified address already exists in the table.
-func BalanceTable_WithNewAddressEntry(table BalanceTableHAMT, address addr.Address, initBalance TokenAmount) (
+func BalanceTable_WithNewAddressEntry(table BalanceTableHAMT, address addr.Address, initBalance actors.TokenAmount) (
 	ret BalanceTableHAMT, ok bool) {
 
 	IMPL_FINISH()
@@ -59,7 +25,7 @@ func BalanceTable_WithDeletedAddressEntry(table BalanceTableHAMT, address addr.A
 }
 
 // Add the given amount to the given address's balance table entry.
-func BalanceTable_WithAdd(table BalanceTableHAMT, address addr.Address, amount TokenAmount) (
+func BalanceTable_WithAdd(table BalanceTableHAMT, address addr.Address, amount actors.TokenAmount) (
 	ret BalanceTableHAMT, ok bool) {
 
 	IMPL_FINISH()
@@ -72,17 +38,17 @@ func BalanceTable_WithAdd(table BalanceTableHAMT, address addr.Address, amount T
 // Note: ok should be set to true here, even if the operation caused the entry to hit zero.
 // The only failure case is when the address does not exist in the table.
 func BalanceTable_WithSubtractPreservingNonnegative(
-	table BalanceTableHAMT, address addr.Address, amount TokenAmount) (
-	ret BalanceTableHAMT, amountSubtracted TokenAmount, ok bool) {
+	table BalanceTableHAMT, address addr.Address, amount actors.TokenAmount) (
+	ret BalanceTableHAMT, amountSubtracted actors.TokenAmount, ok bool) {
 
-	return BalanceTable_WithExtractPartial(table, address, amount, TokenAmount(0))
+	return BalanceTable_WithExtractPartial(table, address, amount, actors.TokenAmount(0))
 }
 
 // Extract the given amount from the given address's balance table entry, subject to the requirement
 // of a minimum balance `minBalanceMaintain`. If not possible to withdraw the entire amount
 // requested, then the balance will remain unchanged.
 func BalanceTable_WithExtract(
-	table BalanceTableHAMT, address addr.Address, amount TokenAmount, minBalanceMaintain TokenAmount) (
+	table BalanceTableHAMT, address addr.Address, amount actors.TokenAmount, minBalanceMaintain actors.TokenAmount) (
 	ret BalanceTableHAMT, ok bool) {
 
 	IMPL_FINISH()
@@ -92,8 +58,8 @@ func BalanceTable_WithExtract(
 // Extract as much as possible (may be zero) up to the specified amount from the given address's
 // balance table entry, subject to the requirement of a minimum balance `minBalanceMaintain`.
 func BalanceTable_WithExtractPartial(
-	table BalanceTableHAMT, address addr.Address, amount TokenAmount, minBalanceMaintain TokenAmount) (
-	ret BalanceTableHAMT, amountExtracted TokenAmount, ok bool) {
+	table BalanceTableHAMT, address addr.Address, amount actors.TokenAmount, minBalanceMaintain actors.TokenAmount) (
+	ret BalanceTableHAMT, amountExtracted actors.TokenAmount, ok bool) {
 
 	IMPL_FINISH()
 	panic("")
@@ -101,7 +67,7 @@ func BalanceTable_WithExtractPartial(
 
 // Extract all available from the given address's balance table entry.
 func BalanceTable_WithExtractAll(table BalanceTableHAMT, address addr.Address) (
-	ret BalanceTableHAMT, amountExtracted TokenAmount, ok bool) {
+	ret BalanceTableHAMT, amountExtracted actors.TokenAmount, ok bool) {
 
 	IMPL_FINISH()
 	panic("")
@@ -110,7 +76,7 @@ func BalanceTable_WithExtractAll(table BalanceTableHAMT, address addr.Address) (
 // Determine whether the given address's entry in the balance table meets the required minimum
 // `minBalanceMaintain`.
 func BalanceTable_IsEntrySufficient(
-	table BalanceTableHAMT, address addr.Address, minBalanceMaintain TokenAmount) (ret bool, ok bool) {
+	table BalanceTableHAMT, address addr.Address, minBalanceMaintain actors.TokenAmount) (ret bool, ok bool) {
 
 	IMPL_FINISH()
 	panic("")
@@ -119,7 +85,7 @@ func BalanceTable_IsEntrySufficient(
 // Retrieve the balance table entry corresponding to the given address.
 func BalanceTable_GetEntry(
 	table BalanceTableHAMT, address addr.Address) (
-	ret TokenAmount, ok bool) {
+	ret actors.TokenAmount, ok bool) {
 
 	IMPL_FINISH()
 	panic("")
@@ -155,7 +121,7 @@ func (x *DealIDQueue_I) Enqueue(dealID deal.DealID) {
 }
 
 func (x *DealIDQueue_I) Dequeue() (dealID deal.DealID, ok bool) {
-	Assert(x.StartIndex() <= x.EndIndex())
+	AssertMsg(x.StartIndex() <= x.EndIndex(), "index %d > end %d", x.StartIndex(), x.EndIndex())
 
 	if x.StartIndex() == x.EndIndex() {
 		dealID = deal.DealID(-1)
@@ -178,17 +144,4 @@ func MinerSetHAMT_Empty() MinerSetHAMT {
 func ActorIDSetHAMT_Empty() ActorIDSetHAMT {
 	IMPL_FINISH()
 	panic("")
-}
-
-// Get the owner account address associated to a given miner actor.
-func GetMinerOwnerAddress(tree st.StateTree, minerAddr addr.Address) (addr.Address, error) {
-	IMPL_FINISH()
-	panic("")
-}
-
-// Get the owner account address associated to a given miner actor.
-func GetMinerOwnerAddress_Assert(tree st.StateTree, a addr.Address) addr.Address {
-	ret, err := GetMinerOwnerAddress(tree, a)
-	Assert(err == nil)
-	return ret
 }

--- a/src/actors/util/actor_util.id
+++ b/src/actors/util/actor_util.id
@@ -1,10 +1,10 @@
-import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
+import actors "github.com/filecoin-project/specs/actors"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
 import deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
 import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 
-type BalanceTableHAMT {addr.Address: actor.TokenAmount}
+type BalanceTableHAMT {addr.Address: actors.TokenAmount}
 
 type DealIDSetHAMT {deal.DealID: bool}
 type IntToDealIDHAMT {Int: deal.DealID}

--- a/src/actors/util/assert.go
+++ b/src/actors/util/assert.go
@@ -1,0 +1,33 @@
+package util
+
+import "fmt"
+
+// Indicates a condition that should never happen. If encountered, execution will halt and the
+// resulting state is undefined.
+func AssertMsg(b bool, format string, a ...interface{}) {
+	if !b {
+		panic(fmt.Sprintf(format, a...))
+	}
+}
+
+func Assert(b bool) {
+	AssertMsg(b, "assertion failed")
+}
+
+// Indicating behavior not yet specified, and may require other spec changes.
+func TODO(...interface{}) {
+	// Indirection to prevent the compiler from ignoring unreachable code
+	panic("TODO")
+}
+
+// Version of TODO() indicating that the operation is clearly implementable,
+// but some details remain to be filled in during implementation.
+func IMPL_TODO(...interface{}) {
+	panic("Not yet implemented in the spec")
+}
+
+// Version of TODO() indicating that the operation is believed to be unambiguous,
+// but is not yet implemented as code in the spec repository.
+func IMPL_FINISH(...interface{}) {
+	panic("Not yet implemented in the spec")
+}

--- a/src/systems/filecoin_markets/retrieval_market/retrieval_client.id
+++ b/src/systems/filecoin_markets/retrieval_market/retrieval_client.id
@@ -1,4 +1,4 @@
-import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
+import actors "github.com/filecoin-project/specs/actors"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import libp2p "github.com/filecoin-project/specs/libraries/libp2p"
 import piece "github.com/filecoin-project/specs/systems/filecoin_files/piece"
@@ -8,7 +8,7 @@ type RetrievalClientDealState struct {
     Status                 DealStatus
     Sender                 libp2p.PeerID
     TotalReceived          UInt
-    FundsSpent             actor.TokenAmount
+    FundsSpent             actors.TokenAmount
 }
 
 type Open struct {}
@@ -40,7 +40,7 @@ type RetrievalClient struct {
     Retrieve(
         pieceCID      piece.PieceCID
         params        RetrievalParams
-        totalFunds    actor.TokenAmount
+        totalFunds    actors.TokenAmount
         miner         libp2p.PeerID
         clientWallet  addr.Address
         minerWallet   addr.Address
@@ -48,7 +48,7 @@ type RetrievalClient struct {
     SubscribeToEvents(subscriber RetrievalClientSubscriber)
 
     // V1
-    AddMoreFunds(id RetrievalDealID, amount actor.TokenAmount) error
+    AddMoreFunds(id RetrievalDealID, amount actors.TokenAmount) error
     CancelDeal(id RetrievalDealID) error
     RetrievalStatus(id RetrievalDealID)
     ListDeals() {RetrievalDealID: RetrievalClientDealState}

--- a/src/systems/filecoin_markets/retrieval_market/retrieval_provider.id
+++ b/src/systems/filecoin_markets/retrieval_market/retrieval_provider.id
@@ -1,4 +1,4 @@
-import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
+import actors "github.com/filecoin-project/specs/actors"
 import libp2p "github.com/filecoin-project/specs/libraries/libp2p"
 
 type RetrievalProviderDealState struct {
@@ -6,7 +6,7 @@ type RetrievalProviderDealState struct {
     Status                 DealStatus
     Receiver               libp2p.PeerID
     TotalSent              UInt
-    FundsReceived          actor.TokenAmount
+    FundsReceived          actors.TokenAmount
 }
 
 type RetrievalProviderEvent struct {
@@ -27,11 +27,11 @@ type RetrievalProviderSubscriber struct {
 
 type RetrievalProvider struct {
     // V0
-    SetPricePerByte(price actor.TokenAmount)
+    SetPricePerByte(price actors.TokenAmount)
     SetPaymentInterval(paymentInterval UInt, paymentIntervalIncrease UInt)
     SubscribeToEvents(subscriber RetrievalProviderSubscriber)
 
     // V1
-    SetPricePerUnseal(price actor.TokenAmount)
+    SetPricePerUnseal(price actors.TokenAmount)
     ListDeals() {RetrievalProviderDealID: RetrievalProviderDealState}
 }

--- a/src/systems/filecoin_markets/retrieval_market/types.id
+++ b/src/systems/filecoin_markets/retrieval_market/types.id
@@ -1,7 +1,7 @@
 import ipld "github.com/filecoin-project/specs/libraries/ipld"
 import libp2p "github.com/filecoin-project/specs/libraries/libp2p"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
-import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
+import actors "github.com/filecoin-project/specs/actors"
 import piece "github.com/filecoin-project/specs/systems/filecoin_files/piece"
 
 type PaymentVoucher struct {}
@@ -29,7 +29,7 @@ type RetrievalQueryItemStatus union {
 type RetrievalQueryParams struct {
     PayloadCID                  ipld.CID  // optional, query if miner has this cid in this piece. some miners may not be able to respond.
     Selector                    ipld.Selector  // optional, query if miner has this cid in this piece. some miners may not be able to respond.
-    MaxPricePerByte             actor.TokenAmount  // optional, tell miner uninterested if more expensive than this
+    MaxPricePerByte             actors.TokenAmount  // optional, tell miner uninterested if more expensive than this
     MinPaymentInterval          UInt  // optional, tell miner uninterested unless payment interval is greater than this
     MinPaymentIntervalIncrease  UInt  // optional, tell miner uninterested unless payment interval increase is greater than this
 }
@@ -48,7 +48,7 @@ type RetrievalQueryResponse struct {
     ExpectedPayloadSize         uint64  // V1 - optional, if PayloadCID + selector are specified and miner knows, can offer an expected size
 
     PaymentAddress              addr.Address  // address to send funds to -- may be different than miner addr
-    MinPricePerByte             actor.TokenAmount
+    MinPricePerByte             actors.TokenAmount
     MaxPaymentInterval          UInt
     MaxPaymentIntervalIncrease  UInt
 
@@ -81,7 +81,7 @@ type DealStatus union {
 type RetrievalParams struct {
     PayloadCID               ipld.CID  // V1
     Selector                 ipld.Selector  // V1
-    PricePerByte             actor.TokenAmount
+    PricePerByte             actors.TokenAmount
     PaymentInterval          UInt
     PaymentIntervalIncrease  UInt
 }
@@ -104,7 +104,7 @@ type RetrievalDealResponse struct {
     ID           RetrievalDealID  // V1 - an identifier for the retrieval
 
     // payment required to proceed
-    PaymentOwed  actor.TokenAmount
+    PaymentOwed  actors.TokenAmount
 
     Message      string
     Blocks       [Block]  // V0 only

--- a/src/systems/filecoin_markets/storage_market/storage_client.id
+++ b/src/systems/filecoin_markets/storage_market/storage_client.id
@@ -1,6 +1,6 @@
 import ipld "github.com/filecoin-project/specs/libraries/ipld"
 import deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
-import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
+import actors "github.com/filecoin-project/specs/actors"
 import libp2p "github.com/filecoin-project/specs/libraries/libp2p"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
@@ -54,13 +54,13 @@ type StorageClient struct {
         payloadCid          ipld.CID
         proposalExpiration  block.ChainEpoch
         duration            block.ChainEpoch
-        price               actor.TokenAmount
-        collateral          actor.TokenAmount
+        price               actors.TokenAmount
+        collateral          actors.TokenAmount
     ) (ProposeStorageDealResult, error)
 
     // GetPaymentEscrow returns the current funds available for deal payment
-    GetPaymentEscrow() (actor.TokenAmount, error)
+    GetPaymentEscrow() (actors.TokenAmount, error)
 
     // AddPaymentEscrow adds storage collateral
-    AddPaymentEscrow(amount actor.TokenAmount) error
+    AddPaymentEscrow(amount actors.TokenAmount) error
 }

--- a/src/systems/filecoin_markets/storage_market/storage_deal/storage_deal.go
+++ b/src/systems/filecoin_markets/storage_market/storage_deal/storage_deal.go
@@ -1,6 +1,6 @@
 package storage_deal
 
-import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
+import actors "github.com/filecoin-project/specs/actors"
 import block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
 
 import util "github.com/filecoin-project/specs/util"
@@ -18,14 +18,14 @@ func (p *StorageDealProposal_I) Duration() block.ChainEpoch {
 	return (p.EndEpoch() - p.StartEpoch())
 }
 
-func (p *StorageDealProposal_I) TotalStorageFee() actor.TokenAmount {
-	return actor.TokenAmount(uint64(p.StoragePricePerEpoch()) * uint64(p.Duration()))
+func (p *StorageDealProposal_I) TotalStorageFee() actors.TokenAmount {
+	return actors.TokenAmount(uint64(p.StoragePricePerEpoch()) * uint64(p.Duration()))
 }
 
-func (p *StorageDealProposal_I) ClientBalanceRequirement() actor.TokenAmount {
+func (p *StorageDealProposal_I) ClientBalanceRequirement() actors.TokenAmount {
 	return (p.ClientCollateral() + p.TotalStorageFee())
 }
 
-func (p *StorageDealProposal_I) ProviderBalanceRequirement() actor.TokenAmount {
+func (p *StorageDealProposal_I) ProviderBalanceRequirement() actors.TokenAmount {
 	return p.ProviderCollateral()
 }

--- a/src/systems/filecoin_markets/storage_market/storage_deal/storage_deal.id
+++ b/src/systems/filecoin_markets/storage_market/storage_deal/storage_deal.id
@@ -1,4 +1,4 @@
-import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
+import actors "github.com/filecoin-project/specs/actors"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
 import filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
@@ -32,15 +32,15 @@ type StorageDealProposal struct {
     // otherwise it is invalid.
     StartEpoch                    block.ChainEpoch
     EndEpoch                      block.ChainEpoch
-    StoragePricePerEpoch          actor.TokenAmount
+    StoragePricePerEpoch          actors.TokenAmount
 
-    ProviderCollateral            actor.TokenAmount
-    ClientCollateral              actor.TokenAmount
+    ProviderCollateral            actors.TokenAmount
+    ClientCollateral              actors.TokenAmount
 
     Duration()                    block.ChainEpoch      @(cached)  // EndEpoch - StartEpoch
-    TotalStorageFee()             actor.TokenAmount  // StoragePricePerEpoch * Duration
-    ClientBalanceRequirement()    actor.TokenAmount  // ClientCollateral + TotalStorageFee
-    ProviderBalanceRequirement()  actor.TokenAmount  // ProviderCollateral
+    TotalStorageFee()             actors.TokenAmount  // StoragePricePerEpoch * Duration
+    ClientBalanceRequirement()    actors.TokenAmount  // ClientCollateral + TotalStorageFee
+    ProviderBalanceRequirement()  actors.TokenAmount  // ProviderCollateral
 
     CID()                         &StorageDealProposal
 }

--- a/src/systems/filecoin_markets/storage_market/storage_market.id
+++ b/src/systems/filecoin_markets/storage_market/storage_market.id
@@ -1,4 +1,4 @@
-import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
+import actors "github.com/filecoin-project/specs/actors"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
 import deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
@@ -12,8 +12,8 @@ type StorageDealStatus uint64
 // StorageAsk is the current price and parameters a miner is currently offering for storage
 // (analogous to an Ask in a financial market)
 type StorageAsk struct {
-    Price             actor.TokenAmount  // attoFIL per GiB per epoch
-    Collateral        actor.TokenAmount  // attoFIL per GiB per epoch
+    Price             actors.TokenAmount  // attoFIL per GiB per epoch
+    Collateral        actors.TokenAmount  // attoFIL per GiB per epoch
 
     MinPieceSize      piece.PieceSize
     // address of miner actor for deals

--- a/src/systems/filecoin_markets/storage_market/storage_provider.id
+++ b/src/systems/filecoin_markets/storage_market/storage_provider.id
@@ -1,6 +1,6 @@
 import ipld "github.com/filecoin-project/specs/libraries/ipld"
 import deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
-import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
+import actors "github.com/filecoin-project/specs/actors"
 import libp2p "github.com/filecoin-project/specs/libraries/libp2p"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import dt "github.com/filecoin-project/specs/systems/filecoin_files/data_transfer"
@@ -25,7 +25,7 @@ type MinerDeal struct {
 
 // The interface provided for storage providers
 type StorageProvider struct {
-    AddAsk(price actor.TokenAmount, ttlsecs int64) error
+    AddAsk(price actors.TokenAmount, ttlsecs int64) error
 
     // ListAsks lists current asks
     ListAsks(addrress addr.Address) [StorageAsk]
@@ -37,10 +37,10 @@ type StorageProvider struct {
     ListIncompleteDeals()  (deals [MinerDeal], error)
 
     // AddStorageCollateral adds storage collateral
-    AddStorageCollateral(amount actor.TokenAmount) error
+    AddStorageCollateral(amount actors.TokenAmount) error
 
     // GetStorageCollateral returns the current collateral balance
-    GetStorageCollateral() (actor.TokenAmount, error)
+    GetStorageCollateral() (actors.TokenAmount, error)
 
     // DataTransferValidator methods
     ValidatePush(

--- a/src/systems/filecoin_mining/storage_mining/storage_mining_subsystem.id
+++ b/src/systems/filecoin_mining/storage_mining/storage_mining_subsystem.id
@@ -2,7 +2,7 @@ import sectoridx "github.com/filecoin-project/specs/systems/filecoin_mining/sect
 import spc "github.com/filecoin-project/specs/systems/filecoin_blockchain/storage_power_consensus"
 import spowact "github.com/filecoin-project/specs/actors/builtin/storage_power"
 import sminact "github.com/filecoin-project/specs/actors/builtin/storage_miner"
-import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
+import actors "github.com/filecoin-project/specs/actors"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
 import blockchain "github.com/filecoin-project/specs/systems/filecoin_blockchain"
@@ -48,7 +48,7 @@ type StorageMiningSubsystem struct {
         workerAddr  addr.Address
         sectorSize  util.UInt
         peerId      libp2p.PeerID
-        pledgeAmt   actor.TokenAmount
+        pledgeAmt   actors.TokenAmount
     )
 
     // call by StorageMarket.StorageProvider at the start of a deal.
@@ -81,7 +81,7 @@ type StorageMiningSubsystem struct {
     _submitSurprisePoStMessage(
         state     stateTree.StateTree
         sPoSt     sector.OnChainPoStVerifyInfo
-        gasPrice  actor.TokenAmount
+        gasPrice  actors.TokenAmount
         gasLimit  msg.GasAmount
     ) error
 

--- a/src/systems/filecoin_nodes/node_base/network_params.go
+++ b/src/systems/filecoin_nodes/node_base/network_params.go
@@ -1,8 +1,8 @@
 package node_base
 
 import (
+	actors "github.com/filecoin-project/specs/actors"
 	block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
-	actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 )
 
 /////////////////////////////////////////////////////////////
@@ -56,7 +56,7 @@ const SPC_LOOKBACK_SEAL = FINALITY  // should be set to finality
 
 // FIL deposit per sector precommit in Interactive PoRep
 // refunded after ProveCommit but burned if PreCommit expires
-const PRECOMMIT_DEPOSIT_PER_BYTE = actor.TokenAmount(0) // placeholder
-const FAULT_SLASH_PERC_DECLARED = 1                     // placeholder
-const FAULT_SLASH_PERC_DETECTED = 10                    // placeholder
-const FAULT_SLASH_PERC_TERMINATED = 100                 // placeholder
+const PRECOMMIT_DEPOSIT_PER_BYTE = actors.TokenAmount(0) // placeholder
+const FAULT_SLASH_PERC_DECLARED = 1                      // placeholder
+const FAULT_SLASH_PERC_DETECTED = 10                     // placeholder
+const FAULT_SLASH_PERC_TERMINATED = 100                  // placeholder

--- a/src/systems/filecoin_token/multisig/multisig_actor.id
+++ b/src/systems/filecoin_token/multisig/multisig_actor.id
@@ -1,5 +1,5 @@
 import address "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
-import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
+import actors "github.com/filecoin-project/specs/actors"
 
 type TxSeqNo UVarint
 type NumRequired UVarint
@@ -10,7 +10,7 @@ type MultisigActor struct {
     signers         [address.Address]
     required        NumRequired
     nextTxId        TxSeqNo
-    initialBalance  actor.TokenAmount
+    initialBalance  actors.TokenAmount
     startingBlock   Epoch
     unlockDuration  EpochDuration
     // transactions    {TxSeqNo: Transaction} // TODO Transaction type does not exist
@@ -22,7 +22,7 @@ type MultisigActor struct {
     )
     Propose(
         to      address.Address
-        value   actor.TokenAmount
+        value   actors.TokenAmount
         method  string
         params  Bytes
     ) TxSeqNo

--- a/src/systems/filecoin_vm/actor/actor.go
+++ b/src/systems/filecoin_vm/actor/actor.go
@@ -1,6 +1,7 @@
 package actor
 
 import (
+	actors "github.com/filecoin-project/specs/actors"
 	ipld "github.com/filecoin-project/specs/libraries/ipld"
 	util "github.com/filecoin-project/specs/util"
 )
@@ -12,11 +13,11 @@ var TODO = util.TODO
 type Serialization = util.Serialization
 
 const (
-	MethodSend        = MethodNum(0)
-	MethodConstructor = MethodNum(1)
+	MethodSend        = actors.MethodNum(0)
+	MethodConstructor = actors.MethodNum(1)
 
 	// TODO: remove this once canonical method numbers are finalized
-	MethodPlaceholder = MethodNum(-(1 << 30))
+	MethodPlaceholder = actors.MethodNum(1 << 30)
 )
 
 func (st *ActorState_I) CID() ipld.CID {
@@ -86,9 +87,4 @@ func (id *CodeID_I) IsSignable() bool {
 
 func (x ActorSubstateCID) Ref() *ActorSubstateCID {
 	return &x
-}
-
-func TokenAmount_Placeholder() TokenAmount {
-	TODO()
-	panic("")
 }

--- a/src/systems/filecoin_vm/actor/actor.id
+++ b/src/systems/filecoin_vm/actor/actor.id
@@ -1,32 +1,8 @@
 // This contains actor things that are _outside_ of VM exection.
 // The VM uses this to execute actors.
 
+import actors "github.com/filecoin-project/specs/actors"
 import ipld "github.com/filecoin-project/specs/libraries/ipld"
-
-// TokenAmount is an amount of Filecoin tokens. This type is used within
-// the VM in message execution, to account movement of tokens, payment
-// of VM gas, and more.
-type TokenAmount Int  // TODO: should be BigInt (attoFIL)
-
-// MethodNum is an integer that represents a particular method
-// in an actor's function table. These numbers are used to compress
-// invocation of actor code, and to decouple human language concerns
-// about method names from the ability to uniquely refer to a particular
-// method.
-//
-// Consider MethodNum numbers to be similar in concerns as for
-// offsets in function tables (in programming languages), and for
-// tags in ProtocolBuffer fields. Tags in ProtocolBuffers recommend
-// assigning a unique tag to a field and never reusing that tag.
-// If a field is no longer used, the field name may change but should
-// still remain defined in the code to ensure the tag number is not
-// reused accidentally. The same should apply to the MethodNum
-// associated with methods in Filecoin VM Actors.
-type MethodNum Int
-
-// MethodParams is an array of objects to pass into a method. This
-// is the list of arguments/parameters.
-type MethodParams [util.Serialization]
 
 // CallSeqNum is an invocation (Call) sequence (Seq) number (Num).
 // This is a value used for securing against replay attacks:
@@ -90,7 +66,7 @@ type ActorState struct {
     // CID of the root of optional actor-specific sub-state.
     State       ActorSubstateCID
     // Balance of tokens held by this actor.
-    Balance     TokenAmount
+    Balance     actors.TokenAmount
     // Expected sequence number of the next message sent by this actor.
     // Initially zero, incremented when an account actor originates a top-level message.
     // Always zero for other actors.

--- a/src/systems/filecoin_vm/indices/indices.go
+++ b/src/systems/filecoin_vm/indices/indices.go
@@ -1,6 +1,7 @@
 package indices
 
 import (
+	actors "github.com/filecoin-project/specs/actors"
 	actor_util "github.com/filecoin-project/specs/actors/util"
 	block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
 	piece "github.com/filecoin-project/specs/systems/filecoin_files/piece"
@@ -18,7 +19,7 @@ func Indices_FromStateTree(tree st.StateTree) Indices {
 	panic("")
 }
 
-func StorageDeal_ProviderInitTimedOutSlashAmount(deal deal.OnChainDeal) actor.TokenAmount {
+func StorageDeal_ProviderInitTimedOutSlashAmount(deal deal.OnChainDeal) actors.TokenAmount {
 	// placeholder
 	PARAM_FINISH()
 	return deal.Deal().Proposal().ProviderBalanceRequirement()
@@ -40,7 +41,7 @@ func (inds *Indices_I) StorageDeal_StoragePricePerEpochBounds(
 	pieceSize piece.PieceSize,
 	startEpoch block.ChainEpoch,
 	endEpoch block.ChainEpoch,
-) (minPrice actor.TokenAmount, maxPrice actor.TokenAmount) {
+) (minPrice actors.TokenAmount, maxPrice actors.TokenAmount) {
 
 	// placeholder
 	PARAM_FINISH()
@@ -51,7 +52,7 @@ func (inds *Indices_I) StorageDeal_ProviderCollateralBounds(
 	pieceSize piece.PieceSize,
 	startEpoch block.ChainEpoch,
 	endEpoch block.ChainEpoch,
-) (minProviderCollateral actor.TokenAmount, maxProviderCollateral actor.TokenAmount) {
+) (minProviderCollateral actors.TokenAmount, maxProviderCollateral actors.TokenAmount) {
 
 	// placeholder
 	PARAM_FINISH()
@@ -62,7 +63,7 @@ func (inds *Indices_I) StorageDeal_ClientCollateralBounds(
 	pieceSize piece.PieceSize,
 	startEpoch block.ChainEpoch,
 	endEpoch block.ChainEpoch,
-) (minClientCollateral actor.TokenAmount, maxClientCollateral actor.TokenAmount) {
+) (minClientCollateral actors.TokenAmount, maxClientCollateral actors.TokenAmount) {
 
 	// placeholder
 	PARAM_FINISH()
@@ -81,7 +82,7 @@ func (inds *Indices_I) SectorWeight(
 	panic("")
 }
 
-func (inds *Indices_I) PledgeCollateralReq(minerNominalPower block.StoragePower) actor.TokenAmount {
+func (inds *Indices_I) PledgeCollateralReq(minerNominalPower block.StoragePower) actors.TokenAmount {
 	PARAM_FINISH()
 	panic("")
 }
@@ -92,7 +93,7 @@ func (inds *Indices_I) SectorWeightProportion(minerActiveSectorWeight block.Sect
 	panic("")
 }
 
-func (inds *Indices_I) PledgeCollateralProportion(minerPledgeCollateral actor.TokenAmount) util.BigInt {
+func (inds *Indices_I) PledgeCollateralProportion(minerPledgeCollateral actors.TokenAmount) util.BigInt {
 	// return proportion of Pledge Collateral for miner
 	PARAM_FINISH()
 	panic("")
@@ -101,7 +102,7 @@ func (inds *Indices_I) PledgeCollateralProportion(minerPledgeCollateral actor.To
 func (inds *Indices_I) StoragePower(
 	minerActiveSectorWeight block.SectorWeight,
 	minerInactiveSectorWeight block.SectorWeight,
-	minerPledgeCollateral actor.TokenAmount,
+	minerPledgeCollateral actors.TokenAmount,
 ) block.StoragePower {
 	// return StoragePower based on inputs
 	// StoragePower for miner = func(ActiveSectorWeight for miner, PledgeCollateral for miner, global indices)
@@ -116,7 +117,7 @@ func (inds *Indices_I) StoragePowerProportion(
 	panic("")
 }
 
-func (inds *Indices_I) CurrEpochBlockReward() actor.TokenAmount {
+func (inds *Indices_I) CurrEpochBlockReward() actors.TokenAmount {
 	// total block reward allocated for CurrEpoch
 	// each expected winner get an equal share of this reward
 	// computed as a function of NetworkKPI, LastEpochReward, TotalUnmminedFIL, etc
@@ -126,9 +127,9 @@ func (inds *Indices_I) CurrEpochBlockReward() actor.TokenAmount {
 
 func (inds *Indices_I) GetCurrBlockRewardRewardForMiner(
 	minerStoragePower block.StoragePower,
-	minerPledgeCollateral actor.TokenAmount,
+	minerPledgeCollateral actors.TokenAmount,
 	// TODO extend or eliminate
-) actor.TokenAmount {
+) actors.TokenAmount {
 	PARAM_FINISH()
 	panic("")
 }
@@ -137,8 +138,8 @@ func (inds *Indices_I) GetPledgeSlashForStorageFault(
 	affectedPower block.StoragePower,
 	newActiveSectorWeight block.SectorWeight,
 	newInactiveSectorWeight block.SectorWeight,
-	currPledge actor.TokenAmount,
-) actor.TokenAmount {
+	currPledge actors.TokenAmount,
+) actors.TokenAmount {
 	PARAM_FINISH()
 	panic("")
 }
@@ -146,7 +147,7 @@ func (inds *Indices_I) GetPledgeSlashForStorageFault(
 func (inds *Indices_I) StorageMining_PreCommitDeposit(
 	sectorSize sector.SectorSize,
 	expirationEpoch block.ChainEpoch,
-) actor.TokenAmount {
+) actors.TokenAmount {
 	PARAM_FINISH()
 	panic("")
 }
@@ -154,15 +155,15 @@ func (inds *Indices_I) StorageMining_PreCommitDeposit(
 func (inds *Indices_I) StorageMining_TemporaryFaultFee(
 	storageWeightDescs []actor_util.SectorStorageWeightDesc,
 	duration block.ChainEpoch,
-) actor.TokenAmount {
+) actors.TokenAmount {
 	PARAM_FINISH()
 	panic("")
 }
 
 func (inds *Indices_I) NetworkTransactionFee(
 	toActorCodeID actor.CodeID,
-	methodNum actor.MethodNum,
-) actor.TokenAmount {
+	methodNum actors.MethodNum,
+) actors.TokenAmount {
 	PARAM_FINISH()
 	panic("")
 }

--- a/src/systems/filecoin_vm/indices/indices.id
+++ b/src/systems/filecoin_vm/indices/indices.id
@@ -1,4 +1,5 @@
 import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
+import actors "github.com/filecoin-project/specs/actors"
 import actor_util "github.com/filecoin-project/specs/actors/util"
 import block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
 import piece "github.com/filecoin-project/specs/systems/filecoin_files/piece"
@@ -15,17 +16,17 @@ type Indices struct {
     Epoch                       block.ChainEpoch
     NetworkKPI                  BigInt
     TotalNetworkSectorWeight    block.SectorWeight
-    TotalPledgeCollateral       actor.TokenAmount
+    TotalPledgeCollateral       actors.TokenAmount
     TotalNetworkEffectivePower  block.StoragePower  // power above minimum miner size
     TotalNetworkPower           block.StoragePower  // total network power irrespective of meeting minimum miner size
 
-    TotalMinedFIL               actor.TokenAmount
-    TotalUnminedFIL             actor.TokenAmount
-    TotalBurnedFIL              actor.TokenAmount
-    LastEpochReward             actor.TokenAmount
+    TotalMinedFIL               actors.TokenAmount
+    TotalUnminedFIL             actors.TokenAmount
+    TotalBurnedFIL              actors.TokenAmount
+    LastEpochReward             actors.TokenAmount
 
     // these methods produce policy output based on user state/action
-    StorageDeal_ProviderInitTimedOutSlashAmount(deal deal.OnChainDeal) actor.TokenAmount
+    StorageDeal_ProviderInitTimedOutSlashAmount(deal deal.OnChainDeal) actors.TokenAmount
 
     StorageDeal_DurationBounds(
         pieceSize   piece.PieceSize
@@ -36,15 +37,15 @@ type Indices struct {
         pieceSize   piece.PieceSize
         startEpoch  block.ChainEpoch
         endEpoch    block.ChainEpoch
-    ) (minPrice actor.TokenAmount, maxPrice actor.TokenAmount)
+    ) (minPrice actors.TokenAmount, maxPrice actors.TokenAmount)
 
     StorageDeal_ProviderCollateralBounds(
         pieceSize   piece.PieceSize
         startEpoch  block.ChainEpoch
         endEpoch    block.ChainEpoch
     ) (
-        minProviderCollateral  actor.TokenAmount
-        maxProviderCollateral  actor.TokenAmount
+        minProviderCollateral  actors.TokenAmount
+        maxProviderCollateral  actors.TokenAmount
     )
 
     StorageDeal_ClientCollateralBounds(
@@ -52,8 +53,8 @@ type Indices struct {
         startEpoch  block.ChainEpoch
         endEpoch    block.ChainEpoch
     ) (
-        minClientCollateral  actor.TokenAmount
-        maxClientCollateral  actor.TokenAmount
+        minClientCollateral  actors.TokenAmount
+        maxClientCollateral  actors.TokenAmount
     )
 
     SectorWeight(
@@ -65,57 +66,57 @@ type Indices struct {
 
     PledgeCollateralReq(
         minerNominalPower block.StoragePower
-    ) actor.TokenAmount
+    ) actors.TokenAmount
 
     SectorWeightProportion(
         minerActiveSectorWeight block.SectorWeight
     ) BigInt
 
     PledgeCollateralProportion(
-        minerPledgeCollateral actor.TokenAmount
+        minerPledgeCollateral actors.TokenAmount
     ) BigInt
 
     StoragePower(
         minerActiveSectorWeight    block.SectorWeight
         minerInactiveSectorWeight  block.SectorWeight
-        minerPledgeCollateral      actor.TokenAmount
+        minerPledgeCollateral      actors.TokenAmount
     ) block.StoragePower
 
     StoragePowerProportion(
         minerStoragePower block.StoragePower
     ) BigInt
 
-    CurrEpochBlockReward() actor.TokenAmount
+    CurrEpochBlockReward() actors.TokenAmount
 
     GetCurrBlockRewardForMiner(
         minerStoragePower      block.StoragePower
-        minerPledgeCollateral  actor.TokenAmount
-    ) actor.TokenAmount
+        minerPledgeCollateral  actors.TokenAmount
+    ) actors.TokenAmount
 
     StorageMining_PreCommitDeposit(
         sectorSize       sector.SectorSize
         expirationEpoch  block.ChainEpoch
-    ) actor.TokenAmount
+    ) actors.TokenAmount
 
     StorageMining_TemporaryFaultFee(
         storageWeightDescs  [actor_util.SectorStorageWeightDesc]
         duration            block.ChainEpoch
-    ) actor.TokenAmount
+    ) actors.TokenAmount
 
     StoragePower_PledgeSlashForSectorTermination(
         storageWeightDesc  actor_util.SectorStorageWeightDesc
         terminationType    actor_util.SectorTerminationType
-    ) actor.TokenAmount
+    ) actors.TokenAmount
 
     StoragePower_PledgeSlashForSurprisePoStFailure(
         minerClaimedPower       block.StoragePower
         numConsecutiveFailures  int
-    ) actor.TokenAmount
+    ) actors.TokenAmount
 
     StoragePower_ConsensusMinMinerPower() block.StoragePower
 
     NetworkTransactionFee(
         toActorCodeID  actor.CodeID
-        methodNum      actor.MethodNum
-    ) actor.TokenAmount
+        methodNum      actors.MethodNum
+    ) actors.TokenAmount
 }

--- a/src/systems/filecoin_vm/interpreter/vm_interpreter.go
+++ b/src/systems/filecoin_vm/interpreter/vm_interpreter.go
@@ -1,9 +1,11 @@
 package interpreter
 
 import (
+	actors "github.com/filecoin-project/specs/actors"
 	cronact "github.com/filecoin-project/specs/actors/builtin/cron"
 	initact "github.com/filecoin-project/specs/actors/builtin/init"
 	sminact "github.com/filecoin-project/specs/actors/builtin/storage_miner"
+	serde "github.com/filecoin-project/specs/actors/serde"
 	ipld "github.com/filecoin-project/specs/libraries/ipld"
 	actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 	addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
@@ -49,8 +51,8 @@ func (vmi *VMInterpreter_I) ApplyTipSetMessages(inTree st.StateTree, msgs TipSet
 		epostMessage := _makeElectionPoStMessage(outTree, minerAddr)
 		outTree = _applyMessageBuiltinAssert(outTree, epostMessage, minerAddr)
 
-		minerPenaltyTotal := actor.TokenAmount(0)
-		var minerPenaltyCurr actor.TokenAmount
+		minerPenaltyTotal := actors.TokenAmount(0)
+		var minerPenaltyCurr actors.TokenAmount
 
 		// Process BLS messages from the block.
 		for _, m := range blk.BLSMessages() {
@@ -94,7 +96,7 @@ func (vmi *VMInterpreter_I) ApplyTipSetMessages(inTree st.StateTree, msgs TipSet
 
 func (vmi *VMInterpreter_I) ApplyMessage(
 	inTree st.StateTree, message msg.UnsignedMessage, onChainMessageSize int, minerAddr addr.Address) (
-	retTree st.StateTree, retReceipt vmr.MessageReceipt, retMinerPenalty actor.TokenAmount) {
+	retTree st.StateTree, retReceipt vmr.MessageReceipt, retMinerPenalty actors.TokenAmount) {
 
 	senderAddr := _resolveSender(inTree, message.From())
 	minerOwner := _lookupMinerOwner(inTree, minerAddr)
@@ -118,7 +120,7 @@ func (vmi *VMInterpreter_I) ApplyMessage(
 			Assert(message.GasLimit().Equals(vmiGasUsed.Add(vmiGasRemaining)))
 			tree = _withTransferFundsAssert(tree, addr.BurntFundsActorAddr, senderAddr, vmiGasRemainingFIL)
 			tree = _withTransferFundsAssert(tree, addr.BurntFundsActorAddr, minerOwner, vmiGasUsedFIL)
-			retMinerPenalty = actor.TokenAmount(0)
+			retMinerPenalty = actors.TokenAmount(0)
 
 		case SenderResolveSpec_Invalid:
 			retMinerPenalty = vmiGasUsedFIL
@@ -281,14 +283,14 @@ func _applyMessageInternal(tree st.StateTree, sender actor.ActorState, senderAdd
 		actor.CallSeqNum(0),
 		tree,
 		senderAddr,
-		actor.TokenAmount(0),
+		actors.TokenAmount(0),
 		gasRemainingInit,
 	)
 
 	return rt.SendToplevelFromInterpreter(invoc)
 }
 
-func _withTransferFundsAssert(tree st.StateTree, from addr.Address, to addr.Address, amount actor.TokenAmount) st.StateTree {
+func _withTransferFundsAssert(tree st.StateTree, from addr.Address, to addr.Address, amount actors.TokenAmount) st.StateTree {
 	// TODO: assert amount nonnegative
 	retTree, err := tree.Impl().WithFundsTransfer(from, to, amount)
 	if err != nil {
@@ -298,10 +300,10 @@ func _withTransferFundsAssert(tree st.StateTree, from addr.Address, to addr.Addr
 	}
 }
 
-func _gasToFIL(gas msg.GasAmount, price actor.TokenAmount) actor.TokenAmount {
+func _gasToFIL(gas msg.GasAmount, price actors.TokenAmount) actors.TokenAmount {
 	IMPL_FINISH()
 	panic("") // BigInt arithmetic
-	// return actor.TokenAmount(util.UVarint(gas) * util.UVarint(price))
+	// return actors.TokenAmount(util.UVarint(gas) * util.UVarint(price))
 }
 
 func _makeInvocInput(message msg.UnsignedMessage) vmr.InvocInput {
@@ -314,11 +316,8 @@ func _makeInvocInput(message msg.UnsignedMessage) vmr.InvocInput {
 }
 
 // Builds a message for paying block reward to a miner's owner.
-func _makeBlockRewardMessage(state st.StateTree, minerAddr addr.Address, penalty actor.TokenAmount) msg.UnsignedMessage {
-	params := make([]util.Serialization, 2)
-	params[0] = addr.Serialize_Address(minerAddr)
-	params[1] = actor.Serialize_TokenAmount(penalty)
-
+func _makeBlockRewardMessage(state st.StateTree, minerAddr addr.Address, penalty actors.TokenAmount) msg.UnsignedMessage {
+	params := serde.MustSerializeParams(minerAddr, penalty)
 	TODO() // serialize other inputs to BlockRewardMessage or get this from query in RewardActor
 
 	sysActor, ok := state.GetActor(addr.SystemActorAddr)
@@ -337,16 +336,13 @@ func _makeBlockRewardMessage(state st.StateTree, minerAddr addr.Address, penalty
 
 // Builds a message for submitting ElectionPost on behalf of a miner actor.
 func _makeElectionPoStMessage(state st.StateTree, minerActorAddr addr.Address) msg.UnsignedMessage {
-	// TODO: determine parameters necessary for this message.
-	params := make([]util.Serialization, 0)
-
 	sysActor, ok := state.GetActor(addr.SystemActorAddr)
 	Assert(ok)
 	return &msg.UnsignedMessage_I{
 		From_:       addr.SystemActorAddr,
 		To_:         minerActorAddr,
 		Method_:     ai.Method_StorageMinerActor_OnVerifiedElectionPoSt,
-		Params_:     params,
+		Params_:     nil,
 		CallSeqNum_: sysActor.CallSeqNum(),
 		Value_:      0,
 		GasPrice_:   0,

--- a/src/systems/filecoin_vm/message/message.id
+++ b/src/systems/filecoin_vm/message/message.id
@@ -1,6 +1,7 @@
 import filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
+import actors "github.com/filecoin-project/specs/actors"
 
 // GasAmount is a quantity of gas.
 type GasAmount struct {
@@ -23,15 +24,15 @@ type UnsignedMessage struct {
     CallSeqNum  actor.CallSeqNum
 
     // Amount of value to transfer from sender's to receiver's balance.
-    Value       actor.TokenAmount
+    Value       actors.TokenAmount
 
     // Optional method to invoke on receiver, zero for a plain value send.
-    Method      actor.MethodNum
+    Method      actors.MethodNum
     /// Serialized parameters to the method (if method is non-zero).
-    Params      actor.MethodParams
+    Params      actors.MethodParams
 
     // GasPrice is a Gas-to-FIL cost
-    GasPrice    actor.TokenAmount
+    GasPrice    actors.TokenAmount
     GasLimit    GasAmount
 }  // representation tuple
 

--- a/src/systems/filecoin_vm/runtime/gascost/vm_gascosts.go
+++ b/src/systems/filecoin_vm/runtime/gascost/vm_gascosts.go
@@ -1,8 +1,11 @@
 package runtime
 
-import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
-import msg "github.com/filecoin-project/specs/systems/filecoin_vm/message"
-import util "github.com/filecoin-project/specs/util"
+import (
+	actors "github.com/filecoin-project/specs/actors"
+	actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
+	msg "github.com/filecoin-project/specs/systems/filecoin_vm/message"
+	util "github.com/filecoin-project/specs/util"
+)
 
 type Bytes = util.Bytes
 
@@ -106,9 +109,9 @@ func IpldPut(dataSize int) msg.GasAmount {
 	return msg.GasAmount_Affine(IpldPutBase, dataSize, IpldPutPerByte)
 }
 
-func InvokeMethod(value actor.TokenAmount, method actor.MethodNum) msg.GasAmount {
+func InvokeMethod(value actors.TokenAmount, method actors.MethodNum) msg.GasAmount {
 	ret := SendBase
-	if value != actor.TokenAmount(0) {
+	if value != actors.TokenAmount(0) {
 		ret = ret.Add(SendTransferFunds)
 	}
 	if method != actor.MethodSend {

--- a/src/systems/filecoin_vm/runtime/rtutil.go
+++ b/src/systems/filecoin_vm/runtime/rtutil.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	actors "github.com/filecoin-project/specs/actors"
 	filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
 	actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 	addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
@@ -25,7 +26,9 @@ func NetworkName() string {
 // ActorCode is the interface that all actor code types should satisfy.
 // It is merely a method dispatch interface.
 type ActorCode interface {
-	InvokeMethod(rt Runtime, method actor.MethodNum, params actor.MethodParams) InvocOutput
+	//InvokeMethod(rt Runtime, method actor.MethodNum, params actor.MethodParams) InvocOutput
+	// IMPL_TODO: method dispatch mechanism is deferred to implementations.
+	// When the executable actor spec is complete we can re-instantiate something here.
 }
 
 type CallerPattern struct {
@@ -57,7 +60,7 @@ func CallerPattern_MakeAcceptAny() CallerPattern {
 	}
 }
 
-func InvocInput_Make(to addr.Address, method actor.MethodNum, params actor.MethodParams, value actor.TokenAmount) InvocInput {
+func InvocInput_Make(to addr.Address, method actors.MethodNum, params actors.MethodParams, value actors.TokenAmount) InvocInput {
 	return &InvocInput_I{
 		To_:     to,
 		Method_: method,
@@ -112,10 +115,10 @@ func RT_Address_Is_StorageMiner(rt Runtime, minerAddr addr.Address) bool {
 
 func RT_GetMinerAccountsAssert(rt Runtime, minerAddr addr.Address) (ownerAddr addr.Address, workerAddr addr.Address) {
 	ownerAddr = addr.Deserialize_Address_Compact_Assert(
-		rt.SendQuery(minerAddr, ai.Method_StorageMinerActor_GetOwnerAddr, []util.Serialization{}))
+		rt.SendQuery(minerAddr, ai.Method_StorageMinerActor_GetOwnerAddr, nil))
 
 	workerAddr = addr.Deserialize_Address_Compact_Assert(
-		rt.SendQuery(minerAddr, ai.Method_StorageMinerActor_GetWorkerAddr, []util.Serialization{}))
+		rt.SendQuery(minerAddr, ai.Method_StorageMinerActor_GetWorkerAddr, nil))
 
 	return
 }
@@ -136,7 +139,7 @@ func RT_MinerEntry_ValidateCaller_DetermineFundsLocation(rt Runtime, entryAddr a
 	}
 }
 
-func RT_ConfirmFundsReceiptOrAbort_RefundRemainder(rt Runtime, fundsRequired actor.TokenAmount) {
+func RT_ConfirmFundsReceiptOrAbort_RefundRemainder(rt Runtime, fundsRequired actors.TokenAmount) {
 	if rt.ValueReceived() < fundsRequired {
 		rt.AbortFundsMsg("Insufficient funds received accompanying message")
 	}

--- a/src/systems/filecoin_vm/runtime/runtime.id
+++ b/src/systems/filecoin_vm/runtime/runtime.id
@@ -1,4 +1,5 @@
 import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
+import actors "github.com/filecoin-project/specs/actors"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
 import exitcode "github.com/filecoin-project/specs/systems/filecoin_vm/runtime/exitcode"
@@ -66,8 +67,8 @@ type Runtime interface {
     // Check that the given condition is true (and call Abort if not).
     Assert(bool)
 
-    CurrentBalance()  actor.TokenAmount
-    ValueReceived()   actor.TokenAmount
+    CurrentBalance()  actors.TokenAmount
+    ValueReceived()   actors.TokenAmount
 
     // Look up the current values of several system-wide economic indices.
     CurrIndices()     indices.Indices
@@ -85,16 +86,16 @@ type Runtime interface {
     SendPropagatingErrors(input InvocInput) InvocOutput
     Send(
         toAddr     addr.Address
-        methodNum  actor.MethodNum
-        params     actor.MethodParams
-        value      actor.TokenAmount
+        methodNum  actors.MethodNum
+        params     actors.MethodParams
+        value      actors.TokenAmount
     ) InvocOutput
     SendQuery(
         toAddr     addr.Address
-        methodNum  actor.MethodNum
-        params     [util.Serialization]
+        methodNum  actors.MethodNum
+        params     actors.MethodParams
     ) util.Serialization
-    SendFunds(toAddr addr.Address, value actor.TokenAmount)
+    SendFunds(toAddr addr.Address, value actors.TokenAmount)
 
     // Sends a message to another actor, trapping an unsuccessful execution.
     // This may only be invoked by the singleton Cron actor.
@@ -126,9 +127,9 @@ type Runtime interface {
 
 type InvocInput struct {
     To      addr.Address
-    Method  actor.MethodNum
-    Params  actor.MethodParams
-    Value   actor.TokenAmount
+    Method  actors.MethodNum
+    Params  actors.MethodParams
+    Value   actors.TokenAmount
 }
 
 type InvocOutput struct {

--- a/src/systems/filecoin_vm/state_tree/state_tree.go
+++ b/src/systems/filecoin_vm/state_tree/state_tree.go
@@ -1,6 +1,7 @@
 package state_tree
 
 import (
+	"github.com/filecoin-project/specs/actors"
 	"github.com/filecoin-project/specs/libraries/ipld"
 	"github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 	addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
@@ -42,7 +43,7 @@ func (st *StateTree_I) WithActorSystemState(a addr.Address, actorState actor.Act
 	panic("")
 }
 
-func (st *StateTree_I) WithFundsTransfer(from addr.Address, to addr.Address, amount actor.TokenAmount) (StateTree, error) {
+func (st *StateTree_I) WithFundsTransfer(from addr.Address, to addr.Address, amount actors.TokenAmount) (StateTree, error) {
 	IMPL_FINISH()
 	panic("")
 }
@@ -73,12 +74,12 @@ func treeIncrementActorSeqNo(inTree StateTree, a actor.Actor) (outTree StateTree
 	panic("todo")
 }
 
-func treeDeductFunds(inTree StateTree, a actor.Actor, amt actor.TokenAmount) (outTree StateTree) {
+func treeDeductFunds(inTree StateTree, a actor.Actor, amt actors.TokenAmount) (outTree StateTree) {
 	// TODO: turn this into a single transfer call.
 	panic("todo")
 }
 
-func treeDepositFunds(inTree StateTree, a actor.Actor, amt actor.TokenAmount) (outTree StateTree) {
+func treeDepositFunds(inTree StateTree, a actor.Actor, amt actors.TokenAmount) (outTree StateTree) {
 	// TODO: turn this into a single transfer call.
 	panic("todo")
 }


### PR DESCRIPTION
Much of this is noise from changing imports, but some significant changes:
- Moved some type aliases into the actors directory (more to follow).
- Removed the InvokeMethod calls and method dispatch, which was mostly just stubs.
  Dispatch belongs in the VM, not the actors themselves, and implementations have existing
  patterns. I do plan to add back exports lists defining the method numbers and types later.
- Changed MethodParams to a single serialized object and replaced use of codegen serialization
  placeholders with a global placeholder. This latter will be filled in with real CBOR
  serialization as part of making the actors executable.

This is based on #788, rebase before merging.

Imports remaining to break:
```
github.com/filecoin-project/specs/algorithms/crypto
github.com/filecoin-project/specs/libraries/filcrypto/filproofs
github.com/filecoin-project/specs/libraries/ipld
github.com/filecoin-project/specs/libraries/libp2p
github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block
github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal
github.com/filecoin-project/specs/systems/filecoin_mining/sector
github.com/filecoin-project/specs/systems/filecoin_nodes/node_base
github.com/filecoin-project/specs/systems/filecoin_vm/actor
github.com/filecoin-project/specs/systems/filecoin_vm/actor/address
github.com/filecoin-project/specs/systems/filecoin_vm/actor_interfaces
github.com/filecoin-project/specs/systems/filecoin_vm/indices
github.com/filecoin-project/specs/systems/filecoin_vm/runtime
github.com/filecoin-project/specs/util
```

cc @jzimmerman 