### PR TITLE
Move types shared with actors to actors/abi package

### DIFF
--- a/src/actors/abi/primitives.go
+++ b/src/actors/abi/primitives.go
@@ -1,4 +1,9 @@
-package actors
+package abi
+
+// The abi package contains definitions of all types that cross the VM boundary and are used
+// within actor code.
+//
+// Primitive types include numerics and opaque array types.
 
 // Epoch number of the chain state, which acts as a proxy for time within the VM.
 type ChainEpoch int64

--- a/src/actors/builtin/cron/cron_actor.go
+++ b/src/actors/builtin/cron/cron_actor.go
@@ -1,7 +1,7 @@
 package cron
 
 import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
-import actors "github.com/filecoin-project/specs/actors"
+import abi "github.com/filecoin-project/specs/actors/abi"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
 
@@ -28,7 +28,7 @@ func (a *CronActorCode_I) EpochTick(rt vmr.Runtime) InvocOutput {
 			To_:     entry.ToAddr(),
 			Method_: entry.MethodNum(),
 			Params_: nil,
-			Value_:  actors.TokenAmount(0),
+			Value_:  abi.TokenAmount(0),
 		})
 	}
 

--- a/src/actors/builtin/cron/cron_actor.id
+++ b/src/actors/builtin/cron/cron_actor.id
@@ -1,4 +1,4 @@
-import actors "github.com/filecoin-project/specs/actors"
+import abi "github.com/filecoin-project/specs/actors/abi"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
 
@@ -8,7 +8,7 @@ type CronActorState struct {
 
 type CronTableEntry struct {
     ToAddr     addr.Address
-    MethodNum  actors.MethodNum
+    MethodNum  abi.MethodNum
 }
 
 type CronActorCode struct {

--- a/src/actors/builtin/init/init_actor.go
+++ b/src/actors/builtin/init/init_actor.go
@@ -1,7 +1,7 @@
 package init
 
 import (
-	actors "github.com/filecoin-project/specs/actors"
+	abi "github.com/filecoin-project/specs/actors/abi"
 	autil "github.com/filecoin-project/specs/actors/util"
 	ipld "github.com/filecoin-project/specs/libraries/ipld"
 	actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
@@ -11,7 +11,7 @@ import (
 
 type InvocOutput = vmr.InvocOutput
 type Runtime = vmr.Runtime
-type Bytes = actors.Bytes
+type Bytes = abi.Bytes
 
 var AssertMsg = autil.AssertMsg
 
@@ -27,7 +27,7 @@ func (a *InitActorCode_I) Constructor(rt Runtime) InvocOutput {
 	return rt.ValueReturn(nil)
 }
 
-func (a *InitActorCode_I) Exec(rt Runtime, execCodeID actor.CodeID, constructorParams actors.MethodParams) InvocOutput {
+func (a *InitActorCode_I) Exec(rt Runtime, execCodeID actor.CodeID, constructorParams abi.MethodParams) InvocOutput {
 	rt.ValidateImmediateCallerAcceptAny()
 	callerCodeID, ok := rt.GetActorCodeID(rt.ImmediateCaller())
 	AssertMsg(ok, "no code for actor at %s", rt.ImmediateCaller())

--- a/src/actors/builtin/init/init_actor.id
+++ b/src/actors/builtin/init/init_actor.id
@@ -1,6 +1,6 @@
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
-import actors "github.com/filecoin-project/specs/actors"
+import abi "github.com/filecoin-project/specs/actors/abi"
 import vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
 
 type InitActorState struct {
@@ -17,7 +17,7 @@ type InitActorState struct {
 
 type InitActorCode struct {
     Constructor(r vmr.Runtime, networkName string)
-    Exec(r vmr.Runtime, code actor.CodeID, params actors.MethodParams) addr.Address
+    Exec(r vmr.Runtime, code actor.CodeID, params abi.MethodParams) addr.Address
 
     // This method is disabled until proven necessary.
     //GetActorIDForAddress(r vmr.Runtime, address addr.Address) addr.ActorID

--- a/src/actors/builtin/multisig/multisig_actor.id
+++ b/src/actors/builtin/multisig/multisig_actor.id
@@ -1,4 +1,4 @@
-import actors "github.com/filecoin-project/specs/actors"
+import abi "github.com/filecoin-project/specs/actors/abi"
 import autil "github.com/filecoin-project/specs/actors/util"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 
@@ -6,12 +6,12 @@ type TxnID int
 
 type MultiSigTransaction struct {
     Proposer    addr.Address
-    Expiration  actors.ChainEpoch
+    Expiration  abi.ChainEpoch
 
     To          addr.Address
-    Method      actors.MethodNum
-    Params      actors.MethodParams
-    Value       actors.TokenAmount
+    Method      abi.MethodNum
+    Params      abi.MethodParams
+    Value       abi.TokenAmount
 
     Equals(MultiSigTransaction) bool
 }

--- a/src/actors/builtin/reward/reward_actor.id
+++ b/src/actors/builtin/reward/reward_actor.id
@@ -1,5 +1,5 @@
 import vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
-import actors "github.com/filecoin-project/specs/actors"
+import abi "github.com/filecoin-project/specs/actors/abi"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 
 type VestingFunction enum {
@@ -13,12 +13,12 @@ type VestingFunction enum {
 
 type Reward struct {
     VestingFunction
-    StartEpoch       actors.ChainEpoch
-    EndEpoch         actors.ChainEpoch
-    Value            actors.TokenAmount
-    AmountWithdrawn  actors.TokenAmount
+    StartEpoch       abi.ChainEpoch
+    EndEpoch         abi.ChainEpoch
+    Value            abi.TokenAmount
+    AmountWithdrawn  abi.TokenAmount
 
-    AmountVested(elapsedEpoch actors.ChainEpoch) actors.TokenAmount
+    AmountVested(elapsedEpoch abi.ChainEpoch) abi.TokenAmount
 }
 
 // ownerAddr to a collection of Reward
@@ -27,7 +27,7 @@ type RewardBalanceAMT {addr.Address: [Reward]}
 type RewardActorState struct {
     RewardMap RewardBalanceAMT
 
-    _withdrawReward(rt vmr.Runtime, ownerAddr addr.Address) actors.TokenAmount
+    _withdrawReward(rt vmr.Runtime, ownerAddr addr.Address) abi.TokenAmount
 }
 
 type RewardActorCode struct {
@@ -36,7 +36,7 @@ type RewardActorCode struct {
     // Allocates a block reward to the owner of a miner, less
     // - penalty, which is burnt
     // - any amount of pledge collateral shortfall, which is transferred to storage power actor
-    AwardBlockReward(rt vmr.Runtime, miner addr.Address, penalty actors.TokenAmount)
+    AwardBlockReward(rt vmr.Runtime, miner addr.Address, penalty abi.TokenAmount)
 
     // withdraw available funds from RewardMap
     WithdrawReward(rt vmr.Runtime)

--- a/src/actors/builtin/storage_market/storage_market_actor.id
+++ b/src/actors/builtin/storage_market/storage_market_actor.id
@@ -1,4 +1,4 @@
-import actors "github.com/filecoin-project/specs/actors"
+import abi "github.com/filecoin-project/specs/actors/abi"
 import actor_util "github.com/filecoin-project/specs/actors/util"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
@@ -8,7 +8,7 @@ type DealsAMT {deal.DealID: deal.OnChainDeal}
 type DealWeight deal.DealWeight
 
 type CachedDealIDsByPartyHAMT {addr.Address: actor_util.DealIDSetHAMT}
-type CachedExpirationsPendingHAMT {actors.ChainEpoch: DealIDQueue}
+type CachedExpirationsPendingHAMT {abi.ChainEpoch: DealIDQueue}
 
 type StorageMarketActorState struct {
     Deals                           DealsAMT
@@ -26,25 +26,25 @@ type StorageMarketActorState struct {
     // Metadata cached for efficient iteration over deals.
     CachedDealIDsByParty            CachedDealIDsByPartyHAMT
     CachedExpirationsPending        CachedExpirationsPendingHAMT
-    CachedExpirationsNextProcEpoch  actors.ChainEpoch
+    CachedExpirationsNextProcEpoch  abi.ChainEpoch
     CurrEpochNumDealsPublished      int
 
     _rtAbortIfAddressEntryDoesNotExist(rt Runtime, entryAddr addr.Address)
-    _rtUpdatePendingDealStatesForParty(rt Runtime, addr addr.Address) (amountSlashedTotal actors.TokenAmount)
+    _rtUpdatePendingDealStatesForParty(rt Runtime, addr addr.Address) (amountSlashedTotal abi.TokenAmount)
     _rtGetOnChainDealOrAbort(rt Runtime, dealID deal.DealID) (deal deal.OnChainDeal, dealP deal.StorageDealProposal)
-    _rtLockBalanceOrAbort(rt Runtime, addr addr.Address, amount actors.TokenAmount)
+    _rtLockBalanceOrAbort(rt Runtime, addr addr.Address, amount abi.TokenAmount)
 
-    _updatePendingDealStates(dealIDs [deal.DealID], epoch actors.ChainEpoch) (amountSlashedTotal actors.TokenAmount)
-    _updatePendingDealState(dealID deal.DealID, epoch actors.ChainEpoch) (amountSlashed actors.TokenAmount)
-    _processDealPaymentEpochsElapsed(dealID deal.DealID, numEpochsElapsed actors.ChainEpoch)
-    _processDealSlashed(dealID deal.DealID) (amountSlashed actors.TokenAmount)
-    _processDealInitTimedOut(dealID deal.DealID) (amountSlashed actors.TokenAmount)
+    _updatePendingDealStates(dealIDs [deal.DealID], epoch abi.ChainEpoch) (amountSlashedTotal abi.TokenAmount)
+    _updatePendingDealState(dealID deal.DealID, epoch abi.ChainEpoch) (amountSlashed abi.TokenAmount)
+    _processDealPaymentEpochsElapsed(dealID deal.DealID, numEpochsElapsed abi.ChainEpoch)
+    _processDealSlashed(dealID deal.DealID) (amountSlashed abi.TokenAmount)
+    _processDealInitTimedOut(dealID deal.DealID) (amountSlashed abi.TokenAmount)
     _processDealExpired(dealID deal.DealID)
     _generateStorageDealID(storageDeal deal.StorageDeal) deal.DealID
 
-    _getLockedReqBalanceInternal(a addr.Address) actors.TokenAmount
-    _lockBalanceMaybe(addr addr.Address, amount actors.TokenAmount) (lockBalanceOK bool)
-    _unlockBalance(addr addr.Address, unlockAmountRequested actors.TokenAmount)
+    _getLockedReqBalanceInternal(a addr.Address) abi.TokenAmount
+    _lockBalanceMaybe(addr addr.Address, amount abi.TokenAmount) (lockBalanceOK bool)
+    _unlockBalance(addr addr.Address, unlockAmountRequested abi.TokenAmount)
 
     _getOnChainDeal(dealID deal.DealID) (deal deal.OnChainDeal, dealP deal.StorageDealProposal, ok bool)
     _getOnChainDealAssert(dealID deal.DealID) (deal deal.OnChainDeal, dealP deal.StorageDealProposal)
@@ -58,7 +58,7 @@ type StorageMarketActorCode struct {
 
     // Attempt to withdraw the specified amount from the balance held in escrow.
     // If less than the specified amount is available, yields the entire available balance.
-    WithdrawBalance(rt Runtime, amount actors.TokenAmount)
+    WithdrawBalance(rt Runtime, amount abi.TokenAmount)
 
     // Publish a new set of storage deals (not yet included in a sector).
     PublishStorageDeals(rt Runtime, deals [deal.StorageDeal])

--- a/src/actors/builtin/storage_market/storage_market_actor_boilerplate.go
+++ b/src/actors/builtin/storage_market/storage_market_actor_boilerplate.go
@@ -1,7 +1,7 @@
 package storage_market
 
 import (
-	actors "github.com/filecoin-project/specs/actors"
+	abi "github.com/filecoin-project/specs/actors/abi"
 	autil "github.com/filecoin-project/specs/actors/util"
 	ipld "github.com/filecoin-project/specs/libraries/ipld"
 	actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
@@ -24,7 +24,7 @@ var RT_ValidateImmediateCallerIsSignable = vmr.RT_ValidateImmediateCallerIsSigna
 
 type InvocOutput = vmr.InvocOutput
 type Runtime = vmr.Runtime
-type Bytes = actors.Bytes
+type Bytes = abi.Bytes
 
 var Assert = autil.Assert
 var IMPL_FINISH = autil.IMPL_FINISH

--- a/src/actors/builtin/storage_market/storage_market_actor_code.go
+++ b/src/actors/builtin/storage_market/storage_market_actor_code.go
@@ -1,7 +1,7 @@
 package storage_market
 
 import (
-	actors "github.com/filecoin-project/specs/actors"
+	abi "github.com/filecoin-project/specs/actors/abi"
 	actor_util "github.com/filecoin-project/specs/actors/util"
 	deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
 	sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
@@ -14,9 +14,9 @@ import (
 // Actor methods
 ////////////////////////////////////////////////////////////////////////////////
 
-func (a *StorageMarketActorCode_I) WithdrawBalance(rt Runtime, entryAddr addr.Address, amountRequested actors.TokenAmount) {
+func (a *StorageMarketActorCode_I) WithdrawBalance(rt Runtime, entryAddr addr.Address, amountRequested abi.TokenAmount) {
 	IMPL_FINISH() // BigInt arithmetic
-	amountSlashedTotal := actors.TokenAmount(0)
+	amountSlashedTotal := abi.TokenAmount(0)
 
 	if amountRequested < 0 {
 		rt.AbortArgMsg("Negative amount.")
@@ -66,7 +66,7 @@ func (a *StorageMarketActorCode_I) AddBalance(rt Runtime, entryAddr addr.Address
 
 func (a *StorageMarketActorCode_I) PublishStorageDeals(rt Runtime, newStorageDeals []deal.StorageDeal) {
 	IMPL_FINISH() // BigInt arithmetic
-	amountSlashedTotal := actors.TokenAmount(0)
+	amountSlashedTotal := abi.TokenAmount(0)
 
 	// Deal message must have a From field identical to the provider of all the deals.
 	// This allows us to retain and verify only the client's signature in each deal proposal itself.
@@ -296,7 +296,7 @@ func (a *StorageMarketActorCode_I) Constructor(rt Runtime) {
 		NextID_:                         deal.DealID(0),
 		CachedDealIDsByParty_:           CachedDealIDsByPartyHAMT_Empty(),
 		CachedExpirationsPending_:       CachedExpirationsPendingHAMT_Empty(),
-		CachedExpirationsNextProcEpoch_: actors.ChainEpoch(0),
+		CachedExpirationsNextProcEpoch_: abi.ChainEpoch(0),
 	}
 
 	UpdateRelease(rt, h, st)
@@ -307,7 +307,7 @@ func (a *StorageMarketActorCode_I) Constructor(rt Runtime) {
 ////////////////////////////////////////////////////////////////////////////////
 
 func (st *StorageMarketActorState_I) _rtUpdatePendingDealStatesForParty(rt Runtime, addr addr.Address) (
-	amountSlashedTotal actors.TokenAmount) {
+	amountSlashedTotal abi.TokenAmount) {
 
 	// For consistency with OnEpochTickEnd, only process updates up to the end of the _previous_ epoch.
 	epoch := rt.CurrEpoch() - 1
@@ -347,7 +347,7 @@ func _rtAbortIfDealEndElapsed(rt Runtime, dealP deal.StorageDealProposal) {
 	}
 }
 
-func _rtAbortIfDealExceedsSectorLifetime(rt Runtime, dealP deal.StorageDealProposal, sectorExpiration actors.ChainEpoch) {
+func _rtAbortIfDealExceedsSectorLifetime(rt Runtime, dealP deal.StorageDealProposal, sectorExpiration abi.ChainEpoch) {
 	if dealP.EndEpoch() > sectorExpiration {
 		rt.AbortStateMsg("Deal would outlive its containing sector.")
 	}
@@ -360,7 +360,7 @@ func (st *StorageMarketActorState_I) _rtAbortIfAddressEntryDoesNotExist(rt Runti
 }
 
 func _rtAbortIfDealInvalidForNewSectorSeal(
-	rt Runtime, minerAddr addr.Address, sectorExpiration actors.ChainEpoch, deal deal.OnChainDeal) {
+	rt Runtime, minerAddr addr.Address, sectorExpiration abi.ChainEpoch, deal deal.OnChainDeal) {
 
 	dealP := deal.Deal().Proposal()
 
@@ -416,7 +416,7 @@ func (st *StorageMarketActorState_I) _rtGetOnChainDealOrAbort(rt Runtime, dealID
 	return
 }
 
-func (st *StorageMarketActorState_I) _rtLockBalanceOrAbort(rt Runtime, addr addr.Address, amount actors.TokenAmount) {
+func (st *StorageMarketActorState_I) _rtLockBalanceOrAbort(rt Runtime, addr addr.Address, amount abi.TokenAmount) {
 	if amount < 0 {
 		rt.AbortArgMsg("Negative amount")
 	}

--- a/src/actors/builtin/storage_market/storage_market_actor_state.go
+++ b/src/actors/builtin/storage_market/storage_market_actor_state.go
@@ -1,7 +1,7 @@
 package storage_market
 
 import (
-	actors "github.com/filecoin-project/specs/actors"
+	abi "github.com/filecoin-project/specs/actors/abi"
 	actor_util "github.com/filecoin-project/specs/actors/util"
 	filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
 	deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
@@ -10,14 +10,14 @@ import (
 	vmr "github.com/filecoin-project/specs/systems/filecoin_vm/runtime"
 )
 
-const epochUndefined = actors.ChainEpoch(-1)
+const epochUndefined = abi.ChainEpoch(-1)
 
 ////////////////////////////////////////////////////////////////////////////////
 // Deal state operations
 ////////////////////////////////////////////////////////////////////////////////
 
-func (st *StorageMarketActorState_I) _updatePendingDealStates(dealIDs []deal.DealID, epoch actors.ChainEpoch) (
-	amountSlashedTotal actors.TokenAmount) {
+func (st *StorageMarketActorState_I) _updatePendingDealStates(dealIDs []deal.DealID, epoch abi.ChainEpoch) (
+	amountSlashedTotal abi.TokenAmount) {
 
 	IMPL_FINISH() // BigInt arithmetic
 	amountSlashedTotal = 0
@@ -30,8 +30,8 @@ func (st *StorageMarketActorState_I) _updatePendingDealStates(dealIDs []deal.Dea
 	return
 }
 
-func (st *StorageMarketActorState_I) _updatePendingDealState(dealID deal.DealID, epoch actors.ChainEpoch) (
-	amountSlashed actors.TokenAmount) {
+func (st *StorageMarketActorState_I) _updatePendingDealState(dealID deal.DealID, epoch abi.ChainEpoch) (
+	amountSlashed abi.TokenAmount) {
 
 	IMPL_FINISH() // BigInt arithmetic
 	amountSlashed = 0
@@ -97,17 +97,17 @@ func (st *StorageMarketActorState_I) _deleteDeal(dealID deal.DealID) {
 }
 
 // Note: only processes deal payments, not deal expiration (even if the deal has expired).
-func (st *StorageMarketActorState_I) _processDealPaymentEpochsElapsed(dealID deal.DealID, numEpochsElapsed actors.ChainEpoch) {
+func (st *StorageMarketActorState_I) _processDealPaymentEpochsElapsed(dealID deal.DealID, numEpochsElapsed abi.ChainEpoch) {
 	deal, dealP := st._getOnChainDealAssert(dealID)
 	Assert(deal.SectorStartEpoch() != epochUndefined)
 
 	// Process deal payment for the elapsed epochs.
 	IMPL_FINISH() // BigInt arithmetic
 	totalPayment := int(numEpochsElapsed) * int(dealP.StoragePricePerEpoch())
-	st._transferBalance(dealP.Client(), dealP.Provider(), actors.TokenAmount(totalPayment))
+	st._transferBalance(dealP.Client(), dealP.Provider(), abi.TokenAmount(totalPayment))
 }
 
-func (st *StorageMarketActorState_I) _processDealSlashed(dealID deal.DealID) (amountSlashed actors.TokenAmount) {
+func (st *StorageMarketActorState_I) _processDealSlashed(dealID deal.DealID) (amountSlashed abi.TokenAmount) {
 	deal, dealP := st._getOnChainDealAssert(dealID)
 	Assert(deal.SectorStartEpoch() != epochUndefined)
 
@@ -130,7 +130,7 @@ func (st *StorageMarketActorState_I) _processDealSlashed(dealID deal.DealID) (am
 // Deal start deadline elapsed without appearing in a proven sector.
 // Delete deal, slash a portion of provider's collateral, and unlock remaining collaterals
 // for both provider and client.
-func (st *StorageMarketActorState_I) _processDealInitTimedOut(dealID deal.DealID) (amountSlashed actors.TokenAmount) {
+func (st *StorageMarketActorState_I) _processDealInitTimedOut(dealID deal.DealID) (amountSlashed abi.TokenAmount) {
 	deal, dealP := st._getOnChainDealAssert(dealID)
 	Assert(deal.SectorStartEpoch() == epochUndefined)
 
@@ -177,21 +177,21 @@ func (st *StorageMarketActorState_I) _addressEntryExists(address addr.Address) b
 	return foundEscrow
 }
 
-func (st *StorageMarketActorState_I) _getTotalEscrowBalanceInternal(a addr.Address) actors.TokenAmount {
+func (st *StorageMarketActorState_I) _getTotalEscrowBalanceInternal(a addr.Address) abi.TokenAmount {
 	Assert(st._addressEntryExists(a))
 	ret, ok := actor_util.BalanceTable_GetEntry(st.EscrowTable(), a)
 	Assert(ok)
 	return ret
 }
 
-func (st *StorageMarketActorState_I) _getLockedReqBalanceInternal(a addr.Address) actors.TokenAmount {
+func (st *StorageMarketActorState_I) _getLockedReqBalanceInternal(a addr.Address) abi.TokenAmount {
 	Assert(st._addressEntryExists(a))
 	ret, ok := actor_util.BalanceTable_GetEntry(st.LockedReqTable(), a)
 	Assert(ok)
 	return ret
 }
 
-func (st *StorageMarketActorState_I) _lockBalanceMaybe(addr addr.Address, amount actors.TokenAmount) (
+func (st *StorageMarketActorState_I) _lockBalanceMaybe(addr addr.Address, amount abi.TokenAmount) (
 	lockBalanceOK bool) {
 
 	Assert(amount >= 0)
@@ -212,7 +212,7 @@ func (st *StorageMarketActorState_I) _lockBalanceMaybe(addr addr.Address, amount
 }
 
 func (st *StorageMarketActorState_I) _unlockBalance(
-	addr addr.Address, unlockAmountRequested actors.TokenAmount) {
+	addr addr.Address, unlockAmountRequested abi.TokenAmount) {
 
 	Assert(unlockAmountRequested >= 0)
 	Assert(st._addressEntryExists(addr))
@@ -221,7 +221,7 @@ func (st *StorageMarketActorState_I) _unlockBalance(
 }
 
 func (st *StorageMarketActorState_I) _tableWithAddBalance(
-	table actor_util.BalanceTableHAMT, toAddr addr.Address, amountToAdd actors.TokenAmount) actor_util.BalanceTableHAMT {
+	table actor_util.BalanceTableHAMT, toAddr addr.Address, amountToAdd abi.TokenAmount) actor_util.BalanceTableHAMT {
 
 	Assert(amountToAdd >= 0)
 
@@ -231,7 +231,7 @@ func (st *StorageMarketActorState_I) _tableWithAddBalance(
 }
 
 func (st *StorageMarketActorState_I) _tableWithDeductBalanceExact(
-	table actor_util.BalanceTableHAMT, fromAddr addr.Address, amountRequested actors.TokenAmount) actor_util.BalanceTableHAMT {
+	table actor_util.BalanceTableHAMT, fromAddr addr.Address, amountRequested abi.TokenAmount) actor_util.BalanceTableHAMT {
 
 	Assert(amountRequested >= 0)
 
@@ -244,7 +244,7 @@ func (st *StorageMarketActorState_I) _tableWithDeductBalanceExact(
 
 // move funds from locked in client to available in provider
 func (st *StorageMarketActorState_I) _transferBalance(
-	fromAddr addr.Address, toAddr addr.Address, transferAmountRequested actors.TokenAmount) {
+	fromAddr addr.Address, toAddr addr.Address, transferAmountRequested abi.TokenAmount) {
 
 	Assert(transferAmountRequested >= 0)
 	Assert(st._addressEntryExists(fromAddr))
@@ -255,7 +255,7 @@ func (st *StorageMarketActorState_I) _transferBalance(
 	st.Impl().EscrowTable_ = st._tableWithAddBalance(st.EscrowTable(), toAddr, transferAmountRequested)
 }
 
-func (st *StorageMarketActorState_I) _slashBalance(addr addr.Address, slashAmount actors.TokenAmount) {
+func (st *StorageMarketActorState_I) _slashBalance(addr addr.Address, slashAmount abi.TokenAmount) {
 	Assert(st._addressEntryExists(addr))
 	Assert(slashAmount >= 0)
 
@@ -295,7 +295,7 @@ func _rtDealProposalIsInternallyValid(rt Runtime, dealP deal.StorageDealProposal
 	return true
 }
 
-func _dealGetPaymentRemaining(deal deal.OnChainDeal, epoch actors.ChainEpoch) actors.TokenAmount {
+func _dealGetPaymentRemaining(deal deal.OnChainDeal, epoch abi.ChainEpoch) abi.TokenAmount {
 	dealP := deal.Deal().Proposal()
 	Assert(epoch <= dealP.EndEpoch())
 
@@ -303,7 +303,7 @@ func _dealGetPaymentRemaining(deal deal.OnChainDeal, epoch actors.ChainEpoch) ac
 	Assert(durationRemaining > 0)
 
 	IMPL_FINISH() // BigInt arithmetic
-	return actors.TokenAmount(int(durationRemaining) * int(dealP.StoragePricePerEpoch()))
+	return abi.TokenAmount(int(durationRemaining) * int(dealP.StoragePricePerEpoch()))
 }
 
 func (st *StorageMarketActorState_I) _getOnChainDeal(dealID deal.DealID) (

--- a/src/actors/builtin/storage_miner/storage_miner_actor.id
+++ b/src/actors/builtin/storage_miner/storage_miner_actor.id
@@ -1,4 +1,4 @@
-import actors "github.com/filecoin-project/specs/actors"
+import abi "github.com/filecoin-project/specs/actors/abi"
 import autil "github.com/filecoin-project/specs/actors/util"
 import address "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
@@ -11,13 +11,13 @@ type MinerPoStState union {
     // Normal operation: The miner has passed either an ElectionPoSt or a SurprisePoSt
     // sufficiently recently.
     OK struct {
-        LastSuccessfulPoSt actors.ChainEpoch
+        LastSuccessfulPoSt abi.ChainEpoch
     }
 
     // SurprisePoSt challenge state: The miner has not submitted timely ElectionPoSts,
     // and as a result, the system has fallen back to proving storage via SurprisePoSt.
     Challenged struct {
-        SurpriseChallengeEpoch  actors.ChainEpoch
+        SurpriseChallengeEpoch  abi.ChainEpoch
         ChallengedSectors       [sector.SectorNumber]
         NumConsecutiveFailures  int
     }
@@ -40,17 +40,17 @@ type SectorState enum {
 type SectorOnChainInfo struct {
     State                       SectorState
     Info                        sealing.SectorPreCommitInfo  // Also contains Expiration field.
-    PreCommitDeposit            actors.TokenAmount
-    PreCommitEpoch              actors.ChainEpoch
-    ActivationEpoch             actors.ChainEpoch  // -1 if still in PreCommit state.
-    DeclaredFaultEpoch          actors.ChainEpoch  // -1 if not currently declared faulted.
-    DeclaredFaultDuration       actors.ChainEpoch  // -1 if not currently declared faulted.
+    PreCommitDeposit            abi.TokenAmount
+    PreCommitEpoch              abi.ChainEpoch
+    ActivationEpoch             abi.ChainEpoch  // -1 if still in PreCommit state.
+    DeclaredFaultEpoch          abi.ChainEpoch  // -1 if not currently declared faulted.
+    DeclaredFaultDuration       abi.ChainEpoch  // -1 if not currently declared faulted.
     DealWeight                  BigInt  // -1 if not yet validated with StorageMarketActor.
 
     // Must be significantly larger than DeclaredFaultEpoch, since otherwise it may be possible
     // to declare faults adaptively in order to exempt challenged sectors.
-    EffectiveFaultBeginEpoch()  actors.ChainEpoch
-    EffectiveFaultEndEpoch()    actors.ChainEpoch
+    EffectiveFaultBeginEpoch()  abi.ChainEpoch
+    EffectiveFaultEndEpoch()    abi.ChainEpoch
 
     Is_TemporaryFault()         bool
 }

--- a/src/actors/builtin/storage_miner/storage_miner_actor_code.go
+++ b/src/actors/builtin/storage_miner/storage_miner_actor_code.go
@@ -3,7 +3,7 @@ package storage_miner
 import (
 	"math/big"
 
-	actors "github.com/filecoin-project/specs/actors"
+	abi "github.com/filecoin-project/specs/actors/abi"
 	serde "github.com/filecoin-project/specs/actors/serde"
 	autil "github.com/filecoin-project/specs/actors/util"
 	filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
@@ -17,7 +17,7 @@ import (
 	indices "github.com/filecoin-project/specs/systems/filecoin_vm/indices"
 )
 
-const epochUndefined = actors.ChainEpoch(-1)
+const epochUndefined = abi.ChainEpoch(-1)
 
 ////////////////////////////////////////////////////////////////////////////////
 // Actor methods
@@ -98,7 +98,7 @@ func (a *StorageMinerActorCode_I) SubmitSurprisePoStResponse(rt Runtime, onChain
 		addr.StoragePowerActorAddr,
 		ai.Method_StoragePowerActor_OnMinerSurprisePoStSuccess,
 		nil,
-		actors.TokenAmount(0),
+		abi.TokenAmount(0),
 	)
 }
 
@@ -154,7 +154,7 @@ func (a *StorageMinerActorCode_I) PreCommitSector(rt Runtime, info sector.Sector
 			info.DealIDs(),
 			info,
 		),
-		actors.TokenAmount(0),
+		abi.TokenAmount(0),
 	)
 
 	h, st = a.State(rt)
@@ -219,7 +219,7 @@ func (a *StorageMinerActorCode_I) ProveCommitSector(rt Runtime, info sector.Sect
 			preCommitSector.Info().DealIDs(),
 			info,
 		),
-		actors.TokenAmount(0),
+		abi.TokenAmount(0),
 	)
 
 	res := rt.SendQuery(
@@ -259,7 +259,7 @@ func (a *StorageMinerActorCode_I) ProveCommitSector(rt Runtime, info sector.Sect
 		serde.MustSerializeParams(
 			storageWeightDesc,
 		),
-		actors.TokenAmount(0),
+		abi.TokenAmount(0),
 	)
 
 	// Return PreCommit deposit to worker upon successful ProveCommit.
@@ -270,7 +270,7 @@ func (a *StorageMinerActorCode_I) ProveCommitSector(rt Runtime, info sector.Sect
 // Sector Modification //
 /////////////////////////
 
-func (a *StorageMinerActorCode_I) ExtendSectorExpiration(rt Runtime, sectorNumber sector.SectorNumber, newExpiration actors.ChainEpoch) {
+func (a *StorageMinerActorCode_I) ExtendSectorExpiration(rt Runtime, sectorNumber sector.SectorNumber, newExpiration abi.ChainEpoch) {
 	storageWeightDescPrev := a._rtGetStorageWeightDescForSector(rt, sectorNumber)
 
 	h, st := a.State(rt)
@@ -300,7 +300,7 @@ func (a *StorageMinerActorCode_I) ExtendSectorExpiration(rt Runtime, sectorNumbe
 			storageWeightDescPrev,
 			storageWeightDescNew,
 		),
-		actors.TokenAmount(0),
+		abi.TokenAmount(0),
 	)
 }
 
@@ -316,8 +316,8 @@ func (a *StorageMinerActorCode_I) TerminateSector(rt Runtime, sectorNumber secto
 // Faults //
 ////////////
 
-func (a *StorageMinerActorCode_I) DeclareTemporaryFaults(rt Runtime, sectorNumbers []sector.SectorNumber, duration actors.ChainEpoch) {
-	if duration <= actors.ChainEpoch(0) {
+func (a *StorageMinerActorCode_I) DeclareTemporaryFaults(rt Runtime, sectorNumbers []sector.SectorNumber, duration abi.ChainEpoch) {
+	if duration <= abi.ChainEpoch(0) {
 		rt.AbortArgMsg("Temporary fault duration must be positive")
 	}
 
@@ -411,7 +411,7 @@ func (a *StorageMinerActorCode_I) _rtCheckTemporaryFaultEvents(rt Runtime, secto
 			serde.MustSerializeParams(
 				storageWeightDesc,
 			),
-			actors.TokenAmount(0),
+			abi.TokenAmount(0),
 		)
 
 		delete(st.ProvingSet(), sectorNumber)
@@ -428,7 +428,7 @@ func (a *StorageMinerActorCode_I) _rtCheckTemporaryFaultEvents(rt Runtime, secto
 			serde.MustSerializeParams(
 				storageWeightDesc,
 			),
-			actors.TokenAmount(0),
+			abi.TokenAmount(0),
 		)
 
 		st.ProvingSet()[sectorNumber] = true
@@ -480,7 +480,7 @@ func (a *StorageMinerActorCode_I) _rtTerminateSector(rt Runtime, sectorNumber se
 			serde.MustSerializeParams(
 				storageWeightDesc,
 			),
-			actors.TokenAmount(0),
+			abi.TokenAmount(0),
 		)
 	}
 
@@ -491,7 +491,7 @@ func (a *StorageMinerActorCode_I) _rtTerminateSector(rt Runtime, sectorNumber se
 			storageWeightDesc,
 			terminationType,
 		),
-		actors.TokenAmount(0),
+		abi.TokenAmount(0),
 	)
 
 	a._rtDeleteSectorEntry(rt, sectorNumber)
@@ -541,11 +541,11 @@ func (a *StorageMinerActorCode_I) _rtCheckSurprisePoStExpiry(rt Runtime) {
 		serde.MustSerializeParams(
 			numConsecutiveFailures,
 		),
-		actors.TokenAmount(0))
+		abi.TokenAmount(0))
 }
 
 func (a *StorageMinerActorCode_I) _rtEnrollCronEvent(
-	rt Runtime, eventEpoch actors.ChainEpoch, sectorNumbers []sector.SectorNumber) {
+	rt Runtime, eventEpoch abi.ChainEpoch, sectorNumbers []sector.SectorNumber) {
 
 	rt.Send(
 		addr.StoragePowerActorAddr,
@@ -554,7 +554,7 @@ func (a *StorageMinerActorCode_I) _rtEnrollCronEvent(
 			eventEpoch,
 			sectorNumbers,
 		),
-		actors.TokenAmount(0),
+		abi.TokenAmount(0),
 	)
 }
 
@@ -604,7 +604,7 @@ func (a *StorageMinerActorCode_I) _rtNotifyMarketForTerminatedSectors(rt Runtime
 		serde.MustSerializeParams(
 			dealIDs,
 		),
-		actors.TokenAmount(0),
+		abi.TokenAmount(0),
 	)
 }
 
@@ -705,8 +705,8 @@ func (a *StorageMinerActorCode_I) _rtVerifySealOrAbort(rt Runtime, onChainInfo s
 	}
 
 	IMPL_TODO() // Use randomness APIs
-	var svInfoRandomness actors.Randomness
-	var svInfoInteractiveRandomness actors.Randomness
+	var svInfoRandomness abi.Randomness
+	var svInfoInteractiveRandomness abi.Randomness
 
 	svInfo := sector.SealVerifyInfo_I{
 		SectorID_: &sector.SectorID_I{
@@ -741,7 +741,7 @@ func getSectorNums(m map[sector.SectorNumber]SectorOnChainInfo) []sector.SectorN
 }
 
 func _surprisePoStSampleChallengedSectors(
-	sampleRandomness actors.Randomness, provingSet []sector.SectorNumber) []sector.SectorNumber {
+	sampleRandomness abi.Randomness, provingSet []sector.SectorNumber) []sector.SectorNumber {
 
 	IMPL_TODO()
 	panic("")

--- a/src/actors/builtin/storage_miner/storage_miner_actor_state.go
+++ b/src/actors/builtin/storage_miner/storage_miner_actor_state.go
@@ -1,7 +1,7 @@
 package storage_miner
 
 import (
-	actors "github.com/filecoin-project/specs/actors"
+	abi "github.com/filecoin-project/specs/actors/abi"
 	actor_util "github.com/filecoin-project/specs/actors/util"
 	libp2p "github.com/filecoin-project/specs/libraries/libp2p"
 	deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
@@ -65,14 +65,14 @@ func (st *StorageMinerActorState_I) _getStorageWeightDescsForSectors(sectorNumbe
 	return ret
 }
 
-func MinerPoStState_New_OK(lastSuccessfulPoSt actors.ChainEpoch) MinerPoStState {
+func MinerPoStState_New_OK(lastSuccessfulPoSt abi.ChainEpoch) MinerPoStState {
 	return MinerPoStState_Make_OK(&MinerPoStState_OK_I{
 		LastSuccessfulPoSt_: lastSuccessfulPoSt,
 	})
 }
 
 func MinerPoStState_New_Challenged(
-	surpriseChallengeEpoch actors.ChainEpoch,
+	surpriseChallengeEpoch abi.ChainEpoch,
 	challengedSectors []sector.SectorNumber,
 	numConsecutiveFailures int,
 ) MinerPoStState {
@@ -98,12 +98,12 @@ func (x *SectorOnChainInfo_I) Is_TemporaryFault() bool {
 	return ret
 }
 
-func (x *SectorOnChainInfo_I) EffectiveFaultBeginEpoch() actors.ChainEpoch {
+func (x *SectorOnChainInfo_I) EffectiveFaultBeginEpoch() abi.ChainEpoch {
 	Assert(x.Is_TemporaryFault())
 	return x.DeclaredFaultEpoch() + indices.StorageMining_DeclaredFaultEffectiveDelay()
 }
 
-func (x *SectorOnChainInfo_I) EffectiveFaultEndEpoch() actors.ChainEpoch {
+func (x *SectorOnChainInfo_I) EffectiveFaultEndEpoch() abi.ChainEpoch {
 	Assert(x.Is_TemporaryFault())
 	return x.EffectiveFaultBeginEpoch() + x.DeclaredFaultDuration()
 }

--- a/src/actors/builtin/storage_power/storage_power_actor.id
+++ b/src/actors/builtin/storage_power/storage_power_actor.id
@@ -1,13 +1,13 @@
 import actor_util "github.com/filecoin-project/specs/actors/util"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
-import actors "github.com/filecoin-project/specs/actors"
+import abi "github.com/filecoin-project/specs/actors/abi"
 
-type PowerTableHAMT {addr.Address: actors.StoragePower}  // TODO: convert address to ActorID
+type PowerTableHAMT {addr.Address: abi.StoragePower}  // TODO: convert address to ActorID
 
-type MinerEventsHAMT {actors.ChainEpoch: actor_util.MinerEventSetHAMT}
+type MinerEventsHAMT {abi.ChainEpoch: actor_util.MinerEventSetHAMT}
 
 type StoragePowerActorState struct {
-    TotalNetworkPower         actors.StoragePower
+    TotalNetworkPower         abi.StoragePower
 
     PowerTable                PowerTableHAMT
     EscrowTable               actor_util.BalanceTableHAMT
@@ -19,8 +19,8 @@ type StoragePowerActorState struct {
     NominalPower              PowerTableHAMT
     NumMinersMeetingMinPower  int
 
-    _slashPledgeCollateral(address addr.Address, amount actors.TokenAmount) actors.TokenAmount
-    _selectMinersToSurprise(challengeCount int, randomness actors.Randomness) [addr.Address]
+    _slashPledgeCollateral(address addr.Address, amount abi.TokenAmount) abi.TokenAmount
+    _selectMinersToSurprise(challengeCount int, randomness abi.Randomness) [addr.Address]
 
     _addClaimedPowerForSector(
         minerAddr          addr.Address
@@ -31,8 +31,8 @@ type StoragePowerActorState struct {
         storageWeightDesc  SectorStorageWeightDesc
     )
     _updatePowerEntriesFromClaimedPower(minerAddr addr.Address)
-    _getCurrPledgeForMiner(minerAddr addr.Address) (currPledge actors.TokenAmount, ok bool)
-    _getPledgeSlashForConsensusFault(currPledge actors.TokenAmount, faultType ConsensusFaultType) actors.TokenAmount
+    _getCurrPledgeForMiner(minerAddr addr.Address) (currPledge abi.TokenAmount, ok bool)
+    _getPledgeSlashForConsensusFault(currPledge abi.TokenAmount, faultType ConsensusFaultType) abi.TokenAmount
 }
 
 type StoragePowerActorCode struct {

--- a/src/actors/builtin/storage_power/storage_power_actor_code.go
+++ b/src/actors/builtin/storage_power/storage_power_actor_code.go
@@ -3,7 +3,7 @@ package storage_power
 import (
 	"math"
 
-	actors "github.com/filecoin-project/specs/actors"
+	abi "github.com/filecoin-project/specs/actors/abi"
 	serde "github.com/filecoin-project/specs/actors/serde"
 	autil "github.com/filecoin-project/specs/actors/util"
 	filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
@@ -43,7 +43,7 @@ func (a *StoragePowerActorCode_I) AddBalance(rt Runtime, minerAddr addr.Address)
 	UpdateRelease(rt, h, st)
 }
 
-func (a *StoragePowerActorCode_I) WithdrawBalance(rt Runtime, minerAddr addr.Address, amountRequested actors.TokenAmount) {
+func (a *StoragePowerActorCode_I) WithdrawBalance(rt Runtime, minerAddr addr.Address, amountRequested abi.TokenAmount) {
 	if amountRequested < 0 {
 		rt.AbortArgMsg("Amount to withdraw must be nonnegative")
 	}
@@ -79,7 +79,7 @@ func (a *StoragePowerActorCode_I) CreateMiner(rt Runtime, workerAddr addr.Addres
 				sectorSize,
 				peerId,
 			),
-			actors.TokenAmount(0),
+			abi.TokenAmount(0),
 		).ReturnValue(),
 	)
 
@@ -87,9 +87,9 @@ func (a *StoragePowerActorCode_I) CreateMiner(rt Runtime, workerAddr addr.Addres
 	newTable, ok := autil.BalanceTable_WithNewAddressEntry(st.EscrowTable(), newMinerAddr, rt.ValueReceived())
 	Assert(ok)
 	st.Impl().EscrowTable_ = newTable
-	st.PowerTable()[newMinerAddr] = actors.StoragePower(0)
-	st.ClaimedPower()[newMinerAddr] = actors.StoragePower(0)
-	st.NominalPower()[newMinerAddr] = actors.StoragePower(0)
+	st.PowerTable()[newMinerAddr] = abi.StoragePower(0)
+	st.ClaimedPower()[newMinerAddr] = abi.StoragePower(0)
+	st.NominalPower()[newMinerAddr] = abi.StoragePower(0)
 	UpdateRelease(rt, h, st)
 
 	return newMinerAddr
@@ -103,7 +103,7 @@ func (a *StoragePowerActorCode_I) DeleteMiner(rt Runtime, minerAddr addr.Address
 		rt.AbortArgMsg("Miner address not found")
 	}
 
-	if minerPledgeBalance > actors.TokenAmount(0) {
+	if minerPledgeBalance > abi.TokenAmount(0) {
 		rt.AbortStateMsg("Deletion requested for miner with pledge balance still remaining")
 	}
 
@@ -189,7 +189,7 @@ func (a *StoragePowerActorCode_I) OnMinerSurprisePoStFailure(rt Runtime, numCons
 	}
 }
 
-func (a *StoragePowerActorCode_I) ReportVerifiedConsensusFault(rt Runtime, slasheeAddr addr.Address, faultEpoch actors.ChainEpoch, faultType ConsensusFaultType) {
+func (a *StoragePowerActorCode_I) ReportVerifiedConsensusFault(rt Runtime, slasheeAddr addr.Address, faultEpoch abi.ChainEpoch, faultType ConsensusFaultType) {
 	TODO()
 	panic("")
 	// TODO: The semantics here are quite delicate:
@@ -262,7 +262,7 @@ func (a *StoragePowerActorCode_I) Constructor(rt Runtime) {
 	h := rt.AcquireState()
 
 	st := &StoragePowerActorState_I{
-		TotalNetworkPower_:        actors.StoragePower(0),
+		TotalNetworkPower_:        abi.StoragePower(0),
 		PowerTable_:               PowerTableHAMT_Empty(),
 		EscrowTable_:              autil.BalanceTableHAMT_Empty(),
 		CachedDeferredCronEvents_: MinerEventsHAMT_Empty(),
@@ -309,7 +309,7 @@ func (a *StoragePowerActorCode_I) _rtInitiateNewSurprisePoStChallenges(rt Runtim
 			addr,
 			ai.Method_StorageMinerActor_OnSurprisePoStChallenge,
 			nil,
-			actors.TokenAmount(0))
+			abi.TokenAmount(0))
 	}
 }
 
@@ -338,12 +338,12 @@ func (a *StoragePowerActorCode_I) _rtProcessDeferredCronEvents(rt Runtime) {
 			serde.MustSerializeParams(
 				minerEvent.Sectors(),
 			),
-			actors.TokenAmount(0),
+			abi.TokenAmount(0),
 		)
 	}
 }
 
-func (a *StoragePowerActorCode_I) _rtGetPledgeCollateralReqForMinerOrAbort(rt Runtime, minerAddr addr.Address) actors.TokenAmount {
+func (a *StoragePowerActorCode_I) _rtGetPledgeCollateralReqForMinerOrAbort(rt Runtime, minerAddr addr.Address) abi.TokenAmount {
 	h, st := a.State(rt)
 	minerNominalPower, found := st.NominalPower()[minerAddr]
 	if !found {
@@ -353,7 +353,7 @@ func (a *StoragePowerActorCode_I) _rtGetPledgeCollateralReqForMinerOrAbort(rt Ru
 	return rt.CurrIndices().PledgeCollateralReq(minerNominalPower)
 }
 
-func (a *StoragePowerActorCode_I) _rtSlashPledgeCollateral(rt Runtime, minerAddr addr.Address, amountToSlash actors.TokenAmount) {
+func (a *StoragePowerActorCode_I) _rtSlashPledgeCollateral(rt Runtime, minerAddr addr.Address, amountToSlash abi.TokenAmount) {
 	h, st := a.State(rt)
 	amountSlashed := st._slashPledgeCollateral(minerAddr, amountToSlash)
 	UpdateRelease(rt, h, st)

--- a/src/actors/builtin/storage_power/storage_power_actor_state.go
+++ b/src/actors/builtin/storage_power/storage_power_actor_state.go
@@ -3,16 +3,16 @@ package storage_power
 import (
 	"sort"
 
-	actors "github.com/filecoin-project/specs/actors"
+	abi "github.com/filecoin-project/specs/actors/abi"
 	autil "github.com/filecoin-project/specs/actors/util"
 	filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
 	addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 	indices "github.com/filecoin-project/specs/systems/filecoin_vm/indices"
 )
 
-func (st *StoragePowerActorState_I) _minerNominalPowerMeetsConsensusMinimum(minerPower actors.StoragePower) bool {
+func (st *StoragePowerActorState_I) _minerNominalPowerMeetsConsensusMinimum(minerPower abi.StoragePower) bool {
 	IMPL_TODO() // import from consts
-	MIN_MINER_SIZE_STOR := actors.StoragePower(0)
+	MIN_MINER_SIZE_STOR := abi.StoragePower(0)
 	MIN_MINER_SIZE_TARG := 0
 
 	// if miner is larger than min power requirement, we're set
@@ -32,7 +32,7 @@ func (st *StoragePowerActorState_I) _minerNominalPowerMeetsConsensusMinimum(mine
 	}
 
 	// get size of MIN_MINER_SIZE_TARGth largest miner
-	minerSizes := make([]actors.StoragePower, 0, len(st.PowerTable()))
+	minerSizes := make([]abi.StoragePower, 0, len(st.PowerTable()))
 	for _, v := range st.PowerTable() {
 		minerSizes = append(minerSizes, v)
 	}
@@ -41,9 +41,9 @@ func (st *StoragePowerActorState_I) _minerNominalPowerMeetsConsensusMinimum(mine
 }
 
 func (st *StoragePowerActorState_I) _slashPledgeCollateral(
-	minerAddr addr.Address, slashAmountRequested actors.TokenAmount) actors.TokenAmount {
+	minerAddr addr.Address, slashAmountRequested abi.TokenAmount) abi.TokenAmount {
 
-	Assert(slashAmountRequested >= actors.TokenAmount(0))
+	Assert(slashAmountRequested >= abi.TokenAmount(0))
 
 	newTable, amountSlashed, ok := autil.BalanceTable_WithSubtractPreservingNonnegative(
 		st.EscrowTable(), minerAddr, slashAmountRequested)
@@ -67,7 +67,7 @@ func addrInArray(a addr.Address, list []addr.Address) bool {
 }
 
 // _selectMinersToSurprise implements the PoSt-Surprise sampling algorithm
-func (st *StoragePowerActorState_I) _selectMinersToSurprise(challengeCount int, randomness actors.Randomness) []addr.Address {
+func (st *StoragePowerActorState_I) _selectMinersToSurprise(challengeCount int, randomness abi.Randomness) []addr.Address {
 	// this wont quite work -- a.PowerTable() is a HAMT by actor address, doesn't
 	// support enumerating by int index. maybe we need that as an interface too,
 	// or something similar to an iterator (or iterator over the keys)
@@ -98,17 +98,17 @@ func (st *StoragePowerActorState_I) _selectMinersToSurprise(challengeCount int, 
 }
 
 func (st *StoragePowerActorState_I) _getPowerTotalForMiner(minerAddr addr.Address) (
-	power actors.StoragePower, ok bool) {
+	power abi.StoragePower, ok bool) {
 
 	minerPower, found := st.PowerTable()[minerAddr]
 	if !found {
-		return actors.StoragePower(0), found
+		return abi.StoragePower(0), found
 	}
 
 	return minerPower, true
 }
 
-func (st *StoragePowerActorState_I) _getCurrPledgeForMiner(minerAddr addr.Address) (currPledge actors.TokenAmount, ok bool) {
+func (st *StoragePowerActorState_I) _getCurrPledgeForMiner(minerAddr addr.Address) (currPledge abi.TokenAmount, ok bool) {
 	return autil.BalanceTable_GetEntry(st.EscrowTable(), minerAddr)
 }
 
@@ -167,12 +167,12 @@ func (st *StoragePowerActorState_I) _updatePowerEntriesFromClaimedPower(minerAdd
 	st._setPowerEntryInternal(minerAddr, power)
 }
 
-func (st *StoragePowerActorState_I) _setClaimedPowerEntryInternal(minerAddr addr.Address, updatedMinerClaimedPower actors.StoragePower) {
+func (st *StoragePowerActorState_I) _setClaimedPowerEntryInternal(minerAddr addr.Address, updatedMinerClaimedPower abi.StoragePower) {
 	Assert(updatedMinerClaimedPower >= 0)
 	st.Impl().ClaimedPower_[minerAddr] = updatedMinerClaimedPower
 }
 
-func (st *StoragePowerActorState_I) _setNominalPowerEntryInternal(minerAddr addr.Address, updatedMinerNominalPower actors.StoragePower) {
+func (st *StoragePowerActorState_I) _setNominalPowerEntryInternal(minerAddr addr.Address, updatedMinerNominalPower abi.StoragePower) {
 	Assert(updatedMinerNominalPower >= 0)
 	prevMinerNominalPower, ok := st.NominalPower()[minerAddr]
 	Assert(ok)
@@ -186,7 +186,7 @@ func (st *StoragePowerActorState_I) _setNominalPowerEntryInternal(minerAddr addr
 	}
 }
 
-func (st *StoragePowerActorState_I) _setPowerEntryInternal(minerAddr addr.Address, updatedMinerPower actors.StoragePower) {
+func (st *StoragePowerActorState_I) _setPowerEntryInternal(minerAddr addr.Address, updatedMinerPower abi.StoragePower) {
 	Assert(updatedMinerPower >= 0)
 	prevMinerPower, ok := st.PowerTable()[minerAddr]
 	Assert(ok)
@@ -194,7 +194,7 @@ func (st *StoragePowerActorState_I) _setPowerEntryInternal(minerAddr addr.Addres
 	st.Impl().TotalNetworkPower_ += (updatedMinerPower - prevMinerPower)
 }
 
-func (st *StoragePowerActorState_I) _getPledgeSlashForConsensusFault(currPledge actors.TokenAmount, faultType ConsensusFaultType) actors.TokenAmount {
+func (st *StoragePowerActorState_I) _getPledgeSlashForConsensusFault(currPledge abi.TokenAmount, faultType ConsensusFaultType) abi.TokenAmount {
 	// default is to slash all pledge collateral for all consensus fault
 	TODO()
 	switch faultType {
@@ -209,14 +209,14 @@ func (st *StoragePowerActorState_I) _getPledgeSlashForConsensusFault(currPledge 
 	}
 }
 
-func _getConsensusFaultSlasherReward(elapsedEpoch actors.ChainEpoch, collateralToSlash actors.TokenAmount) actors.TokenAmount {
+func _getConsensusFaultSlasherReward(elapsedEpoch abi.ChainEpoch, collateralToSlash abi.TokenAmount) abi.TokenAmount {
 	TODO()
 	// BigInt Operation
 	// var growthRate = node_base.SLASHER_SHARE_GROWTH_RATE_NUM / node_base.SLASHER_SHARE_GROWTH_RATE_DENOM
 	// var multiplier = growthRate^elapsedEpoch
 	// var slasherProportion = min(INITIAL_SLASHER_SHARE * multiplier, 1.0)
 	// return collateralToSlash * slasherProportion
-	return actors.TokenAmount(0)
+	return abi.TokenAmount(0)
 }
 
 func PowerTableHAMT_Empty() PowerTableHAMT {

--- a/src/actors/util/actor_util.go
+++ b/src/actors/util/actor_util.go
@@ -1,14 +1,14 @@
 package util
 
 import (
-	actors "github.com/filecoin-project/specs/actors"
+	abi "github.com/filecoin-project/specs/actors/abi"
 	deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
 	addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 )
 
 // Create a new entry in the balance table, with the specified initial balance.
 // May fail if the specified address already exists in the table.
-func BalanceTable_WithNewAddressEntry(table BalanceTableHAMT, address addr.Address, initBalance actors.TokenAmount) (
+func BalanceTable_WithNewAddressEntry(table BalanceTableHAMT, address addr.Address, initBalance abi.TokenAmount) (
 	ret BalanceTableHAMT, ok bool) {
 
 	IMPL_FINISH()
@@ -25,7 +25,7 @@ func BalanceTable_WithDeletedAddressEntry(table BalanceTableHAMT, address addr.A
 }
 
 // Add the given amount to the given address's balance table entry.
-func BalanceTable_WithAdd(table BalanceTableHAMT, address addr.Address, amount actors.TokenAmount) (
+func BalanceTable_WithAdd(table BalanceTableHAMT, address addr.Address, amount abi.TokenAmount) (
 	ret BalanceTableHAMT, ok bool) {
 
 	IMPL_FINISH()
@@ -38,17 +38,17 @@ func BalanceTable_WithAdd(table BalanceTableHAMT, address addr.Address, amount a
 // Note: ok should be set to true here, even if the operation caused the entry to hit zero.
 // The only failure case is when the address does not exist in the table.
 func BalanceTable_WithSubtractPreservingNonnegative(
-	table BalanceTableHAMT, address addr.Address, amount actors.TokenAmount) (
-	ret BalanceTableHAMT, amountSubtracted actors.TokenAmount, ok bool) {
+	table BalanceTableHAMT, address addr.Address, amount abi.TokenAmount) (
+	ret BalanceTableHAMT, amountSubtracted abi.TokenAmount, ok bool) {
 
-	return BalanceTable_WithExtractPartial(table, address, amount, actors.TokenAmount(0))
+	return BalanceTable_WithExtractPartial(table, address, amount, abi.TokenAmount(0))
 }
 
 // Extract the given amount from the given address's balance table entry, subject to the requirement
 // of a minimum balance `minBalanceMaintain`. If not possible to withdraw the entire amount
 // requested, then the balance will remain unchanged.
 func BalanceTable_WithExtract(
-	table BalanceTableHAMT, address addr.Address, amount actors.TokenAmount, minBalanceMaintain actors.TokenAmount) (
+	table BalanceTableHAMT, address addr.Address, amount abi.TokenAmount, minBalanceMaintain abi.TokenAmount) (
 	ret BalanceTableHAMT, ok bool) {
 
 	IMPL_FINISH()
@@ -58,8 +58,8 @@ func BalanceTable_WithExtract(
 // Extract as much as possible (may be zero) up to the specified amount from the given address's
 // balance table entry, subject to the requirement of a minimum balance `minBalanceMaintain`.
 func BalanceTable_WithExtractPartial(
-	table BalanceTableHAMT, address addr.Address, amount actors.TokenAmount, minBalanceMaintain actors.TokenAmount) (
-	ret BalanceTableHAMT, amountExtracted actors.TokenAmount, ok bool) {
+	table BalanceTableHAMT, address addr.Address, amount abi.TokenAmount, minBalanceMaintain abi.TokenAmount) (
+	ret BalanceTableHAMT, amountExtracted abi.TokenAmount, ok bool) {
 
 	IMPL_FINISH()
 	panic("")
@@ -67,7 +67,7 @@ func BalanceTable_WithExtractPartial(
 
 // Extract all available from the given address's balance table entry.
 func BalanceTable_WithExtractAll(table BalanceTableHAMT, address addr.Address) (
-	ret BalanceTableHAMT, amountExtracted actors.TokenAmount, ok bool) {
+	ret BalanceTableHAMT, amountExtracted abi.TokenAmount, ok bool) {
 
 	IMPL_FINISH()
 	panic("")
@@ -76,7 +76,7 @@ func BalanceTable_WithExtractAll(table BalanceTableHAMT, address addr.Address) (
 // Determine whether the given address's entry in the balance table meets the required minimum
 // `minBalanceMaintain`.
 func BalanceTable_IsEntrySufficient(
-	table BalanceTableHAMT, address addr.Address, minBalanceMaintain actors.TokenAmount) (ret bool, ok bool) {
+	table BalanceTableHAMT, address addr.Address, minBalanceMaintain abi.TokenAmount) (ret bool, ok bool) {
 
 	IMPL_FINISH()
 	panic("")
@@ -85,7 +85,7 @@ func BalanceTable_IsEntrySufficient(
 // Retrieve the balance table entry corresponding to the given address.
 func BalanceTable_GetEntry(
 	table BalanceTableHAMT, address addr.Address) (
-	ret actors.TokenAmount, ok bool) {
+	ret abi.TokenAmount, ok bool) {
 
 	IMPL_FINISH()
 	panic("")

--- a/src/actors/util/actor_util.id
+++ b/src/actors/util/actor_util.id
@@ -1,9 +1,9 @@
-import actors "github.com/filecoin-project/specs/actors"
+import abi "github.com/filecoin-project/specs/actors/abi"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
 import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 
-type BalanceTableHAMT {addr.Address: actors.TokenAmount}
+type BalanceTableHAMT {addr.Address: abi.TokenAmount}
 
 type DealIDSetHAMT {deal.DealID: bool}
 type IntToDealIDHAMT {Int: deal.DealID}
@@ -30,7 +30,7 @@ type MinerEventSetHAMT {MinerEvent: bool}
 
 type SectorStorageWeightDesc struct {
     SectorSize  sector.SectorSize
-    Duration    actors.ChainEpoch
+    Duration    abi.ChainEpoch
     DealWeight  BigInt
 }
 

--- a/src/appendix/network_params.md
+++ b/src/appendix/network_params.md
@@ -3,7 +3,7 @@ title = "Filecoin Parameters"
 draft = false
 +++
 
-Some of these parameters are used around the code in the Filecoin subsystems and actors. Others are used as part of the proofs libraries. 
+Some of these parameters are used around the code in the Filecoin subsystems and abi. Others are used as part of the proofs libraries. 
 
 Most are generated/finalized using the [orient framework](https://github.com/filecoin-project/orient). It is used to modelize the Filecoin network.
 

--- a/src/systems/filecoin_blockchain/blockchain.id
+++ b/src/systems/filecoin_blockchain/blockchain.id
@@ -1,4 +1,4 @@
-import actors "github.com/filecoin-project/specs/actors"
+import abi "github.com/filecoin-project/specs/actors/abi"
 import clock "github.com/filecoin-project/specs/systems/filecoin_nodes/clock"
 import st "github.com/filecoin-project/specs/systems/filecoin_vm/state_tree"
 import block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
@@ -18,7 +18,7 @@ type SyncState union {
 type BlockchainSubsystem struct @(mutable) {
     Clock              &clock.UTCClock
 
-    LatestEpoch()      actors.ChainEpoch
+    LatestEpoch()      abi.ChainEpoch
     BestChain()        chain.Chain
     CandidateChains()  [chain.Chain]
 

--- a/src/systems/filecoin_blockchain/storage_power_consensus/expected_consensus.go
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/expected_consensus.go
@@ -3,7 +3,7 @@ package storage_power_consensus
 import (
 	"math/big"
 
-	actors "github.com/filecoin-project/specs/actors"
+	abi "github.com/filecoin-project/specs/actors/abi"
 	spowact "github.com/filecoin-project/specs/actors/builtin/storage_power"
 	block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
 	chain "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/chain"
@@ -44,7 +44,7 @@ func (self *ExpectedConsensus_I) IsValidConsensusFault(faults spowact.ConsensusF
 	// && !block2.Parents.include(block1)
 }
 
-func (self *ExpectedConsensus_I) IsWinningChallengeTicket(challengeTicket util.Bytes, sectorPower actors.StoragePower, networkPower actors.StoragePower, numSectorsSampled util.UVarint, numSectorsMiner util.UVarint) bool {
+func (self *ExpectedConsensus_I) IsWinningChallengeTicket(challengeTicket util.Bytes, sectorPower abi.StoragePower, networkPower abi.StoragePower, numSectorsSampled util.UVarint, numSectorsMiner util.UVarint) bool {
 	// Conceptually we are mapping the pseudorandom, deterministic hash output of the challenge ticket onto [0,1]
 	// by dividing by 2^HashLen and comparing that to the sector's target.
 	// if the challenge ticket hash / max hash val < sectorPower / totalPower * ec.ExpectedLeaders * numSectorsMiner / numSectorsSampled

--- a/src/systems/filecoin_blockchain/storage_power_consensus/expected_consensus.id
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/expected_consensus.id
@@ -1,4 +1,4 @@
-import actors "github.com/filecoin-project/specs/actors"
+import abi "github.com/filecoin-project/specs/actors/abi"
 import block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
 import chain "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/chain"
 import spowact "github.com/filecoin-project/specs/actors/builtin/storage_power"
@@ -11,8 +11,8 @@ type ExpectedConsensus struct {
     IsValidConsensusFault(faults spowact.ConsensusFaultType, blocks [block.Block]) bool
     IsWinningChallengeTicket(
         challengeTicket    util.Bytes
-        sectorPower        actors.StoragePower
-        networkPower       actors.StoragePower
+        sectorPower        abi.StoragePower
+        networkPower       abi.StoragePower
         numSectorsSampled  util.UVarint
         numSectorsMiner    util.UVarint
     ) bool

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_consensus_subsystem.go
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_consensus_subsystem.go
@@ -3,7 +3,7 @@ package storage_power_consensus
 import (
 	"math"
 
-	actors "github.com/filecoin-project/specs/actors"
+	abi "github.com/filecoin-project/specs/actors/abi"
 	spowact "github.com/filecoin-project/specs/actors/builtin/storage_power"
 	filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
 	ipld "github.com/filecoin-project/specs/libraries/ipld"
@@ -34,7 +34,7 @@ func (spc *StoragePowerConsensusSubsystem_I) ComputeChainWeight(tipset chain.Tip
 	return spc.ec().ComputeChainWeight(tipset)
 }
 
-func (spc *StoragePowerConsensusSubsystem_I) IsWinningPartialTicket(stateTree stateTree.StateTree, inds inds.Indices, partialTicket sector.PartialTicket, sectorUtilization actors.StoragePower, numSectors util.UVarint) bool {
+func (spc *StoragePowerConsensusSubsystem_I) IsWinningPartialTicket(stateTree stateTree.StateTree, inds inds.Indices, partialTicket sector.PartialTicket, sectorUtilization abi.StoragePower, numSectors util.UVarint) bool {
 
 	// finalize the partial ticket
 	challengeTicket := filcrypto.SHA256(partialTicket)
@@ -66,18 +66,18 @@ func (spc *StoragePowerConsensusSubsystem_I) _getStoragePowerActorState(stateTre
 	return st
 }
 
-func (spc *StoragePowerConsensusSubsystem_I) GetTicketProductionRand(chain chain.Chain, epoch actors.ChainEpoch) util.Randomness {
+func (spc *StoragePowerConsensusSubsystem_I) GetTicketProductionRand(chain chain.Chain, epoch abi.ChainEpoch) util.Randomness {
 	return chain.RandomnessAtEpoch(epoch - node_base.SPC_LOOKBACK_TICKET)
 }
 
-func (spc *StoragePowerConsensusSubsystem_I) GetSealRand(chain chain.Chain, epoch actors.ChainEpoch) util.Randomness {
+func (spc *StoragePowerConsensusSubsystem_I) GetSealRand(chain chain.Chain, epoch abi.ChainEpoch) util.Randomness {
 	return chain.RandomnessAtEpoch(epoch - node_base.SPC_LOOKBACK_SEAL)
 }
 
-func (spc *StoragePowerConsensusSubsystem_I) GetPoStChallengeRand(chain chain.Chain, epoch actors.ChainEpoch) util.Randomness {
+func (spc *StoragePowerConsensusSubsystem_I) GetPoStChallengeRand(chain chain.Chain, epoch abi.ChainEpoch) util.Randomness {
 	return chain.RandomnessAtEpoch(epoch - node_base.SPC_LOOKBACK_POST)
 }
 
-func (spc *StoragePowerConsensusSubsystem_I) GetFinalizedEpoch(currentEpoch actors.ChainEpoch) actors.ChainEpoch {
+func (spc *StoragePowerConsensusSubsystem_I) GetFinalizedEpoch(currentEpoch abi.ChainEpoch) abi.ChainEpoch {
 	return currentEpoch - node_base.FINALITY
 }

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_consensus_subsystem.id
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_consensus_subsystem.id
@@ -1,4 +1,4 @@
-import actors "github.com/filecoin-project/specs/actors"
+import abi "github.com/filecoin-project/specs/actors/abi"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
 import chain "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/chain"
@@ -22,7 +22,7 @@ type StoragePowerConsensusSubsystem struct {//(@mutable)
     IsWinningPartialTicket(
         st                 st.StateTree
         partialTicket      sector.PartialTicket
-        sectorUtilization  actors.StoragePower
+        sectorUtilization  abi.StoragePower
         numSectors         util.UVarint
     ) bool
 
@@ -41,15 +41,15 @@ type StoragePowerConsensusSubsystem struct {//(@mutable)
     // Randomness methods
 
     // call by StorageMiningSubsystem during block production
-    GetTicketProductionRand(chain chain.Chain, epoch actors.ChainEpoch) util.Randomness
+    GetTicketProductionRand(chain chain.Chain, epoch abi.ChainEpoch) util.Randomness
 
     // call by StorageMiningSubsystem in sealing sector
-    GetSealRand(chain chain.Chain, epoch actors.ChainEpoch) util.Randomness
+    GetSealRand(chain chain.Chain, epoch abi.ChainEpoch) util.Randomness
 
     // call by StorageMiningSubsystem after sealing
-    GetPoStChallengeRand(chain chain.Chain, epoch actors.ChainEpoch) util.Randomness
+    GetPoStChallengeRand(chain chain.Chain, epoch abi.ChainEpoch) util.Randomness
 
-    GetFinalizedEpoch(currentEpoch actors.ChainEpoch) actors.ChainEpoch
+    GetFinalizedEpoch(currentEpoch abi.ChainEpoch) abi.ChainEpoch
 }
 
 type StoragePowerConsensusError struct {}

--- a/src/systems/filecoin_blockchain/struct/block/block.id
+++ b/src/systems/filecoin_blockchain/struct/block/block.id
@@ -1,6 +1,6 @@
 import filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
 
-import actors "github.com/filecoin-project/specs/actors"
+import abi "github.com/filecoin-project/specs/actors/abi"
 import st "github.com/filecoin-project/specs/systems/filecoin_vm/state_tree"
 import clock "github.com/filecoin-project/specs/systems/filecoin_nodes/clock"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
@@ -19,7 +19,7 @@ type BlockHeader struct {
     ParentMessageReceipts  &[&MessageReceipt]  // array-mapped trie ref
 
     // Consensus things
-    Epoch                  actors.ChainEpoch
+    Epoch                  abi.ChainEpoch
     Timestamp              clock.UnixTime
     Ticket
 

--- a/src/systems/filecoin_blockchain/struct/block/election.go
+++ b/src/systems/filecoin_blockchain/struct/block/election.go
@@ -1,7 +1,7 @@
 package block
 
 import (
-	actors "github.com/filecoin-project/specs/actors"
+	abi "github.com/filecoin-project/specs/actors/abi"
 	filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
 	addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 	util "github.com/filecoin-project/specs/util"
@@ -22,7 +22,7 @@ func (tix *Ticket_I) Verify(randomness util.Bytes, pk filcrypto.VRFPublicKey, mi
 	return tix.VRFResult_.Verify(input, pk)
 }
 
-func (tix *Ticket_I) DrawRandomness(epoch actors.ChainEpoch) util.Bytes {
+func (tix *Ticket_I) DrawRandomness(epoch abi.ChainEpoch) util.Bytes {
 	input := Serialize_TicketDrawingSeedInput(&TicketDrawingSeedInput_I{
 		PastTicket_: tix.Output(),
 		Epoch_:      epoch,

--- a/src/systems/filecoin_blockchain/struct/block/election.id
+++ b/src/systems/filecoin_blockchain/struct/block/election.id
@@ -1,4 +1,4 @@
-import actors "github.com/filecoin-project/specs/actors"
+import abi "github.com/filecoin-project/specs/actors/abi"
 import filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 
@@ -6,7 +6,7 @@ type Ticket struct {
     VRFResult  filcrypto.VRFResult
 
     Output     Bytes                @(cached)
-    DrawRandomness(round actors.ChainEpoch) Bytes
+    DrawRandomness(round abi.ChainEpoch) Bytes
     ValidateSyntax() bool
     Verify(
         input           Bytes
@@ -22,5 +22,5 @@ type TicketProductionSeedInput struct {
 
 type TicketDrawingSeedInput struct {
     PastTicket  util.Randomness
-    Epoch       actors.ChainEpoch
+    Epoch       abi.ChainEpoch
 }

--- a/src/systems/filecoin_blockchain/struct/chain/chain.go
+++ b/src/systems/filecoin_blockchain/struct/chain/chain.go
@@ -1,12 +1,12 @@
 package chain
 
 import (
-	"github.com/filecoin-project/specs/actors"
+	"github.com/filecoin-project/specs/actors/abi"
 	"github.com/filecoin-project/specs/util"
 )
 
 // Returns the tipset at or immediately prior to `epoch`.
-func (chain *Chain_I) TipsetAtEpoch(epoch actors.ChainEpoch) Tipset {
+func (chain *Chain_I) TipsetAtEpoch(epoch abi.ChainEpoch) Tipset {
 	current := chain.HeadTipset()
 	for current.Epoch() > epoch {
 		current = current.Parents()
@@ -16,7 +16,7 @@ func (chain *Chain_I) TipsetAtEpoch(epoch actors.ChainEpoch) Tipset {
 }
 
 // Draws randomness from the tipset at or immediately prior to `epoch`.
-func (chain *Chain_I) RandomnessAtEpoch(epoch actors.ChainEpoch) util.Bytes {
+func (chain *Chain_I) RandomnessAtEpoch(epoch abi.ChainEpoch) util.Bytes {
 	ts := chain.TipsetAtEpoch(epoch)
 	return ts.MinTicket().DrawRandomness(epoch)
 }

--- a/src/systems/filecoin_blockchain/struct/chain/chain.id
+++ b/src/systems/filecoin_blockchain/struct/chain/chain.id
@@ -1,13 +1,13 @@
-import actors "github.com/filecoin-project/specs/actors"
+import abi "github.com/filecoin-project/specs/actors/abi"
 import block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
 
 type Chain struct {
     HeadTipset Tipset
 
-    TipsetAtEpoch(epoch actors.ChainEpoch) Tipset
-    RandomnessAtEpoch(epoch actors.ChainEpoch) Bytes
+    TipsetAtEpoch(epoch abi.ChainEpoch) Tipset
+    RandomnessAtEpoch(epoch abi.ChainEpoch) Bytes
 
-    LatestCheckpoint() actors.ChainEpoch
+    LatestCheckpoint() abi.ChainEpoch
 }
 
 // Checkpoint represents a particular block to use as a trust anchor

--- a/src/systems/filecoin_blockchain/struct/chain/tipset.id
+++ b/src/systems/filecoin_blockchain/struct/chain/tipset.id
@@ -1,4 +1,4 @@
-import actors "github.com/filecoin-project/specs/actors"
+import abi "github.com/filecoin-project/specs/actors/abi"
 import block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
 import clock "github.com/filecoin-project/specs/systems/filecoin_nodes/clock"
 import st "github.com/filecoin-project/specs/systems/filecoin_vm/state_tree"
@@ -11,7 +11,7 @@ type Tipset struct {
     Parents             Tipset                @(cached)
     StateTree           st.StateTree          @(cached)
     Weight              block.ChainWeight     @(cached)
-    Epoch               actors.ChainEpoch     @(cached)
+    Epoch               abi.ChainEpoch        @(cached)
 
     // Returns the largest timestamp fom the tipset's blocks.
     LatestTimestamp()   clock.UnixTime        @(cached)

--- a/src/systems/filecoin_markets/retrieval_market/retrieval_client.id
+++ b/src/systems/filecoin_markets/retrieval_market/retrieval_client.id
@@ -1,4 +1,4 @@
-import actors "github.com/filecoin-project/specs/actors"
+import abi "github.com/filecoin-project/specs/actors/abi"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import libp2p "github.com/filecoin-project/specs/libraries/libp2p"
 import piece "github.com/filecoin-project/specs/systems/filecoin_files/piece"
@@ -8,7 +8,7 @@ type RetrievalClientDealState struct {
     Status                 DealStatus
     Sender                 libp2p.PeerID
     TotalReceived          UInt
-    FundsSpent             actors.TokenAmount
+    FundsSpent             abi.TokenAmount
 }
 
 type Open struct {}
@@ -40,7 +40,7 @@ type RetrievalClient struct {
     Retrieve(
         pieceCID      piece.PieceCID
         params        RetrievalParams
-        totalFunds    actors.TokenAmount
+        totalFunds    abi.TokenAmount
         miner         libp2p.PeerID
         clientWallet  addr.Address
         minerWallet   addr.Address
@@ -48,7 +48,7 @@ type RetrievalClient struct {
     SubscribeToEvents(subscriber RetrievalClientSubscriber)
 
     // V1
-    AddMoreFunds(id RetrievalDealID, amount actors.TokenAmount) error
+    AddMoreFunds(id RetrievalDealID, amount abi.TokenAmount) error
     CancelDeal(id RetrievalDealID) error
     RetrievalStatus(id RetrievalDealID)
     ListDeals() {RetrievalDealID: RetrievalClientDealState}

--- a/src/systems/filecoin_markets/retrieval_market/retrieval_provider.id
+++ b/src/systems/filecoin_markets/retrieval_market/retrieval_provider.id
@@ -1,4 +1,4 @@
-import actors "github.com/filecoin-project/specs/actors"
+import abi "github.com/filecoin-project/specs/actors/abi"
 import libp2p "github.com/filecoin-project/specs/libraries/libp2p"
 
 type RetrievalProviderDealState struct {
@@ -6,7 +6,7 @@ type RetrievalProviderDealState struct {
     Status                 DealStatus
     Receiver               libp2p.PeerID
     TotalSent              UInt
-    FundsReceived          actors.TokenAmount
+    FundsReceived          abi.TokenAmount
 }
 
 type RetrievalProviderEvent struct {
@@ -27,11 +27,11 @@ type RetrievalProviderSubscriber struct {
 
 type RetrievalProvider struct {
     // V0
-    SetPricePerByte(price actors.TokenAmount)
+    SetPricePerByte(price abi.TokenAmount)
     SetPaymentInterval(paymentInterval UInt, paymentIntervalIncrease UInt)
     SubscribeToEvents(subscriber RetrievalProviderSubscriber)
 
     // V1
-    SetPricePerUnseal(price actors.TokenAmount)
+    SetPricePerUnseal(price abi.TokenAmount)
     ListDeals() {RetrievalProviderDealID: RetrievalProviderDealState}
 }

--- a/src/systems/filecoin_markets/retrieval_market/types.id
+++ b/src/systems/filecoin_markets/retrieval_market/types.id
@@ -1,7 +1,7 @@
 import ipld "github.com/filecoin-project/specs/libraries/ipld"
 import libp2p "github.com/filecoin-project/specs/libraries/libp2p"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
-import actors "github.com/filecoin-project/specs/actors"
+import abi "github.com/filecoin-project/specs/actors/abi"
 import piece "github.com/filecoin-project/specs/systems/filecoin_files/piece"
 
 type PaymentVoucher struct {}
@@ -29,7 +29,7 @@ type RetrievalQueryItemStatus union {
 type RetrievalQueryParams struct {
     PayloadCID                  ipld.CID  // optional, query if miner has this cid in this piece. some miners may not be able to respond.
     Selector                    ipld.Selector  // optional, query if miner has this cid in this piece. some miners may not be able to respond.
-    MaxPricePerByte             actors.TokenAmount  // optional, tell miner uninterested if more expensive than this
+    MaxPricePerByte             abi.TokenAmount  // optional, tell miner uninterested if more expensive than this
     MinPaymentInterval          UInt  // optional, tell miner uninterested unless payment interval is greater than this
     MinPaymentIntervalIncrease  UInt  // optional, tell miner uninterested unless payment interval increase is greater than this
 }
@@ -48,7 +48,7 @@ type RetrievalQueryResponse struct {
     ExpectedPayloadSize         uint64  // V1 - optional, if PayloadCID + selector are specified and miner knows, can offer an expected size
 
     PaymentAddress              addr.Address  // address to send funds to -- may be different than miner addr
-    MinPricePerByte             actors.TokenAmount
+    MinPricePerByte             abi.TokenAmount
     MaxPaymentInterval          UInt
     MaxPaymentIntervalIncrease  UInt
 
@@ -81,7 +81,7 @@ type DealStatus union {
 type RetrievalParams struct {
     PayloadCID               ipld.CID  // V1
     Selector                 ipld.Selector  // V1
-    PricePerByte             actors.TokenAmount
+    PricePerByte             abi.TokenAmount
     PaymentInterval          UInt
     PaymentIntervalIncrease  UInt
 }
@@ -104,7 +104,7 @@ type RetrievalDealResponse struct {
     ID           RetrievalDealID  // V1 - an identifier for the retrieval
 
     // payment required to proceed
-    PaymentOwed  actors.TokenAmount
+    PaymentOwed  abi.TokenAmount
 
     Message      string
     Blocks       [Block]  // V0 only

--- a/src/systems/filecoin_markets/storage_market/storage_client.id
+++ b/src/systems/filecoin_markets/storage_market/storage_client.id
@@ -1,6 +1,6 @@
 import ipld "github.com/filecoin-project/specs/libraries/ipld"
 import deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
-import actors "github.com/filecoin-project/specs/actors"
+import abi "github.com/filecoin-project/specs/actors/abi"
 import libp2p "github.com/filecoin-project/specs/libraries/libp2p"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import message "github.com/filecoin-project/specs/systems/filecoin_vm/message"
@@ -51,15 +51,15 @@ type StorageClient struct {
     ProposeStorageDeal(
         info                StorageProviderInfo
         payloadCid          ipld.CID
-        proposalExpiration  actors.ChainEpoch
-        duration            actors.ChainEpoch
-        price               actors.TokenAmount
-        collateral          actors.TokenAmount
+        proposalExpiration  abi.ChainEpoch
+        duration            abi.ChainEpoch
+        price               abi.TokenAmount
+        collateral          abi.TokenAmount
     ) (ProposeStorageDealResult, error)
 
     // GetPaymentEscrow returns the current funds available for deal payment
-    GetPaymentEscrow() (actors.TokenAmount, error)
+    GetPaymentEscrow() (abi.TokenAmount, error)
 
     // AddPaymentEscrow adds storage collateral
-    AddPaymentEscrow(amount actors.TokenAmount) error
+    AddPaymentEscrow(amount abi.TokenAmount) error
 }

--- a/src/systems/filecoin_markets/storage_market/storage_deal/storage_deal.go
+++ b/src/systems/filecoin_markets/storage_market/storage_deal/storage_deal.go
@@ -1,6 +1,6 @@
 package storage_deal
 
-import actors "github.com/filecoin-project/specs/actors"
+import abi "github.com/filecoin-project/specs/actors/abi"
 
 import util "github.com/filecoin-project/specs/util"
 
@@ -13,18 +13,18 @@ func (d *StorageDeal_I) Proposal() StorageDealProposal {
 	panic("")
 }
 
-func (p *StorageDealProposal_I) Duration() actors.ChainEpoch {
+func (p *StorageDealProposal_I) Duration() abi.ChainEpoch {
 	return (p.EndEpoch() - p.StartEpoch())
 }
 
-func (p *StorageDealProposal_I) TotalStorageFee() actors.TokenAmount {
-	return actors.TokenAmount(uint64(p.StoragePricePerEpoch()) * uint64(p.Duration()))
+func (p *StorageDealProposal_I) TotalStorageFee() abi.TokenAmount {
+	return abi.TokenAmount(uint64(p.StoragePricePerEpoch()) * uint64(p.Duration()))
 }
 
-func (p *StorageDealProposal_I) ClientBalanceRequirement() actors.TokenAmount {
+func (p *StorageDealProposal_I) ClientBalanceRequirement() abi.TokenAmount {
 	return (p.ClientCollateral() + p.TotalStorageFee())
 }
 
-func (p *StorageDealProposal_I) ProviderBalanceRequirement() actors.TokenAmount {
+func (p *StorageDealProposal_I) ProviderBalanceRequirement() abi.TokenAmount {
 	return p.ProviderCollateral()
 }

--- a/src/systems/filecoin_markets/storage_market/storage_deal/storage_deal.id
+++ b/src/systems/filecoin_markets/storage_market/storage_deal/storage_deal.id
@@ -1,4 +1,4 @@
-import actors "github.com/filecoin-project/specs/actors"
+import abi "github.com/filecoin-project/specs/actors/abi"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
 import msg "github.com/filecoin-project/specs/systems/filecoin_vm/message"
@@ -29,17 +29,17 @@ type StorageDealProposal struct {
     // with total amount StoragePricePerEpoch * (EndEpoch - StartEpoch).
     // Storage deal must appear in a sealed (proven) sector no later than StartEpoch,
     // otherwise it is invalid.
-    StartEpoch                    actors.ChainEpoch
-    EndEpoch                      actors.ChainEpoch
-    StoragePricePerEpoch          actors.TokenAmount
+    StartEpoch                    abi.ChainEpoch
+    EndEpoch                      abi.ChainEpoch
+    StoragePricePerEpoch          abi.TokenAmount
 
-    ProviderCollateral            actors.TokenAmount
-    ClientCollateral              actors.TokenAmount
+    ProviderCollateral            abi.TokenAmount
+    ClientCollateral              abi.TokenAmount
 
-    Duration()                    actors.ChainEpoch     @(cached)  // EndEpoch - StartEpoch
-    TotalStorageFee()             actors.TokenAmount  // StoragePricePerEpoch * Duration
-    ClientBalanceRequirement()    actors.TokenAmount  // ClientCollateral + TotalStorageFee
-    ProviderBalanceRequirement()  actors.TokenAmount  // ProviderCollateral
+    Duration()                    abi.ChainEpoch        @(cached)  // EndEpoch - StartEpoch
+    TotalStorageFee()             abi.TokenAmount  // StoragePricePerEpoch * Duration
+    ClientBalanceRequirement()    abi.TokenAmount  // ClientCollateral + TotalStorageFee
+    ProviderBalanceRequirement()  abi.TokenAmount  // ProviderCollateral
 
     CID()                         &StorageDealProposal
 }
@@ -57,7 +57,7 @@ type StorageDeal struct {
 type OnChainDeal struct {
     ID                DealID
     Deal              StorageDeal
-    SectorStartEpoch  actors.ChainEpoch  // -1 if not yet included in proven sector
-    LastUpdatedEpoch  actors.ChainEpoch  // -1 if deal state never updated
-    SlashEpoch        actors.ChainEpoch  // -1 if deal never slashed
+    SectorStartEpoch  abi.ChainEpoch  // -1 if not yet included in proven sector
+    LastUpdatedEpoch  abi.ChainEpoch  // -1 if deal state never updated
+    SlashEpoch        abi.ChainEpoch  // -1 if deal never slashed
 }

--- a/src/systems/filecoin_markets/storage_market/storage_market.id
+++ b/src/systems/filecoin_markets/storage_market/storage_market.id
@@ -1,4 +1,4 @@
-import actors "github.com/filecoin-project/specs/actors"
+import abi "github.com/filecoin-project/specs/actors/abi"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
 import filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
@@ -11,16 +11,16 @@ type StorageDealStatus uint64
 // StorageAsk is the current price and parameters a miner is currently offering for storage
 // (analogous to an Ask in a financial market)
 type StorageAsk struct {
-    Price             actors.TokenAmount  // attoFIL per GiB per epoch
-    Collateral        actors.TokenAmount  // attoFIL per GiB per epoch
+    Price             abi.TokenAmount  // attoFIL per GiB per epoch
+    Collateral        abi.TokenAmount  // attoFIL per GiB per epoch
 
     MinPieceSize      piece.PieceSize
     // address of miner actor for deals
     Miner             addr.Address
     // the epoch at the time this ask was published
-    PublicationEpoch  actors.ChainEpoch
-    MaxDuration       actors.ChainEpoch
-    MinDuration       actors.ChainEpoch
+    PublicationEpoch  abi.ChainEpoch
+    MaxDuration       abi.ChainEpoch
+    MinDuration       abi.ChainEpoch
     // a miner should update sequence number each time it publishes an ask
     // so that anyone with two asks from the same miner can determine which is
     // more current

--- a/src/systems/filecoin_markets/storage_market/storage_provider.id
+++ b/src/systems/filecoin_markets/storage_market/storage_provider.id
@@ -1,6 +1,6 @@
 import ipld "github.com/filecoin-project/specs/libraries/ipld"
 import deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
-import actors "github.com/filecoin-project/specs/actors"
+import abi "github.com/filecoin-project/specs/actors/abi"
 import libp2p "github.com/filecoin-project/specs/libraries/libp2p"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import dt "github.com/filecoin-project/specs/systems/filecoin_files/data_transfer"
@@ -25,7 +25,7 @@ type MinerDeal struct {
 
 // The interface provided for storage providers
 type StorageProvider struct {
-    AddAsk(price actors.TokenAmount, ttlsecs int64) error
+    AddAsk(price abi.TokenAmount, ttlsecs int64) error
 
     // ListAsks lists current asks
     ListAsks(addrress addr.Address) [StorageAsk]
@@ -37,10 +37,10 @@ type StorageProvider struct {
     ListIncompleteDeals()  (deals [MinerDeal], error)
 
     // AddStorageCollateral adds storage collateral
-    AddStorageCollateral(amount actors.TokenAmount) error
+    AddStorageCollateral(amount abi.TokenAmount) error
 
     // GetStorageCollateral returns the current collateral balance
-    GetStorageCollateral() (actors.TokenAmount, error)
+    GetStorageCollateral() (abi.TokenAmount, error)
 
     // DataTransferValidator methods
     ValidatePush(

--- a/src/systems/filecoin_mining/sector/sealing.id
+++ b/src/systems/filecoin_mining/sector/sealing.id
@@ -1,4 +1,4 @@
-import actors "github.com/filecoin-project/specs/actors"
+import abi "github.com/filecoin-project/specs/actors/abi"
 import file "github.com/filecoin-project/specs/systems/filecoin_files/file"
 import piece "github.com/filecoin-project/specs/systems/filecoin_files/piece"
 import deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
@@ -36,8 +36,8 @@ type SealVerifyInfo struct {
 // data stored on the state tree for each sector.
 type OnChainSealVerifyInfo struct {
     SealedCID         SealedSectorCID  // CommR
-    SealEpoch         actors.ChainEpoch
-    InteractiveEpoch  actors.ChainEpoch
+    SealEpoch         abi.ChainEpoch
+    InteractiveEpoch  abi.ChainEpoch
     Proof             SealProof
     DealIDs           deal.DealIDs
     SectorNumber
@@ -48,22 +48,22 @@ type OnChainSealVerifyInfo struct {
 type SealCommitment struct {
     SealedCID   SealedSectorCID  // CommR
     DealIDs     deal.DealIDs
-    Expiration  actors.ChainEpoch
+    Expiration  abi.ChainEpoch
 }
 
 type SectorPreCommitInfo struct {
     SectorNumber
     SealedCID     SealedSectorCID  // CommR
-    SealEpoch     actors.ChainEpoch
+    SealEpoch     abi.ChainEpoch
     DealIDs       deal.DealIDs
-    Expiration    actors.ChainEpoch
+    Expiration    abi.ChainEpoch
 }
 
 type SectorProveCommitInfo struct {
     SectorNumber
     Proof             SealProof
-    InteractiveEpoch  actors.ChainEpoch
-    Expiration        actors.ChainEpoch
+    InteractiveEpoch  abi.ChainEpoch
+    Expiration        abi.ChainEpoch
 }
 
 // PersistentProofAux is meta data required to generate certain proofs

--- a/src/systems/filecoin_mining/sector/sector.go
+++ b/src/systems/filecoin_mining/sector/sector.go
@@ -1,7 +1,7 @@
 package sector
 
 import (
-	actors "github.com/filecoin-project/specs/actors"
+	abi "github.com/filecoin-project/specs/actors/abi"
 	deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
 	util "github.com/filecoin-project/specs/util"
 )
@@ -15,8 +15,8 @@ type Serialization = util.Serialization
 //   (T + MIN_PROVE_COMMIT_SECTOR_EPOCH, T + MAX_PROVE_COMMIT_SECTOR_EPOCH)
 // inclusive.
 // TODO: placeholder epoch values -- will be set later
-const MIN_PROVE_COMMIT_SECTOR_EPOCH = actors.ChainEpoch(5)
-const MAX_PROVE_COMMIT_SECTOR_EPOCH = actors.ChainEpoch(10)
+const MIN_PROVE_COMMIT_SECTOR_EPOCH = abi.ChainEpoch(5)
+const MAX_PROVE_COMMIT_SECTOR_EPOCH = abi.ChainEpoch(10)
 
 const (
 	DeclaredFault StorageFaultType = 1 + iota
@@ -28,7 +28,7 @@ func (amt *DealExpirationAMT_I) Size() int {
 	return 0
 }
 
-func (amt *DealExpirationAMT_I) Add(key actors.ChainEpoch, value DealExpirationValue) {
+func (amt *DealExpirationAMT_I) Add(key abi.ChainEpoch, value DealExpirationValue) {
 	// helper function to add entry into the AMT
 }
 
@@ -38,13 +38,13 @@ func (amt *DealExpirationAMT_I) ActiveDealIDs() []deal.DealID {
 }
 
 // return last item in the expiration amt
-func (q *DealExpirationAMT_I) LastDealExpiration() actors.ChainEpoch {
-	ret := actors.ChainEpoch(0)
+func (q *DealExpirationAMT_I) LastDealExpiration() abi.ChainEpoch {
+	ret := abi.ChainEpoch(0)
 	return ret
 }
 
 // return deal IDs expiring in epoch range
-func (q *DealExpirationAMT_I) ExpiredDealsInRange(start actors.ChainEpoch, end actors.ChainEpoch) []DealExpirationValue {
+func (q *DealExpirationAMT_I) ExpiredDealsInRange(start abi.ChainEpoch, end abi.ChainEpoch) []DealExpirationValue {
 	ret := make([]DealExpirationValue, 0)
 	return ret
 }

--- a/src/systems/filecoin_mining/sector/sector.id
+++ b/src/systems/filecoin_mining/sector/sector.id
@@ -1,4 +1,4 @@
-import actors "github.com/filecoin-project/specs/actors"
+import abi "github.com/filecoin-project/specs/actors/abi"
 import piece "github.com/filecoin-project/specs/systems/filecoin_files/piece"
 import ipld "github.com/filecoin-project/specs/libraries/ipld"
 import deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
@@ -20,13 +20,13 @@ type StorageFaultType int
 // defined as struct to specify helpers
 // effectively an AMT of the form DealExpirationAMT[Expiration][DealID] = PayloadPower
 type DealExpirationAMT struct {
-    Expiration  actors.ChainEpoch  // key
+    Expiration  abi.ChainEpoch  // key
     Value       DealExpirationValue  // value
 }
 
 type DealExpirationValue struct {
     ID     deal.DealID  // key
-    Power  actors.StoragePower  // value
+    Power  abi.StoragePower  // value
 }
 // SectorSize indicates one of a set of possible sizes in the network.
 type SectorSize UInt

--- a/src/systems/filecoin_mining/sector_index/sector_index_subsystem.go
+++ b/src/systems/filecoin_mining/sector_index/sector_index_subsystem.go
@@ -1,7 +1,7 @@
 package sector_index
 
 import (
-	actors "github.com/filecoin-project/specs/actors"
+	abi "github.com/filecoin-project/specs/actors/abi"
 	deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
 	sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 )
@@ -14,7 +14,7 @@ func (sis *SectorIndexerSubsystem_I) AddNewDeal(deal deal.StorageDeal) StageDeal
 // 	panic("TODO")
 // }
 
-func (sis *SectorIndexerSubsystem_I) SectorsExpiredAtEpoch(epoch actors.ChainEpoch) []sector.SectorID {
+func (sis *SectorIndexerSubsystem_I) SectorsExpiredAtEpoch(epoch abi.ChainEpoch) []sector.SectorID {
 	panic("TODO")
 }
 

--- a/src/systems/filecoin_mining/sector_index/sector_index_subsystem.id
+++ b/src/systems/filecoin_mining/sector_index/sector_index_subsystem.id
@@ -1,4 +1,4 @@
-import actors "github.com/filecoin-project/specs/actors"
+import abi "github.com/filecoin-project/specs/actors/abi"
 import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 import piece "github.com/filecoin-project/specs/systems/filecoin_files/piece"
 import deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
@@ -23,11 +23,11 @@ type SectorIndexerSubsystem struct {
     AddNewDeal(deal deal.StorageDeal) StageDealResponse
 
     // bring back if needed.
-    // OnNewTipset(chain Chain, epoch actors.Epoch) struct {}
+    // OnNewTipset(chain Chain, epoch abi.Epoch) struct {}
 
     // SectorsExpiredAtEpoch returns the set of sectors that expire
     // at a particular epoch.
-    SectorsExpiredAtEpoch(epoch actors.ChainEpoch) [sector.SectorID]
+    SectorsExpiredAtEpoch(epoch abi.ChainEpoch) [sector.SectorID]
 
     // removeSectors removes the given sectorIDs from storage.
     removeSectors(sectorIDs [sector.SectorID])

--- a/src/systems/filecoin_mining/storage_mining/storage_mining_subsystem.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_mining_subsystem.go
@@ -3,7 +3,7 @@ package storage_mining
 // import sectoridx "github.com/filecoin-project/specs/systems/filecoin_mining/sector_index"
 // import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 import (
-	actors "github.com/filecoin-project/specs/actors"
+	abi "github.com/filecoin-project/specs/actors/abi"
 	sminact "github.com/filecoin-project/specs/actors/builtin/storage_miner"
 	spowact "github.com/filecoin-project/specs/actors/builtin/storage_power"
 	serde "github.com/filecoin-project/specs/actors/serde"
@@ -38,7 +38,7 @@ func (sms *StorageMiningSubsystem_I) CreateMiner(
 	workerAddr addr.Address,
 	sectorSize util.UInt,
 	peerId libp2p.PeerID,
-	pledgeAmt actors.TokenAmount,
+	pledgeAmt abi.TokenAmount,
 ) (addr.Address, error) {
 
 	ownerActor, ok := state.GetActor(ownerAddr)
@@ -116,7 +116,7 @@ func (sms *StorageMiningSubsystem_I) _runMiningCycle() {
 		sPoSt := sms._trySurprisePoSt(chainHead.StateTree(), sma)
 
 		var gasLimit msg.GasAmount
-		var gasPrice = actors.TokenAmount(0)
+		var gasPrice = abi.TokenAmount(0)
 		util.IMPL_FINISH("read from consts (in this case user set param)")
 		sms._submitSurprisePoStMessage(chainHead.StateTree(), sPoSt, gasPrice, gasLimit)
 	}
@@ -260,7 +260,7 @@ func (sms *StorageMiningSubsystem_I) VerifyElectionPoSt(inds indices.Indices, he
 
 	// 1. Verify miner has enough power (includes implicit checks on min miner size
 	// and challenge status via SPA's power table).
-	if pow == actors.StoragePower(0) {
+	if pow == abi.StoragePower(0) {
 		return false
 	}
 
@@ -377,7 +377,7 @@ func (sms *StorageMiningSubsystem_I) _trySurprisePoSt(currState stateTree.StateT
 	return surprisePoSt
 }
 
-func (sms *StorageMiningSubsystem_I) _submitSurprisePoStMessage(state stateTree.StateTree, sPoSt sector.OnChainPoStVerifyInfo, gasPrice actors.TokenAmount, gasLimit msg.GasAmount) error {
+func (sms *StorageMiningSubsystem_I) _submitSurprisePoStMessage(state stateTree.StateTree, sPoSt sector.OnChainPoStVerifyInfo, gasPrice abi.TokenAmount, gasLimit msg.GasAmount) error {
 
 	workerAddr, err := addr.Address_Make_Key(node_base.NETWORK, addr.KeyHash(sms.Node().Repository().KeyStore().WorkerKey().VRFPublicKey()))
 	if err != nil {
@@ -391,7 +391,7 @@ func (sms *StorageMiningSubsystem_I) _submitSurprisePoStMessage(state stateTree.
 		Method_:     ai.Method_StorageMinerActor_SubmitSurprisePoStResponse,
 		Params_:     serde.MustSerializeParams(sPoSt),
 		CallSeqNum_: worker.CallSeqNum(),
-		Value_:      actors.TokenAmount(0),
+		Value_:      abi.TokenAmount(0),
 		GasPrice_:   gasPrice,
 		GasLimit_:   gasLimit,
 	}

--- a/src/systems/filecoin_mining/storage_mining/storage_mining_subsystem.id
+++ b/src/systems/filecoin_mining/storage_mining/storage_mining_subsystem.id
@@ -2,7 +2,7 @@ import sectoridx "github.com/filecoin-project/specs/systems/filecoin_mining/sect
 import spc "github.com/filecoin-project/specs/systems/filecoin_blockchain/storage_power_consensus"
 import spowact "github.com/filecoin-project/specs/actors/builtin/storage_power"
 import sminact "github.com/filecoin-project/specs/actors/builtin/storage_miner"
-import actors "github.com/filecoin-project/specs/actors"
+import abi "github.com/filecoin-project/specs/actors/abi"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
 import blockchain "github.com/filecoin-project/specs/systems/filecoin_blockchain"
@@ -44,7 +44,7 @@ type StorageMiningSubsystem struct {
         workerAddr  addr.Address
         sectorSize  util.UInt
         peerId      libp2p.PeerID
-        pledgeAmt   actors.TokenAmount
+        pledgeAmt   abi.TokenAmount
     )
 
     // call by StorageMarket.StorageProvider at the start of a deal.
@@ -77,7 +77,7 @@ type StorageMiningSubsystem struct {
     _submitSurprisePoStMessage(
         state     stateTree.StateTree
         sPoSt     sector.OnChainPoStVerifyInfo
-        gasPrice  actors.TokenAmount
+        gasPrice  abi.TokenAmount
         gasLimit  msg.GasAmount
     ) error
 

--- a/src/systems/filecoin_mining/storage_proving/poster/post_generator.id
+++ b/src/systems/filecoin_mining/storage_proving/poster/post_generator.id
@@ -1,4 +1,4 @@
-import actors "github.com/filecoin-project/specs/actors"
+import abi "github.com/filecoin-project/specs/actors/abi"
 import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 import sector_index "github.com/filecoin-project/specs/systems/filecoin_mining/sector_index"
 
@@ -10,7 +10,7 @@ type UInt64 UInt
 // - "blockchain/builtins" or something like that - a component in the blockchain that handles storage verification
 type PoStSubmission struct {
     PostProof   sector.PoStProof
-    ChainEpoch  actors.ChainEpoch
+    ChainEpoch  abi.ChainEpoch
 }
 
 type PoStGenerator struct {

--- a/src/systems/filecoin_nodes/node_base/network_params.go
+++ b/src/systems/filecoin_nodes/node_base/network_params.go
@@ -1,7 +1,7 @@
 package node_base
 
 import (
-	actors "github.com/filecoin-project/specs/actors"
+	abi "github.com/filecoin-project/specs/actors/abi"
 	addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 )
 
@@ -16,28 +16,28 @@ const NETWORK = addr.Address_NetworkID_Testnet
 /////////////////////////////////////////////////////////////
 
 // TODO: placeholder epoch value -- this will be set later
-const MAX_PROVE_COMMIT_SECTOR_PERIOD = actors.ChainEpoch(3) // placeholder
+const MAX_PROVE_COMMIT_SECTOR_PERIOD = abi.ChainEpoch(3) // placeholder
 
 /////////////////////////////////////////////////////////////
 // PoSt
 /////////////////////////////////////////////////////////////
 
-const MAX_SURPRISE_POST_RESPONSE_PERIOD = actors.ChainEpoch(4) // placeholder
-const POST_CHALLENGE_TIME = actors.ChainEpoch(1)               // placeholder
+const MAX_SURPRISE_POST_RESPONSE_PERIOD = abi.ChainEpoch(4) // placeholder
+const POST_CHALLENGE_TIME = abi.ChainEpoch(1)               // placeholder
 // sets the average frequency
-const PROVING_PERIOD = actors.ChainEpoch(2) // placeholder, 2 days
+const PROVING_PERIOD = abi.ChainEpoch(2) // placeholder, 2 days
 // how long after a POST challenge before a miner can get challenged again
-const SURPRISE_NO_CHALLENGE_PERIOD = actors.ChainEpoch(0) // placeholder, 2 hours
+const SURPRISE_NO_CHALLENGE_PERIOD = abi.ChainEpoch(0) // placeholder, 2 hours
 // how many sectors should be challenged in surprise post (if miner has fewer, will get dup challenges)
 const SURPRISE_CHALLENGE_COUNT = 200 // placeholder
 // how long miner has to respond to the challenge before it expires
-const CHALLENGE_DURATION = actors.ChainEpoch(0) // placeholder, 2 hours
+const CHALLENGE_DURATION = abi.ChainEpoch(0) // placeholder, 2 hours
 // number of detected faults before a miner's sectors are all terminated
 const MAX_CONSECUTIVE_FAULTS = 3
 
 // Time between when a temporary sector fault is declared, and when it becomes
 // effective for purposes of reducing the active proving set for PoSts.
-const DECLARED_FAULT_EFFECTIVE_DELAY = actors.ChainEpoch(20) // placeholder
+const DECLARED_FAULT_EFFECTIVE_DELAY = abi.ChainEpoch(20) // placeholder
 
 const EPOST_SAMPLE_RATE_NUM = 1    // placeholder
 const EPOST_SAMPLE_RATE_DENOM = 25 // placeholder
@@ -63,10 +63,10 @@ const SPC_LOOKBACK_SEAL = FINALITY  // should be set to finality
 // FIL deposit per sector precommit in Interactive PoRep
 // refunded after ProveCommit but burned if PreCommit expires
 
-const PRECOMMIT_DEPOSIT_PER_BYTE = actors.TokenAmount(0) // placeholder
-const FAULT_SLASH_PERC_DECLARED = 1                      // placeholder
-const FAULT_SLASH_PERC_DETECTED = 10                     // placeholder
-const FAULT_SLASH_PERC_TERMINATED = 100                  // placeholder
+const PRECOMMIT_DEPOSIT_PER_BYTE = abi.TokenAmount(0) // placeholder
+const FAULT_SLASH_PERC_DECLARED = 1                   // placeholder
+const FAULT_SLASH_PERC_DETECTED = 10                  // placeholder
+const FAULT_SLASH_PERC_TERMINATED = 100               // placeholder
 
 /////////////////////////////////////////////////////////////
 // Slashing

--- a/src/systems/filecoin_token/multisig/multisig_actor.id
+++ b/src/systems/filecoin_token/multisig/multisig_actor.id
@@ -1,5 +1,5 @@
 import address "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
-import actors "github.com/filecoin-project/specs/actors"
+import abi "github.com/filecoin-project/specs/actors/abi"
 
 type TxSeqNo UVarint
 type NumRequired UVarint
@@ -10,7 +10,7 @@ type MultisigActor struct {
     signers         [address.Address]
     required        NumRequired
     nextTxId        TxSeqNo
-    initialBalance  actors.TokenAmount
+    initialBalance  abi.TokenAmount
     startingBlock   Epoch
     unlockDuration  EpochDuration
     // transactions    {TxSeqNo: Transaction} // TODO Transaction type does not exist
@@ -22,7 +22,7 @@ type MultisigActor struct {
     )
     Propose(
         to      address.Address
-        value   actors.TokenAmount
+        value   abi.TokenAmount
         method  string
         params  Bytes
     ) TxSeqNo

--- a/src/systems/filecoin_vm/actor/actor.go
+++ b/src/systems/filecoin_vm/actor/actor.go
@@ -1,7 +1,7 @@
 package actor
 
 import (
-	actors "github.com/filecoin-project/specs/actors"
+	abi "github.com/filecoin-project/specs/actors/abi"
 	ipld "github.com/filecoin-project/specs/libraries/ipld"
 	util "github.com/filecoin-project/specs/util"
 )
@@ -13,11 +13,11 @@ var TODO = util.TODO
 type Serialization = util.Serialization
 
 const (
-	MethodSend        = actors.MethodNum(0)
-	MethodConstructor = actors.MethodNum(1)
+	MethodSend        = abi.MethodNum(0)
+	MethodConstructor = abi.MethodNum(1)
 
 	// TODO: remove this once canonical method numbers are finalized
-	MethodPlaceholder = actors.MethodNum(1 << 30)
+	MethodPlaceholder = abi.MethodNum(1 << 30)
 )
 
 func (st *ActorState_I) CID() ipld.CID {

--- a/src/systems/filecoin_vm/actor/actor.id
+++ b/src/systems/filecoin_vm/actor/actor.id
@@ -1,7 +1,7 @@
 // This contains actor things that are _outside_ of VM exection.
-// The VM uses this to execute actors.
+// The VM uses this to execute abi.
 
-import actors "github.com/filecoin-project/specs/actors"
+import abi "github.com/filecoin-project/specs/actors/abi"
 import ipld "github.com/filecoin-project/specs/libraries/ipld"
 
 // CallSeqNum is an invocation (Call) sequence (Seq) number (Num).
@@ -66,10 +66,10 @@ type ActorState struct {
     // CID of the root of optional actor-specific sub-state.
     State       ActorSubstateCID
     // Balance of tokens held by this actor.
-    Balance     actors.TokenAmount
+    Balance     abi.TokenAmount
     // Expected sequence number of the next message sent by this actor.
     // Initially zero, incremented when an account actor originates a top-level message.
-    // Always zero for other actors.
+    // Always zero for other abi.
     CallSeqNum
 }
 

--- a/src/systems/filecoin_vm/actor/address/address.go
+++ b/src/systems/filecoin_vm/actor/address/address.go
@@ -10,7 +10,7 @@ var Assert = util.Assert
 
 type Int = util.Int
 
-// Addresses for singleton system actors.
+// Addresses for singleton system abi.
 var (
 	// Distinguished AccountActor that is the source of system implicit messages.
 	SystemActorAddr        = Address_Make_ID(Address_NetworkID_Testnet, 0)

--- a/src/systems/filecoin_vm/indices/indices.go
+++ b/src/systems/filecoin_vm/indices/indices.go
@@ -1,7 +1,7 @@
 package indices
 
 import (
-	actors "github.com/filecoin-project/specs/actors"
+	abi "github.com/filecoin-project/specs/actors/abi"
 	actor_util "github.com/filecoin-project/specs/actors/util"
 	piece "github.com/filecoin-project/specs/systems/filecoin_files/piece"
 	deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
@@ -18,7 +18,7 @@ func Indices_FromStateTree(tree st.StateTree) Indices {
 	panic("")
 }
 
-func StorageDeal_ProviderInitTimedOutSlashAmount(deal deal.OnChainDeal) actors.TokenAmount {
+func StorageDeal_ProviderInitTimedOutSlashAmount(deal deal.OnChainDeal) abi.TokenAmount {
 	// placeholder
 	PARAM_FINISH()
 	return deal.Deal().Proposal().ProviderBalanceRequirement()
@@ -26,21 +26,21 @@ func StorageDeal_ProviderInitTimedOutSlashAmount(deal deal.OnChainDeal) actors.T
 
 func (inds *Indices_I) StorageDeal_DurationBounds(
 	pieceSize piece.PieceSize,
-	startEpoch actors.ChainEpoch,
-) (minDuration actors.ChainEpoch, maxDuration actors.ChainEpoch) {
+	startEpoch abi.ChainEpoch,
+) (minDuration abi.ChainEpoch, maxDuration abi.ChainEpoch) {
 
 	// placeholder
 	PARAM_FINISH()
-	minDuration = actors.ChainEpoch(0)
-	maxDuration = actors.ChainEpoch(1 << 20)
+	minDuration = abi.ChainEpoch(0)
+	maxDuration = abi.ChainEpoch(1 << 20)
 	return
 }
 
 func (inds *Indices_I) StorageDeal_StoragePricePerEpochBounds(
 	pieceSize piece.PieceSize,
-	startEpoch actors.ChainEpoch,
-	endEpoch actors.ChainEpoch,
-) (minPrice actors.TokenAmount, maxPrice actors.TokenAmount) {
+	startEpoch abi.ChainEpoch,
+	endEpoch abi.ChainEpoch,
+) (minPrice abi.TokenAmount, maxPrice abi.TokenAmount) {
 
 	// placeholder
 	PARAM_FINISH()
@@ -49,9 +49,9 @@ func (inds *Indices_I) StorageDeal_StoragePricePerEpochBounds(
 
 func (inds *Indices_I) StorageDeal_ProviderCollateralBounds(
 	pieceSize piece.PieceSize,
-	startEpoch actors.ChainEpoch,
-	endEpoch actors.ChainEpoch,
-) (minProviderCollateral actors.TokenAmount, maxProviderCollateral actors.TokenAmount) {
+	startEpoch abi.ChainEpoch,
+	endEpoch abi.ChainEpoch,
+) (minProviderCollateral abi.TokenAmount, maxProviderCollateral abi.TokenAmount) {
 
 	// placeholder
 	PARAM_FINISH()
@@ -60,9 +60,9 @@ func (inds *Indices_I) StorageDeal_ProviderCollateralBounds(
 
 func (inds *Indices_I) StorageDeal_ClientCollateralBounds(
 	pieceSize piece.PieceSize,
-	startEpoch actors.ChainEpoch,
-	endEpoch actors.ChainEpoch,
-) (minClientCollateral actors.TokenAmount, maxClientCollateral actors.TokenAmount) {
+	startEpoch abi.ChainEpoch,
+	endEpoch abi.ChainEpoch,
+) (minClientCollateral abi.TokenAmount, maxClientCollateral abi.TokenAmount) {
 
 	// placeholder
 	PARAM_FINISH()
@@ -71,38 +71,38 @@ func (inds *Indices_I) StorageDeal_ClientCollateralBounds(
 
 func (inds *Indices_I) SectorWeight(
 	sectorSize sector.SectorSize,
-	startEpoch actors.ChainEpoch,
-	endEpoch actors.ChainEpoch,
+	startEpoch abi.ChainEpoch,
+	endEpoch abi.ChainEpoch,
 	dealWeight deal.DealWeight,
-) actors.SectorWeight {
+) abi.SectorWeight {
 	// for every sector, given its size, start, end, and deals within the sector
 	// assign sector power for the duration of its lifetime
 	PARAM_FINISH()
 	panic("")
 }
 
-func (inds *Indices_I) PledgeCollateralReq(minerNominalPower actors.StoragePower) actors.TokenAmount {
+func (inds *Indices_I) PledgeCollateralReq(minerNominalPower abi.StoragePower) abi.TokenAmount {
 	PARAM_FINISH()
 	panic("")
 }
 
-func (inds *Indices_I) SectorWeightProportion(minerActiveSectorWeight actors.SectorWeight) util.BigInt {
+func (inds *Indices_I) SectorWeightProportion(minerActiveSectorWeight abi.SectorWeight) util.BigInt {
 	// return proportion of SectorWeight for miner
 	PARAM_FINISH()
 	panic("")
 }
 
-func (inds *Indices_I) PledgeCollateralProportion(minerPledgeCollateral actors.TokenAmount) util.BigInt {
+func (inds *Indices_I) PledgeCollateralProportion(minerPledgeCollateral abi.TokenAmount) util.BigInt {
 	// return proportion of Pledge Collateral for miner
 	PARAM_FINISH()
 	panic("")
 }
 
 func (inds *Indices_I) StoragePower(
-	minerActiveSectorWeight actors.SectorWeight,
-	minerInactiveSectorWeight actors.SectorWeight,
-	minerPledgeCollateral actors.TokenAmount,
-) actors.StoragePower {
+	minerActiveSectorWeight abi.SectorWeight,
+	minerInactiveSectorWeight abi.SectorWeight,
+	minerPledgeCollateral abi.TokenAmount,
+) abi.StoragePower {
 	// return StoragePower based on inputs
 	// StoragePower for miner = func(ActiveSectorWeight for miner, PledgeCollateral for miner, global indices)
 	PARAM_FINISH()
@@ -110,13 +110,13 @@ func (inds *Indices_I) StoragePower(
 }
 
 func (inds *Indices_I) StoragePowerProportion(
-	minerStoragePower actors.StoragePower,
+	minerStoragePower abi.StoragePower,
 ) util.BigInt {
 	PARAM_FINISH()
 	panic("")
 }
 
-func (inds *Indices_I) CurrEpochBlockReward() actors.TokenAmount {
+func (inds *Indices_I) CurrEpochBlockReward() abi.TokenAmount {
 	// total block reward allocated for CurrEpoch
 	// each expected winner get an equal share of this reward
 	// computed as a function of NetworkKPI, LastEpochReward, TotalUnmminedFIL, etc
@@ -125,10 +125,10 @@ func (inds *Indices_I) CurrEpochBlockReward() actors.TokenAmount {
 }
 
 func (inds *Indices_I) GetCurrBlockRewardRewardForMiner(
-	minerStoragePower actors.StoragePower,
-	minerPledgeCollateral actors.TokenAmount,
+	minerStoragePower abi.StoragePower,
+	minerPledgeCollateral abi.TokenAmount,
 	// TODO extend or eliminate
-) actors.TokenAmount {
+) abi.TokenAmount {
 	PARAM_FINISH()
 	panic("")
 }
@@ -137,62 +137,62 @@ func (inds *Indices_I) GetCurrBlockRewardRewardForMiner(
 func (inds *Indices_I) StoragePower_PledgeSlashForSectorTermination(
 	storageWeightDesc actor_util.SectorStorageWeightDesc,
 	terminationType actor_util.SectorTerminationType,
-) actors.TokenAmount {
+) abi.TokenAmount {
 	PARAM_FINISH()
 	panic("")
 }
 
 // DetectedFault
 func (inds *Indices_I) StoragePower_PledgeSlashForSurprisePoStFailure(
-	minerClaimedPower actors.StoragePower,
+	minerClaimedPower abi.StoragePower,
 	numConsecutiveFailures int,
-) actors.TokenAmount {
+) abi.TokenAmount {
 	PARAM_FINISH()
 	panic("")
 }
 
 func (inds *Indices_I) StorageMining_PreCommitDeposit(
 	sectorSize sector.SectorSize,
-	expirationEpoch actors.ChainEpoch,
-) actors.TokenAmount {
+	expirationEpoch abi.ChainEpoch,
+) abi.TokenAmount {
 	PARAM_FINISH()
 	panic("")
 }
 
 func (inds *Indices_I) StorageMining_TemporaryFaultFee(
 	storageWeightDescs []actor_util.SectorStorageWeightDesc,
-	duration actors.ChainEpoch,
-) actors.TokenAmount {
+	duration abi.ChainEpoch,
+) abi.TokenAmount {
 	PARAM_FINISH()
 	panic("")
 }
 
 func (inds *Indices_I) NetworkTransactionFee(
 	toActorCodeID actor.CodeID,
-	methodNum actors.MethodNum,
-) actors.TokenAmount {
+	methodNum abi.MethodNum,
+) abi.TokenAmount {
 	PARAM_FINISH()
 	panic("")
 }
 
 func ConsensusPowerForStorageWeight(
 	storageWeightDesc actor_util.SectorStorageWeightDesc,
-) actors.StoragePower {
+) abi.StoragePower {
 	PARAM_FINISH()
 	panic("")
 }
 
-func StoragePower_ConsensusMinMinerPower() actors.StoragePower {
+func StoragePower_ConsensusMinMinerPower() abi.StoragePower {
 	PARAM_FINISH()
 	panic("")
 }
 
-func StorageMining_PoStNoChallengePeriod() actors.ChainEpoch {
+func StorageMining_PoStNoChallengePeriod() abi.ChainEpoch {
 	PARAM_FINISH()
 	panic("")
 }
 
-func StorageMining_SurprisePoStProvingPeriod() actors.ChainEpoch {
+func StorageMining_SurprisePoStProvingPeriod() abi.ChainEpoch {
 	PARAM_FINISH()
 	panic("")
 }
@@ -202,7 +202,7 @@ func StoragePower_SurprisePoStMaxConsecutiveFailures() int {
 	panic("")
 }
 
-func StorageMining_DeclaredFaultEffectiveDelay() actors.ChainEpoch {
+func StorageMining_DeclaredFaultEffectiveDelay() abi.ChainEpoch {
 	PARAM_FINISH()
 	panic("")
 }

--- a/src/systems/filecoin_vm/indices/indices.id
+++ b/src/systems/filecoin_vm/indices/indices.id
@@ -1,5 +1,5 @@
 import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
-import actors "github.com/filecoin-project/specs/actors"
+import abi "github.com/filecoin-project/specs/actors/abi"
 import actor_util "github.com/filecoin-project/specs/actors/util"
 import piece "github.com/filecoin-project/specs/systems/filecoin_files/piece"
 import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
@@ -12,110 +12,110 @@ import deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_
 type Indices struct {
     // these fields are computed from StateTree upon construction
     // they are treated as globally available states
-    Epoch                       actors.ChainEpoch
+    Epoch                       abi.ChainEpoch
     NetworkKPI                  BigInt
-    TotalNetworkSectorWeight    actors.SectorWeight
-    TotalPledgeCollateral       actors.TokenAmount
-    TotalNetworkEffectivePower  actors.StoragePower  // power above minimum miner size
-    TotalNetworkPower           actors.StoragePower  // total network power irrespective of meeting minimum miner size
+    TotalNetworkSectorWeight    abi.SectorWeight
+    TotalPledgeCollateral       abi.TokenAmount
+    TotalNetworkEffectivePower  abi.StoragePower  // power above minimum miner size
+    TotalNetworkPower           abi.StoragePower  // total network power irrespective of meeting minimum miner size
 
-    TotalMinedFIL               actors.TokenAmount
-    TotalUnminedFIL             actors.TokenAmount
-    TotalBurnedFIL              actors.TokenAmount
-    LastEpochReward             actors.TokenAmount
+    TotalMinedFIL               abi.TokenAmount
+    TotalUnminedFIL             abi.TokenAmount
+    TotalBurnedFIL              abi.TokenAmount
+    LastEpochReward             abi.TokenAmount
 
     // these methods produce policy output based on user state/action
-    StorageDeal_ProviderInitTimedOutSlashAmount(deal deal.OnChainDeal) actors.TokenAmount
+    StorageDeal_ProviderInitTimedOutSlashAmount(deal deal.OnChainDeal) abi.TokenAmount
 
     StorageDeal_DurationBounds(
         pieceSize   piece.PieceSize
-        startEpoch  actors.ChainEpoch
-    ) (minDuration actors.ChainEpoch, maxDuration actors.ChainEpoch)
+        startEpoch  abi.ChainEpoch
+    ) (minDuration abi.ChainEpoch, maxDuration abi.ChainEpoch)
 
     StorageDeal_StoragePricePerEpochBounds(
         pieceSize   piece.PieceSize
-        startEpoch  actors.ChainEpoch
-        endEpoch    actors.ChainEpoch
-    ) (minPrice actors.TokenAmount, maxPrice actors.TokenAmount)
+        startEpoch  abi.ChainEpoch
+        endEpoch    abi.ChainEpoch
+    ) (minPrice abi.TokenAmount, maxPrice abi.TokenAmount)
 
     StorageDeal_ProviderCollateralBounds(
         pieceSize   piece.PieceSize
-        startEpoch  actors.ChainEpoch
-        endEpoch    actors.ChainEpoch
+        startEpoch  abi.ChainEpoch
+        endEpoch    abi.ChainEpoch
     ) (
-        minProviderCollateral  actors.TokenAmount
-        maxProviderCollateral  actors.TokenAmount
+        minProviderCollateral  abi.TokenAmount
+        maxProviderCollateral  abi.TokenAmount
     )
 
     StorageDeal_ClientCollateralBounds(
         pieceSize   piece.PieceSize
-        startEpoch  actors.ChainEpoch
-        endEpoch    actors.ChainEpoch
+        startEpoch  abi.ChainEpoch
+        endEpoch    abi.ChainEpoch
     ) (
-        minClientCollateral  actors.TokenAmount
-        maxClientCollateral  actors.TokenAmount
+        minClientCollateral  abi.TokenAmount
+        maxClientCollateral  abi.TokenAmount
     )
 
     SectorWeight(
         sectorSize  sector.SectorSize
-        startEpoch  actors.ChainEpoch
-        endEpoch    actors.ChainEpoch
+        startEpoch  abi.ChainEpoch
+        endEpoch    abi.ChainEpoch
         dealWeight  deal.DealWeight
-    ) actors.SectorWeight
+    ) abi.SectorWeight
 
     PledgeCollateralReq(
-        minerNominalPower actors.StoragePower
-    ) actors.TokenAmount
+        minerNominalPower abi.StoragePower
+    ) abi.TokenAmount
 
     SectorWeightProportion(
-        minerActiveSectorWeight actors.SectorWeight
+        minerActiveSectorWeight abi.SectorWeight
     ) BigInt
 
     PledgeCollateralProportion(
-        minerPledgeCollateral actors.TokenAmount
+        minerPledgeCollateral abi.TokenAmount
     ) BigInt
 
     StoragePower(
-        minerActiveSectorWeight    actors.SectorWeight
-        minerInactiveSectorWeight  actors.SectorWeight
-        minerPledgeCollateral      actors.TokenAmount
-    ) actors.StoragePower
+        minerActiveSectorWeight    abi.SectorWeight
+        minerInactiveSectorWeight  abi.SectorWeight
+        minerPledgeCollateral      abi.TokenAmount
+    ) abi.StoragePower
 
     StoragePowerProportion(
-        minerStoragePower actors.StoragePower
+        minerStoragePower abi.StoragePower
     ) BigInt
 
-    CurrEpochBlockReward() actors.TokenAmount
+    CurrEpochBlockReward() abi.TokenAmount
 
     GetCurrBlockRewardForMiner(
-        minerStoragePower      actors.StoragePower
-        minerPledgeCollateral  actors.TokenAmount
-    ) actors.TokenAmount
+        minerStoragePower      abi.StoragePower
+        minerPledgeCollateral  abi.TokenAmount
+    ) abi.TokenAmount
 
     StorageMining_PreCommitDeposit(
         sectorSize       sector.SectorSize
-        expirationEpoch  actors.ChainEpoch
-    ) actors.TokenAmount
+        expirationEpoch  abi.ChainEpoch
+    ) abi.TokenAmount
 
     StorageMining_TemporaryFaultFee(
         storageWeightDescs  [actor_util.SectorStorageWeightDesc]
-        duration            actors.ChainEpoch
-    ) actors.TokenAmount
+        duration            abi.ChainEpoch
+    ) abi.TokenAmount
 
     StoragePower_PledgeSlashForSectorTermination(
         storageWeightDesc  actor_util.SectorStorageWeightDesc
         terminationType    actor_util.SectorTerminationType
-    ) actors.TokenAmount
+    ) abi.TokenAmount
 
     StoragePower_PledgeSlashForSurprisePoStFailure(
-        minerClaimedPower       actors.StoragePower
+        minerClaimedPower       abi.StoragePower
         numConsecutiveFailures  int
-    ) actors.TokenAmount
+    ) abi.TokenAmount
 
-    StoragePower_ConsensusMinMinerPower() actors.StoragePower
+    StoragePower_ConsensusMinMinerPower() abi.StoragePower
 
     NetworkTransactionFee(
         toActorCodeID  actor.CodeID
-        methodNum      actors.MethodNum
-    ) actors.TokenAmount
+        methodNum      abi.MethodNum
+    ) abi.TokenAmount
 }

--- a/src/systems/filecoin_vm/interpreter/vm_interpreter.go
+++ b/src/systems/filecoin_vm/interpreter/vm_interpreter.go
@@ -1,7 +1,7 @@
 package interpreter
 
 import (
-	actors "github.com/filecoin-project/specs/actors"
+	abi "github.com/filecoin-project/specs/actors/abi"
 	cronact "github.com/filecoin-project/specs/actors/builtin/cron"
 	initact "github.com/filecoin-project/specs/actors/builtin/init"
 	sminact "github.com/filecoin-project/specs/actors/builtin/storage_miner"
@@ -48,8 +48,8 @@ func (vmi *VMInterpreter_I) ApplyTipSetMessages(inTree st.StateTree, msgs TipSet
 		epostMessage := _makeElectionPoStMessage(outTree, minerAddr)
 		outTree = _applyMessageBuiltinAssert(store, outTree, epostMessage, minerAddr)
 
-		minerPenaltyTotal := actors.TokenAmount(0)
-		var minerPenaltyCurr actors.TokenAmount
+		minerPenaltyTotal := abi.TokenAmount(0)
+		var minerPenaltyCurr abi.TokenAmount
 
 		// Process BLS messages from the block.
 		for _, m := range blk.BLSMessages() {
@@ -93,7 +93,7 @@ func (vmi *VMInterpreter_I) ApplyTipSetMessages(inTree st.StateTree, msgs TipSet
 
 func (vmi *VMInterpreter_I) ApplyMessage(
 	inTree st.StateTree, message msg.UnsignedMessage, onChainMessageSize int, minerAddr addr.Address) (
-	retTree st.StateTree, retReceipt vmr.MessageReceipt, retMinerPenalty actors.TokenAmount) {
+	retTree st.StateTree, retReceipt vmr.MessageReceipt, retMinerPenalty abi.TokenAmount) {
 
 	store := vmi.Node().Repository().StateStore()
 	senderAddr := _resolveSender(store, inTree, message.From())
@@ -118,7 +118,7 @@ func (vmi *VMInterpreter_I) ApplyMessage(
 			Assert(message.GasLimit().Equals(vmiGasUsed.Add(vmiGasRemaining)))
 			tree = _withTransferFundsAssert(tree, addr.BurntFundsActorAddr, senderAddr, vmiGasRemainingFIL)
 			tree = _withTransferFundsAssert(tree, addr.BurntFundsActorAddr, minerOwner, vmiGasUsedFIL)
-			retMinerPenalty = actors.TokenAmount(0)
+			retMinerPenalty = abi.TokenAmount(0)
 
 		case SenderResolveSpec_Invalid:
 			retMinerPenalty = vmiGasUsedFIL
@@ -281,14 +281,14 @@ func _applyMessageInternal(store ipld.GraphStore, tree st.StateTree, sender acto
 		actor.CallSeqNum(0),
 		tree,
 		senderAddr,
-		actors.TokenAmount(0),
+		abi.TokenAmount(0),
 		gasRemainingInit,
 	)
 
 	return rt.SendToplevelFromInterpreter(invoc)
 }
 
-func _withTransferFundsAssert(tree st.StateTree, from addr.Address, to addr.Address, amount actors.TokenAmount) st.StateTree {
+func _withTransferFundsAssert(tree st.StateTree, from addr.Address, to addr.Address, amount abi.TokenAmount) st.StateTree {
 	// TODO: assert amount nonnegative
 	retTree, err := tree.Impl().WithFundsTransfer(from, to, amount)
 	if err != nil {
@@ -298,10 +298,10 @@ func _withTransferFundsAssert(tree st.StateTree, from addr.Address, to addr.Addr
 	}
 }
 
-func _gasToFIL(gas msg.GasAmount, price actors.TokenAmount) actors.TokenAmount {
+func _gasToFIL(gas msg.GasAmount, price abi.TokenAmount) abi.TokenAmount {
 	IMPL_FINISH()
 	panic("") // BigInt arithmetic
-	// return actors.TokenAmount(util.UVarint(gas) * util.UVarint(price))
+	// return abi.TokenAmount(util.UVarint(gas) * util.UVarint(price))
 }
 
 func _makeInvocInput(message msg.UnsignedMessage) vmr.InvocInput {
@@ -314,7 +314,7 @@ func _makeInvocInput(message msg.UnsignedMessage) vmr.InvocInput {
 }
 
 // Builds a message for paying block reward to a miner's owner.
-func _makeBlockRewardMessage(state st.StateTree, minerAddr addr.Address, penalty actors.TokenAmount) msg.UnsignedMessage {
+func _makeBlockRewardMessage(state st.StateTree, minerAddr addr.Address, penalty abi.TokenAmount) msg.UnsignedMessage {
 	params := serde.MustSerializeParams(minerAddr, penalty)
 	TODO() // serialize other inputs to BlockRewardMessage or get this from query in RewardActor
 

--- a/src/systems/filecoin_vm/message/message.id
+++ b/src/systems/filecoin_vm/message/message.id
@@ -1,7 +1,7 @@
 import filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
-import actors "github.com/filecoin-project/specs/actors"
+import abi "github.com/filecoin-project/specs/actors/abi"
 
 // GasAmount is a quantity of gas.
 type GasAmount struct {
@@ -24,15 +24,15 @@ type UnsignedMessage struct {
     CallSeqNum  actor.CallSeqNum
 
     // Amount of value to transfer from sender's to receiver's balance.
-    Value       actors.TokenAmount
+    Value       abi.TokenAmount
 
     // Optional method to invoke on receiver, zero for a plain value send.
-    Method      actors.MethodNum
+    Method      abi.MethodNum
     /// Serialized parameters to the method (if method is non-zero).
-    Params      actors.MethodParams
+    Params      abi.MethodParams
 
     // GasPrice is a Gas-to-FIL cost
-    GasPrice    actors.TokenAmount
+    GasPrice    abi.TokenAmount
     GasLimit    GasAmount
 }  // representation tuple
 

--- a/src/systems/filecoin_vm/runtime/gascost/vm_gascosts.go
+++ b/src/systems/filecoin_vm/runtime/gascost/vm_gascosts.go
@@ -1,7 +1,7 @@
 package runtime
 
 import (
-	actors "github.com/filecoin-project/specs/actors"
+	abi "github.com/filecoin-project/specs/actors/abi"
 	actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 	msg "github.com/filecoin-project/specs/systems/filecoin_vm/message"
 	util "github.com/filecoin-project/specs/util"
@@ -109,9 +109,9 @@ func IpldPut(dataSize int) msg.GasAmount {
 	return msg.GasAmount_Affine(IpldPutBase, dataSize, IpldPutPerByte)
 }
 
-func InvokeMethod(value actors.TokenAmount, method actors.MethodNum) msg.GasAmount {
+func InvokeMethod(value abi.TokenAmount, method abi.MethodNum) msg.GasAmount {
 	ret := SendBase
-	if value != actors.TokenAmount(0) {
+	if value != abi.TokenAmount(0) {
 		ret = ret.Add(SendTransferFunds)
 	}
 	if method != actor.MethodSend {

--- a/src/systems/filecoin_vm/runtime/impl/runtime.go
+++ b/src/systems/filecoin_vm/runtime/impl/runtime.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 
-	actors "github.com/filecoin-project/specs/actors"
+	abi "github.com/filecoin-project/specs/actors/abi"
 	acctact "github.com/filecoin-project/specs/actors/builtin/account"
 	initact "github.com/filecoin-project/specs/actors/builtin/init"
 	filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
@@ -92,7 +92,7 @@ type VMContext struct {
 	// during the current top-level message execution.
 	// Note: resets with every top-level message, and therefore not necessarily monotonic.
 	_internalCallSeqNum actor.CallSeqNum
-	_valueReceived      actors.TokenAmount
+	_valueReceived      abi.TokenAmount
 	_gasRemaining       msg.GasAmount
 	_numValidateCalls   int
 	_output             vmr.InvocOutput
@@ -106,7 +106,7 @@ func VMContext_Make(
 	internalCallSeqNum actor.CallSeqNum,
 	globalState st.StateTree,
 	actorAddress addr.Address,
-	valueReceived actors.TokenAmount,
+	valueReceived abi.TokenAmount,
 	gasRemaining msg.GasAmount) *VMContext {
 
 	return &VMContext{
@@ -173,7 +173,7 @@ func (rt *VMContext) _createActor(codeID actor.CodeID, address addr.Address) {
 	actorState := &actor.ActorState_I{
 		CodeID_:     codeID,
 		State_:      actor.ActorSubstateCID(ipld.EmptyCID()),
-		Balance_:    actors.TokenAmount(0),
+		Balance_:    abi.TokenAmount(0),
 		CallSeqNum_: 0,
 	}
 
@@ -390,7 +390,7 @@ func (rt *VMContext) _rtAllocGas(x msg.GasAmount) {
 	}
 }
 
-func (rt *VMContext) _transferFunds(from addr.Address, to addr.Address, amount actors.TokenAmount) error {
+func (rt *VMContext) _transferFunds(from addr.Address, to addr.Address, amount abi.TokenAmount) error {
 	rt._checkRunning()
 	rt._checkActorStateNotAcquired()
 
@@ -449,8 +449,8 @@ func _catchRuntimeErrors(f func() InvocOutput) (output InvocOutput, exitCode exi
 func _invokeMethodInternal(
 	rt *VMContext,
 	actorCode vmr.ActorCode,
-	method actors.MethodNum,
-	params actors.MethodParams) (
+	method abi.MethodNum,
+	params abi.MethodParams) (
 	ret InvocOutput, exitCode exitcode.ExitCode, internalCallSeqNumFinal actor.CallSeqNum) {
 
 	if method == actor.MethodSend {
@@ -600,19 +600,19 @@ func (rt *VMContext) _sendInternalOutputs(input InvocInput, errSpec ErrorHandlin
 }
 
 func (rt *VMContext) Send(
-	toAddr addr.Address, methodNum actors.MethodNum, params actors.MethodParams, value actors.TokenAmount) InvocOutput {
+	toAddr addr.Address, methodNum abi.MethodNum, params abi.MethodParams, value abi.TokenAmount) InvocOutput {
 
 	return rt.SendPropagatingErrors(vmr.InvocInput_Make(toAddr, methodNum, params, value))
 }
 
-func (rt *VMContext) SendQuery(toAddr addr.Address, methodNum actors.MethodNum, params actors.MethodParams) util.Serialization {
-	invocOutput := rt.Send(toAddr, methodNum, params, actors.TokenAmount(0))
+func (rt *VMContext) SendQuery(toAddr addr.Address, methodNum abi.MethodNum, params abi.MethodParams) util.Serialization {
+	invocOutput := rt.Send(toAddr, methodNum, params, abi.TokenAmount(0))
 	ret := invocOutput.ReturnValue()
 	Assert(ret != nil)
 	return ret
 }
 
-func (rt *VMContext) SendFunds(toAddr addr.Address, value actors.TokenAmount) {
+func (rt *VMContext) SendFunds(toAddr addr.Address, value abi.TokenAmount) {
 	rt.Send(toAddr, actor.MethodSend, nil, value)
 }
 
@@ -626,22 +626,22 @@ func (rt *VMContext) SendCatchingErrors(input InvocInput) (InvocOutput, exitcode
 	return rt._sendInternalOutputs(input, CatchErrors)
 }
 
-func (rt *VMContext) CurrentBalance() actors.TokenAmount {
+func (rt *VMContext) CurrentBalance() abi.TokenAmount {
 	IMPL_FINISH()
 	panic("")
 }
 
-func (rt *VMContext) ValueReceived() actors.TokenAmount {
+func (rt *VMContext) ValueReceived() abi.TokenAmount {
 	return rt._valueReceived
 }
 
-func (rt *VMContext) Randomness(tag filcrypto.DomainSeparationTag, epoch actors.ChainEpoch) util.Randomness {
+func (rt *VMContext) Randomness(tag filcrypto.DomainSeparationTag, epoch abi.ChainEpoch) util.Randomness {
 	IMPL_TODO()
 	panic("")
 }
 
 func (rt *VMContext) RandomnessWithAuxSeed(
-	tag filcrypto.DomainSeparationTag, epoch actors.ChainEpoch, auxSeed util.Serialization) util.Randomness {
+	tag filcrypto.DomainSeparationTag, epoch abi.ChainEpoch, auxSeed util.Serialization) util.Randomness {
 
 	IMPL_TODO()
 	panic("")
@@ -677,7 +677,7 @@ func (rt *VMContext) IpldGet(c ipld.CID, o ipld.Object) bool {
 	return ok
 }
 
-func (rt *VMContext) CurrEpoch() actors.ChainEpoch {
+func (rt *VMContext) CurrEpoch() abi.ChainEpoch {
 	IMPL_FINISH()
 	panic("")
 }

--- a/src/systems/filecoin_vm/runtime/rtutil.go
+++ b/src/systems/filecoin_vm/runtime/rtutil.go
@@ -1,7 +1,7 @@
 package runtime
 
 import (
-	actors "github.com/filecoin-project/specs/actors"
+	abi "github.com/filecoin-project/specs/actors/abi"
 	filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
 	actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 	addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
@@ -60,7 +60,7 @@ func CallerPattern_MakeAcceptAny() CallerPattern {
 	}
 }
 
-func InvocInput_Make(to addr.Address, method actors.MethodNum, params actors.MethodParams, value actors.TokenAmount) InvocInput {
+func InvocInput_Make(to addr.Address, method abi.MethodNum, params abi.MethodParams, value abi.TokenAmount) InvocInput {
 	return &InvocInput_I{
 		To_:     to,
 		Method_: method,
@@ -139,7 +139,7 @@ func RT_MinerEntry_ValidateCaller_DetermineFundsLocation(rt Runtime, entryAddr a
 	}
 }
 
-func RT_ConfirmFundsReceiptOrAbort_RefundRemainder(rt Runtime, fundsRequired actors.TokenAmount) {
+func RT_ConfirmFundsReceiptOrAbort_RefundRemainder(rt Runtime, fundsRequired abi.TokenAmount) {
 	if rt.ValueReceived() < fundsRequired {
 		rt.AbortFundsMsg("Insufficient funds received accompanying message")
 	}

--- a/src/systems/filecoin_vm/runtime/runtime.id
+++ b/src/systems/filecoin_vm/runtime/runtime.id
@@ -1,5 +1,5 @@
 import actor "github.com/filecoin-project/specs/systems/filecoin_vm/actor"
-import actors "github.com/filecoin-project/specs/actors"
+import abi "github.com/filecoin-project/specs/actors/abi"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import exitcode "github.com/filecoin-project/specs/systems/filecoin_vm/runtime/exitcode"
 import filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
@@ -10,15 +10,15 @@ import msg "github.com/filecoin-project/specs/systems/filecoin_vm/message"
 // Runtime is the VM's internal runtime object.
 // this is everything that is accessible to actors, beyond parameters.
 type Runtime interface {
-    CurrEpoch() actors.ChainEpoch
+    CurrEpoch() abi.ChainEpoch
 
     // Randomness returns a (pseudo)random string for the given epoch and tag.
-    Randomness(tag filcrypto.DomainSeparationTag, epoch actors.ChainEpoch) actors.Randomness
+    Randomness(tag filcrypto.DomainSeparationTag, epoch abi.ChainEpoch) abi.Randomness
     RandomnessWithAuxSeed(
         tag      filcrypto.DomainSeparationTag
-        epoch    actors.ChainEpoch
+        epoch    abi.ChainEpoch
         auxSeed  util.Serialization
-    ) actors.Randomness
+    ) abi.Randomness
 
     // The address of the immediate calling actor.
     // Not necessarily the actor in the From field of the initial on-chain Message.
@@ -66,8 +66,8 @@ type Runtime interface {
     // Check that the given condition is true (and call Abort if not).
     Assert(bool)
 
-    CurrentBalance()  actors.TokenAmount
-    ValueReceived()   actors.TokenAmount
+    CurrentBalance()  abi.TokenAmount
+    ValueReceived()   abi.TokenAmount
 
     // Look up the current values of several system-wide economic indices.
     CurrIndices()     indices.Indices
@@ -85,16 +85,16 @@ type Runtime interface {
     SendPropagatingErrors(input InvocInput) InvocOutput
     Send(
         toAddr     addr.Address
-        methodNum  actors.MethodNum
-        params     actors.MethodParams
-        value      actors.TokenAmount
+        methodNum  abi.MethodNum
+        params     abi.MethodParams
+        value      abi.TokenAmount
     ) InvocOutput
     SendQuery(
         toAddr     addr.Address
-        methodNum  actors.MethodNum
-        params     actors.MethodParams
+        methodNum  abi.MethodNum
+        params     abi.MethodParams
     ) util.Serialization
-    SendFunds(toAddr addr.Address, value actors.TokenAmount)
+    SendFunds(toAddr addr.Address, value abi.TokenAmount)
 
     // Sends a message to another actor, trapping an unsuccessful execution.
     // This may only be invoked by the singleton Cron actor.
@@ -126,9 +126,9 @@ type Runtime interface {
 
 type InvocInput struct {
     To      addr.Address
-    Method  actors.MethodNum
-    Params  actors.MethodParams
-    Value   actors.TokenAmount
+    Method  abi.MethodNum
+    Params  abi.MethodParams
+    Value   abi.TokenAmount
 }
 
 type InvocOutput struct {

--- a/src/systems/filecoin_vm/state_tree/state_tree.go
+++ b/src/systems/filecoin_vm/state_tree/state_tree.go
@@ -1,7 +1,7 @@
 package state_tree
 
 import (
-	"github.com/filecoin-project/specs/actors"
+	"github.com/filecoin-project/specs/actors/abi"
 	"github.com/filecoin-project/specs/libraries/ipld"
 	"github.com/filecoin-project/specs/systems/filecoin_vm/actor"
 	addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
@@ -43,7 +43,7 @@ func (st *StateTree_I) WithActorSystemState(a addr.Address, actorState actor.Act
 	panic("")
 }
 
-func (st *StateTree_I) WithFundsTransfer(from addr.Address, to addr.Address, amount actors.TokenAmount) (StateTree, error) {
+func (st *StateTree_I) WithFundsTransfer(from addr.Address, to addr.Address, amount abi.TokenAmount) (StateTree, error) {
 	IMPL_FINISH()
 	panic("")
 }
@@ -74,12 +74,12 @@ func treeIncrementActorSeqNo(inTree StateTree, a actor.Actor) (outTree StateTree
 	panic("todo")
 }
 
-func treeDeductFunds(inTree StateTree, a actor.Actor, amt actors.TokenAmount) (outTree StateTree) {
+func treeDeductFunds(inTree StateTree, a actor.Actor, amt abi.TokenAmount) (outTree StateTree) {
 	// TODO: turn this into a single transfer call.
 	panic("todo")
 }
 
-func treeDepositFunds(inTree StateTree, a actor.Actor, amt actors.TokenAmount) (outTree StateTree) {
+func treeDepositFunds(inTree StateTree, a actor.Actor, amt abi.TokenAmount) (outTree StateTree) {
 	// TODO: turn this into a single transfer call.
 	panic("todo")
 }


### PR DESCRIPTION
Moved shared types out of actors top-level to an `abi` (application binary interface) package. There are many more to come, including proofs and sector info used by more than one actor.

This was an automated refactor performed with find/replace tools. No semantic changes.

~Based on #793~

  
