### PR TITLE
simplified surprise post randomness generation

### DIFF
--- a/src/systems/filecoin_blockchain/struct/block/block.id
+++ b/src/systems/filecoin_blockchain/struct/block/block.id
@@ -49,13 +49,13 @@ type Block struct {
     SECPMessages  [msg.SignedMessage]
 }
 
-// HACK: Duplicated from posting.id (actual source)
+// HACK: All of the below was duplicated from posting.id
+// in order to get spec to compile. Check the actual source for details
 type ElectionPoStVerifyInfo struct {
     Candidates  [PoStCandidate]
-    Randomness  PoStRandomness
     Proof       PoStProof
+    Randomness  PoStRandomness
 }
-
 type ChallengeTicketsCommitment struct {}  // see sector
 type PoStCandidate struct {}  // see sector
 type PoStRandomness struct {}  // see sector

--- a/src/systems/filecoin_blockchain/struct/block_producer/block_producer.id
+++ b/src/systems/filecoin_blockchain/struct/block_producer/block_producer.id
@@ -11,7 +11,7 @@ type BlockProducer struct {
     // and then get back the messages and call AssembleBlock
     // TODO minerAddr is of type StorageMiner.Address
     GenerateBlock(
-        ePoStInfo  sector.OnChainPoStVerifyInfo
+        ePoStInfo  sector.OnChainElectionPoStVerifyInfo
         newTicket  block.Ticket
         chainHead  chain.Tipset
         minerAddr  addr.Address
@@ -19,7 +19,7 @@ type BlockProducer struct {
 
     // call by BlockProducer itself after getting back messages
     AssembleBlock(
-        ePoStInfo  sector.OnChainPoStVerifyInfo
+        ePoStInfo  sector.OnChainElectionPoStVerifyInfo
         T0         block.Ticket
         tipset     chain.Tipset
         minerAddr  addr.Address

--- a/src/systems/filecoin_mining/sector/posting.id
+++ b/src/systems/filecoin_mining/sector/posting.id
@@ -30,11 +30,22 @@ type PoStCandidate struct {
     ChallengeIndex  UInt
 }
 
-type OnChainPoStVerifyInfo struct {
-    CommT       ChallengeTicketsCommitment  // Optional — only needed for SurprisePoSt.
+// implemented by both OnChainElectionPoStVerifyInfo and OnChainSurprisePoStVerifyInfo
+type OnChainPoStVerifyInfo interface {
+    Candidates()  [PoStCandidate]
+    Proof()       PoStProof
+}
+
+type OnChainElectionPoStVerifyInfo struct {
     Candidates  [PoStCandidate]
-    Randomness  PoStRandomness
     Proof       PoStProof
+    Randomness  PoStRandomness
+}
+
+type OnChainSurprisePoStVerifyInfo struct {
+    Candidates  [PoStCandidate]
+    Proof       PoStProof
+    CommT       ChallengeTicketsCommitment
 }
 
 type PoStWitness struct {

--- a/src/systems/filecoin_mining/storage_mining/storage_mining_subsystem.id
+++ b/src/systems/filecoin_mining/storage_mining/storage_mining_subsystem.id
@@ -71,22 +71,22 @@ type StorageMiningSubsystem struct {
     OnNewRound()
 
     _runMiningCycle()
-    _tryLeaderElection(st stateTree.StateTree, sma sminact.StorageMinerActorState) sector.OnChainPoStVerifyInfo
+    _tryLeaderElection(st stateTree.StateTree, sma sminact.StorageMinerActorState) sector.OnChainElectionPoStVerifyInfo
     _trySurprisePoSt(st stateTree.StateTree, sma sminact.StorageMinerActorState) error
     _submitSurprisePoStMessage(
         state     stateTree.StateTree
-        sPoSt     sector.OnChainPoStVerifyInfo
+        sPoSt     sector.OnChainSurprisePoStVerifyInfo
         gasPrice  abi.TokenAmount
         gasLimit  msg.GasAmount
     ) error
 
     VerifyElectionPoSt(
         header       block.BlockHeader
-        onChainInfo  sector.OnChainPoStVerifyInfo
+        onChainInfo  sector.OnChainElectionPoStVerifyInfo
     ) bool
 
     _verifyElection(
         header       block.BlockHeader
-        onChainInfo  sector.OnChainPoStVerifyInfo
+        onChainInfo  sector.OnChainElectionPoStVerifyInfo
     ) bool
 }


### PR DESCRIPTION
**In this PR:**
- Simplified SurprisePoSt randomness generation to not use VRF
- accordingly removed randomness from on-chain footprint for SurprisePoSt

the above necessitated splitting the `OnChainPoStVerifyInfo` for ePoSt and sPoSt. I'll note two things for @porcuquine to opine on:
- Do we need to include the round from which randomness was drawn for the surprise PoSt in the `OnChainSurprisePoStVerifyInfo`? It is already on chain in the actor code, but maybe it makes sense to have it there since it is needed for verif (so while we can get it elsewhere, maybe we shouldn't).
- It seems to me like the interface of `PoStVerifyInfo` potentially duplicates the `Randomness` field in the case of `OnChainElectionPoStVerifyInfo` (specifically randomness is both present in `Randomness` and `OnChain.Randomness`). I think that's fine. Just FYI.