### PR TITLE
StorageMarket touch up

### DIFF
--- a/src/actors/builtin/storage_miner/storage_miner_actor_code.go
+++ b/src/actors/builtin/storage_miner/storage_miner_actor_code.go
@@ -172,7 +172,7 @@ func (a *StorageMinerActorCode_I) PreCommitSector(rt Runtime, info sector.Sector
 	UpdateRelease(rt, h, st)
 
 	// Request deferred Cron check for PreCommit expiry check.
-	expiryBound := rt.CurrEpoch() + sector.MAX_PROVE_COMMIT_SECTOR_EPOCH + 1
+	expiryBound := rt.CurrEpoch() + node_base.MAX_PROVE_COMMIT_SECTOR_EPOCH + 1
 	a._rtEnrollCronEvent(rt, expiryBound, []sector.SectorNumber{info.SectorNumber()})
 
 	if info.Expiration() <= rt.CurrEpoch() {
@@ -192,8 +192,8 @@ func (a *StorageMinerActorCode_I) ProveCommitSector(rt Runtime, info sector.Sect
 		rt.AbortArgMsg("Sector not valid or not in PreCommit state")
 	}
 
-	if rt.CurrEpoch() > preCommitSector.PreCommitEpoch()+sector.MAX_PROVE_COMMIT_SECTOR_EPOCH {
-		rt.AbortStateMsg("Deadline exceeded for ProveCommitSector")
+	if rt.CurrEpoch() > preCommitSector.PreCommitEpoch()+node_base.MAX_PROVE_COMMIT_SECTOR_EPOCH || rt.CurrEpoch() < preCommitSector.PreCommitEpoch()+node_base.MIN_PROVE_COMMIT_SECTOR_EPOCH {
+		rt.AbortStateMsg("Invalid ProveCommitSector epoch")
 	}
 
 	TODO()
@@ -449,7 +449,7 @@ func (a *StorageMinerActorCode_I) _rtCheckSectorExpiry(rt Runtime, sectorNumber 
 	}
 
 	if checkSector.State() == SectorState_PreCommit {
-		if rt.CurrEpoch()-checkSector.PreCommitEpoch() > sector.MAX_PROVE_COMMIT_SECTOR_EPOCH {
+		if rt.CurrEpoch()-checkSector.PreCommitEpoch() > node_base.MAX_PROVE_COMMIT_SECTOR_EPOCH {
 			a._rtDeleteSectorEntry(rt, sectorNumber)
 			rt.SendFunds(addr.BurntFundsActorAddr, checkSector.PreCommitDeposit())
 		}

--- a/src/systems/filecoin_markets/storage_market/_index.md
+++ b/src/systems/filecoin_markets/storage_market/_index.md
@@ -76,12 +76,11 @@ Execution now moves back to the `StorageClient`
 
 # Publishing
 
-Data is now transferred, both parties have agreed, and it's time for the `StorageProvider` to publish the deal.
+Data is now transferred, both parties have agreed, and it's time to publish the deal. Given that the counter signature on a deal proposal is a standard message signature by the provider and the signed deal is an on-chain message, it is usually the `StorageProvider` that publishes the deal. However, if `StorageProvider` decides to send this signed on-chain message to the client before calling `PublishStorageDeal` then client can publish the deal on chain. Client's funds are not locked until the deal is published and a published deal that is not activated within some window will result in on-chain penalty.
 
 12. First, the `StorageProvider` adds collateral for the deal as needed to the `StorageMarketActor` (using `AddBalance`)
-13. Now, the `StorageProvider` calls `PublishStorageDeals` on the `StorageMarketActor` to publish the deal. It sends the StorageDealProposal signed by the client as well as its own signature in the message to publish the storage deal.
-14. For convenience, the `StorageProvider` responds sends a message to the `StorageClient` on the `Storage Deal Protocol` with the CID of the message it is
-putting on chain
+13. Now, the `StorageProvider` prepares and signs the on-chain `StorageDeal` message with the `StorageDealProposal` signed by the client and its own signature. It can now either send this message back to the client or call `PublishStorageDeals` on the `StorageMarketActor` to publish the deal. It is recommended for `StorageProvider` to send back the signed message before `PublishStorageDeals` is called.
+14. After calling `PublishStorageDeals`, `StorageProvider` sends a message to the `StorageClient` on the `Storage Deal Protocol` with the CID of the message that it is putting on chain for convenience.
 15. If all goes well, the `StorageMarketActor` responds with an on chain `DealID` for the published deal.
 
 

--- a/src/systems/filecoin_markets/storage_market/storage_client.id
+++ b/src/systems/filecoin_markets/storage_market/storage_client.id
@@ -5,10 +5,10 @@ import libp2p "github.com/filecoin-project/specs/libraries/libp2p"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import message "github.com/filecoin-project/specs/systems/filecoin_vm/message"
 
-// ClientDeal is the information about a storage deal that storage client tracks
+// ClientLocalDealInfo is the information about a storage deal that storage client tracks
 // locally about a deal until it goes on chain. It is persisted to local storage
 // and updated as the deal goes through stages leading up to its being published
-type ClientDeal struct {
+type ClientLocalDealInfo struct {
     ProposalCid     &deal.StorageDealProposal
     Proposal        deal.StorageDealProposal
     State           StorageDealStatus
@@ -39,10 +39,10 @@ type StorageClient struct {
 
     // ListInProgressDeals lists deals that are in progress or rejected
     // - but not on chain
-    ListLocalDeals()  (deals [ClientDeal], error)
+    ListLocalDeals()  (deals [ClientLocalDealInfo], error)
 
     // GetInProgressDeal looks up an in progress deal by proposal CID
-    GetInProgressDeal(proposalCID &deal.StorageDealProposal) (ClientDeal, error)
+    GetInProgressDeal(proposalCID &deal.StorageDealProposal) (ClientLocalDealInfo, error)
 
     // GetAsk returns the current ask for a storage provider
     GetAsk(info StorageProviderInfo) (StorageAsk, error)

--- a/src/systems/filecoin_markets/storage_market/storage_provider.id
+++ b/src/systems/filecoin_markets/storage_market/storage_provider.id
@@ -6,11 +6,11 @@ import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address
 import dt "github.com/filecoin-project/specs/systems/filecoin_files/data_transfer"
 import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 
-// MinerDeal is the information that a storage provider tracks locally about
+// ProviderLocalDealInfo is the information that a storage provider tracks locally about
 // a deal. It contains not only the storage proposal but the state of the deal
 // as it moves throught the system. It is persisted to local storage and updated 
 // as the deal goes through stages leading up to its being published (and afterward)
-type MinerDeal struct {
+type ProviderLocalDealInfo struct {
     ProposalCid   &deal.StorageDealProposal
     Proposal      deal.StorageDealProposal
     MinerPeerID   libp2p.PeerID
@@ -34,7 +34,7 @@ type StorageProvider struct {
     ListDeals()            (deals [deal.StorageDeal], error)
 
     // ListIncompleteDeals lists deals that are in progress or rejected
-    ListIncompleteDeals()  (deals [MinerDeal], error)
+    ListIncompleteDeals()  (deals [ProviderLocalDealInfo], error)
 
     // AddStorageCollateral adds storage collateral
     AddStorageCollateral(amount abi.TokenAmount) error

--- a/src/systems/filecoin_mining/sector/sector.go
+++ b/src/systems/filecoin_mining/sector/sector.go
@@ -1,8 +1,6 @@
 package sector
 
 import (
-	abi "github.com/filecoin-project/specs/actors/abi"
-	deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
 	util "github.com/filecoin-project/specs/util"
 )
 
@@ -10,41 +8,8 @@ var IMPL_FINISH = util.IMPL_FINISH
 
 type Serialization = util.Serialization
 
-// If a sector PreCommit appear at epoch T, then the corresponding ProveCommit
-// must appear between epochs
-//   (T + MIN_PROVE_COMMIT_SECTOR_EPOCH, T + MAX_PROVE_COMMIT_SECTOR_EPOCH)
-// inclusive.
-// TODO: placeholder epoch values -- will be set later
-const MIN_PROVE_COMMIT_SECTOR_EPOCH = abi.ChainEpoch(5)
-const MAX_PROVE_COMMIT_SECTOR_EPOCH = abi.ChainEpoch(10)
-
 const (
 	DeclaredFault StorageFaultType = 1 + iota
 	DetectedFault
 	TerminatedFault
 )
-
-func (amt *DealExpirationAMT_I) Size() int {
-	return 0
-}
-
-func (amt *DealExpirationAMT_I) Add(key abi.ChainEpoch, value DealExpirationValue) {
-	// helper function to add entry into the AMT
-}
-
-func (amt *DealExpirationAMT_I) ActiveDealIDs() []deal.DealID {
-	ret := make([]deal.DealID, 0)
-	return ret
-}
-
-// return last item in the expiration amt
-func (q *DealExpirationAMT_I) LastDealExpiration() abi.ChainEpoch {
-	ret := abi.ChainEpoch(0)
-	return ret
-}
-
-// return deal IDs expiring in epoch range
-func (q *DealExpirationAMT_I) ExpiredDealsInRange(start abi.ChainEpoch, end abi.ChainEpoch) []DealExpirationValue {
-	ret := make([]DealExpirationValue, 0)
-	return ret
-}

--- a/src/systems/filecoin_mining/sector/sector.id
+++ b/src/systems/filecoin_mining/sector/sector.id
@@ -1,4 +1,3 @@
-import abi "github.com/filecoin-project/specs/actors/abi"
 import piece "github.com/filecoin-project/specs/systems/filecoin_files/piece"
 import ipld "github.com/filecoin-project/specs/libraries/ipld"
 import deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
@@ -16,18 +15,6 @@ type SectorNumber UInt
 type FaultSet CompactSectorSet
 type StorageFaultType int
 
-// AMT from expiration epoch to dealID and to sectorNumber
-// defined as struct to specify helpers
-// effectively an AMT of the form DealExpirationAMT[Expiration][DealID] = PayloadPower
-type DealExpirationAMT struct {
-    Expiration  abi.ChainEpoch  // key
-    Value       DealExpirationValue  // value
-}
-
-type DealExpirationValue struct {
-    ID     deal.DealID  // key
-    Power  abi.StoragePower  // value
-}
 // SectorSize indicates one of a set of possible sizes in the network.
 type SectorSize UInt
 

--- a/src/systems/filecoin_nodes/node_base/network_params.go
+++ b/src/systems/filecoin_nodes/node_base/network_params.go
@@ -15,8 +15,13 @@ const NETWORK = addr.Address_NetworkID_Testnet
 // Commitment
 /////////////////////////////////////////////////////////////
 
-// TODO: placeholder epoch value -- this will be set later
-const MAX_PROVE_COMMIT_SECTOR_PERIOD = abi.ChainEpoch(3) // placeholder
+// If a sector PreCommit appear at epoch T, then the corresponding ProveCommit
+// must appear between epochs
+//   (T + MIN_PROVE_COMMIT_SECTOR_EPOCH, T + MAX_PROVE_COMMIT_SECTOR_EPOCH)
+// inclusive.
+// TODO: placeholder epoch values -- will be set later
+const MIN_PROVE_COMMIT_SECTOR_EPOCH = abi.ChainEpoch(5)
+const MAX_PROVE_COMMIT_SECTOR_EPOCH = abi.ChainEpoch(10)
 
 /////////////////////////////////////////////////////////////
 // PoSt


### PR DESCRIPTION
Address review comments from #730

> [x] revise https://github.com/filecoin-project/specs/pull/730/files#diff-25a562a0dc3d8403f934f9886041f058R79 to specify either party can publish deal per https://github.com/filecoin-project/specs/pull/730/files#r356798561 and https://github.com/filecoin-project/specs/pull/730#discussion_r360664478

done
> [x] Rename `ClientDeal` to less confusing name per https://github.com/filecoin-project/specs/pull/730/files#r360664529

renamed both `ClientDeal` and `MinerDeal` to `ClientLocalDealInfo` and `ProviderLocalDealInfo`
> [ ] resolve https://github.com/filecoin-project/specs/pull/730/files#r360613740 and workerID caching in light of new libraries enabling worker addr lookups from actor IDs.

this is local info for convenience, dont think we need to resolve
> [ ] Ensure start/endEpoch for deals and proposals is consistent across spec per https://github.com/filecoin-project/specs/pull/730/files#r360663613

this is related to #731, will resolve in a separate PR, thank you @hannahhoward for the tracking issue! will need some brief discussion but should be relatively uncontroversial
> [x] fix relevant `IPLD.CID` inclusions to disambiguate where possible per https://github.com/filecoin-project/specs/pull/730#discussion_r357044532

this has been fixed in 730
> [x] DealExpirationAMT removal consequence per https://github.com/filecoin-project/specs/pull/730#discussion_r360664788

removed