### PR TITLE
Move all piece, sector, and proof types used on-chain into the actors abi.

### DIFF
--- a/src/actors/abi/deal.go
+++ b/src/actors/abi/deal.go
@@ -1,0 +1,6 @@
+package abi
+
+type DealID int64
+type DealIDs struct {
+	Items []DealID
+}

--- a/src/actors/abi/piece.go
+++ b/src/actors/abi/piece.go
@@ -1,0 +1,39 @@
+package abi
+
+import (
+	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+)
+
+// PieceCID is the main reference to pieces in Filecoin. It is the CID of the piece.
+type PieceCID cid.Cid
+
+func (c PieceCID) Bytes() []byte {
+	return cid.Cid(c).Bytes()
+}
+
+func PieceCIDOf(data []byte) PieceCID {
+	b := cid.V1Builder{Codec: cid.DagCBOR, MhType: mh.SHA2_256}
+	c, err := b.Sum(data)
+	assertNoError(err)
+	return PieceCID(c)
+}
+
+// PieceSize is the size of a piece, in bytes
+type PieceSize struct {
+	PayloadSize  int64
+	OverheadSize int64
+}
+
+func (p PieceSize) Total() int64 {
+	return p.PayloadSize + p.OverheadSize
+}
+
+type PieceInfo struct {
+	Size     int64 // Size in nodes. For BLS12-381 (capacity 254 bits), must be >= 16. (16 * 8 = 128)
+	PieceCID PieceCID
+}
+
+type PieceInfos struct {
+	Items []PieceInfo
+}

--- a/src/actors/abi/primitives.go
+++ b/src/actors/abi/primitives.go
@@ -14,6 +14,10 @@ type ChainEpoch int64
 // or, in the future, a CID of VM bytecode for a user-defined actor).
 type ActorCodeID cid.Cid
 
+// ActorID is a sequential number assigned to actors in the state tree.
+// ActorIDs are assigned by the InitActor when an actor is created.
+type ActorID int64
+
 // MethodNum is an integer that represents a particular method
 // in an actor's function table. These numbers are used to compress
 // invocation of actor code, and to decouple human language concerns
@@ -47,13 +51,3 @@ type RandomnessSeed []byte
 
 // Randomness is a string of random bytes
 type Randomness []byte
-
-// The unit of storage power (measured in bytes)
-type StoragePower int64 // TODO bigint
-
-// The unit of sector weight (power-epochs)
-type SectorWeight int64 // TODO bigint
-
-// ActorID is a sequential number assigned to actors in the state tree.
-// ActorIDs are assigned by the InitActor when an actor is created.
-type ActorID int64

--- a/src/actors/abi/sector.go
+++ b/src/actors/abi/sector.go
@@ -1,0 +1,138 @@
+package abi
+
+import (
+	cid "github.com/ipfs/go-cid"
+)
+
+// SectorNumber is a numeric identifier for a sector. It is usually relative to a miner.
+type SectorNumber int64
+
+// SectorSize indicates one of a set of possible sizes in the network.
+// Ideally, SectorSize would be an enum
+// type SectorSize enum {
+//   1KiB = 1024
+//   1MiB = 1048576
+//   1GiB = 1073741824
+//   1TiB = 1099511627776
+//   1PiB = 1125899906842624
+// }
+type SectorSize int64
+
+// TODO make sure this is globally unique
+type SectorID struct {
+	Miner  ActorID
+	Number SectorNumber
+}
+
+// The unit of sector weight (power-epochs)
+type SectorWeight int64 // TODO bigint
+
+// The unit of storage power (measured in bytes)
+type StoragePower int64 // TODO bigint
+
+type UnsealedSectorCID cid.Cid // CommD
+type SealedSectorCID cid.Cid   // CommR
+
+// This ordering, defines mappings to UInt in a way which MUST never change.
+type RegisteredProof int64
+
+const (
+	RegisteredProof_WinStackedDRG32GiBSeal = RegisteredProof(1)
+	RegisteredProof_WinStackedDRG32GiBPoSt = RegisteredProof(2)
+	RegisteredProof_StackedDRG32GiBSeal    = RegisteredProof(3)
+	RegisteredProof_StackedDRG32GiBPoSt    = RegisteredProof(4)
+)
+
+///
+/// Sealing
+///
+
+type SealRandomness Bytes
+type InteractiveSealRandomness Bytes
+
+// SealVerifyInfo is the structure of all the information a verifier
+// needs to verify a Seal.
+type SealVerifyInfo struct {
+	SectorID
+	OnChain               OnChainSealVerifyInfo
+	Randomness            SealRandomness
+	InteractiveRandomness InteractiveSealRandomness
+	UnsealedCID           UnsealedSectorCID // CommD
+}
+
+// OnChainSealVerifyInfo is the structure of information that must be sent with
+// a message to commit a sector. Most of this information is not needed in the
+// state tree but will be verified in sm.CommitSector. See SealCommitment for
+// data stored on the state tree for each sector.
+type OnChainSealVerifyInfo struct {
+	SealedCID        SealedSectorCID // CommR
+	SealEpoch        ChainEpoch
+	InteractiveEpoch ChainEpoch
+	RegisteredProof
+	Proof   SealProof
+	DealIDs DealIDs
+	SectorNumber
+
+	//IsValidAtSealEpoch()  bool
+}
+
+type SealProof struct { //<curve, system> {
+	ProofBytes Bytes
+}
+
+///
+/// PoSting
+///
+
+type ChallengeTicketsCommitment Bytes
+type PoStRandomness Bytes
+type PartialTicket []byte // 32 bytes
+
+// TODO: refactor these types to get rid of the squishy optional fields.
+type PoStVerifyInfo struct {
+	Randomness      PoStRandomness
+	CommR           SealedSectorCID
+	Candidates      []PoStCandidate              // From OnChain*PoStVerifyInfo
+	Proofs          []PoStProof                  // From OnChain*PoStVerifyInfo
+	EligibleSectors map[SectorID]SealedSectorCID // TODO: HAMT?
+}
+
+type OnChainElectionPoStVerifyInfo struct {
+	// There should be one RegisteredProof for each PoSt Candidate
+	RegisteredProofs []RegisteredProof
+	Candidates       []PoStCandidate
+	Proofs           []PoStProof
+	Randomness       PoStRandomness
+}
+
+type OnChainSurprisePoStVerifyInfo struct {
+	RegisteredProof
+	Candidates []PoStCandidate
+	Proofs     []PoStProof
+	CommT      ChallengeTicketsCommitment
+}
+
+type PoStCandidate struct {
+	PartialTicket  PartialTicket             // Optional —  will eventually be omitted for SurprisePoSt verification, needed for now.
+	PrivateProof   PrivatePoStCandidateProof // Optional — should be ommitted for verification.
+	SectorID       SectorID
+	ChallengeIndex int64
+}
+
+type PoStProof struct { //<curve, system> {
+	ProofBytes Bytes
+}
+
+type PrivatePoStCandidateProof struct {
+	Algorithm    ProofAlgorithm
+	Externalized Bytes
+}
+
+type ProofAlgorithm int64
+
+const (
+	ProofAlgorithm_StackedDRGSeal    = ProofAlgorithm(1)
+	ProofAlgorithm_WinStackedDRGSeal = ProofAlgorithm(2)
+	ProofAlgorithm_StackedDRGPoSt    = ProofAlgorithm(3)
+	ProofAlgorithm_WinStackedDRGPoSt = ProofAlgorithm(4)
+)

--- a/src/actors/abi/util.go
+++ b/src/actors/abi/util.go
@@ -1,0 +1,7 @@
+package abi
+
+func assertNoError(e error) {
+	if e != nil {
+		panic(e.Error())
+	}
+}

--- a/src/actors/builtin/storage_market/storage_market_actor.id
+++ b/src/actors/builtin/storage_market/storage_market_actor.id
@@ -2,9 +2,9 @@ import abi "github.com/filecoin-project/specs/actors/abi"
 import actor_util "github.com/filecoin-project/specs/actors/util"
 import addr "github.com/filecoin-project/go-address"
 import deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
-import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
+import sminer "github.com/filecoin-project/specs/actors/builtin/storage_miner"
 
-type DealsAMT {deal.DealID: deal.OnChainDeal}
+type DealsAMT {abi.DealID: deal.OnChainDeal}
 type DealWeight deal.DealWeight
 
 type CachedDealIDsByPartyHAMT {addr.Address: actor_util.DealIDSetHAMT}
@@ -21,7 +21,7 @@ type StorageMarketActorState struct {
     // only the _portion_ of the total escrow amount that is locked.
     LockedReqTable                  actor_util.BalanceTableHAMT
 
-    NextID                          deal.DealID
+    NextID                          abi.DealID
 
     // Metadata cached for efficient iteration over deals.
     CachedDealIDsByParty            CachedDealIDsByPartyHAMT
@@ -31,23 +31,23 @@ type StorageMarketActorState struct {
 
     _rtAbortIfAddressEntryDoesNotExist(rt Runtime, entryAddr addr.Address)
     _rtUpdatePendingDealStatesForParty(rt Runtime, addr addr.Address) (amountSlashedTotal abi.TokenAmount)
-    _rtGetOnChainDealOrAbort(rt Runtime, dealID deal.DealID) (deal deal.OnChainDeal, dealP deal.StorageDealProposal)
+    _rtGetOnChainDealOrAbort(rt Runtime, dealID abi.DealID) (deal deal.OnChainDeal, dealP deal.StorageDealProposal)
     _rtLockBalanceOrAbort(rt Runtime, addr addr.Address, amount abi.TokenAmount)
 
-    _updatePendingDealStates(dealIDs [deal.DealID], epoch abi.ChainEpoch) (amountSlashedTotal abi.TokenAmount)
-    _updatePendingDealState(dealID deal.DealID, epoch abi.ChainEpoch) (amountSlashed abi.TokenAmount)
-    _processDealPaymentEpochsElapsed(dealID deal.DealID, numEpochsElapsed abi.ChainEpoch)
-    _processDealSlashed(dealID deal.DealID) (amountSlashed abi.TokenAmount)
-    _processDealInitTimedOut(dealID deal.DealID) (amountSlashed abi.TokenAmount)
-    _processDealExpired(dealID deal.DealID)
-    _generateStorageDealID(storageDeal deal.StorageDeal) deal.DealID
+    _updatePendingDealStates(dealIDs [abi.DealID], epoch abi.ChainEpoch) (amountSlashedTotal abi.TokenAmount)
+    _updatePendingDealState(dealID abi.DealID, epoch abi.ChainEpoch) (amountSlashed abi.TokenAmount)
+    _processDealPaymentEpochsElapsed(dealID abi.DealID, numEpochsElapsed abi.ChainEpoch)
+    _processDealSlashed(dealID abi.DealID) (amountSlashed abi.TokenAmount)
+    _processDealInitTimedOut(dealID abi.DealID) (amountSlashed abi.TokenAmount)
+    _processDealExpired(dealID abi.DealID)
+    _generateStorageDealID(storageDeal deal.StorageDeal) abi.DealID
 
     _getLockedReqBalanceInternal(a addr.Address) abi.TokenAmount
     _lockBalanceMaybe(addr addr.Address, amount abi.TokenAmount) (lockBalanceOK bool)
     _unlockBalance(addr addr.Address, unlockAmountRequested abi.TokenAmount)
 
-    _getOnChainDeal(dealID deal.DealID) (deal deal.OnChainDeal, dealP deal.StorageDealProposal, ok bool)
-    _getOnChainDealAssert(dealID deal.DealID) (deal deal.OnChainDeal, dealP deal.StorageDealProposal)
+    _getOnChainDeal(dealID abi.DealID) (deal deal.OnChainDeal, dealP deal.StorageDealProposal, ok bool)
+    _getOnChainDealAssert(dealID abi.DealID) (deal deal.OnChainDeal, dealP deal.StorageDealProposal)
     _addressEntryExists(address addr.Address) bool
 }
 
@@ -66,28 +66,28 @@ type StorageMarketActorCode struct {
     // Verify that a given set of storage deals is valid for a sector currently being PreCommitted.
     VerifyDealsOnSectorPreCommit(
         rt          Runtime
-        dealIDs     deal.DealIDs
-        sectorInfo  sector.SectorPreCommitInfo
+        dealIDs     abi.DealIDs
+        sectorInfo  sminer.SectorPreCommitInfo
     )
 
     // Verify that a given set of storage deals is valid for a sector currently being ProveCommitted,
     // and update the market's internal state accordingly.
     UpdateDealsOnSectorProveCommit(
         rt          Runtime
-        dealIDs     deal.DealIDs
-        sectorInfo  sector.SectorProveCommitInfo
+        dealIDs     abi.DealIDs
+        sectorInfo  sminer.SectorProveCommitInfo
     )
 
     // Get the weight for a given set of storage deals.
     // The weight is defined as the sum, over all deals in the set, of the product of its size
     // with its duration. This quantity may be an input into the functions specifying block reward,
     // sector power, collateral, and/or other parameters.
-    GetWeightForDealSet(rt Runtime, dealIDs deal.DealIDs) DealWeight
+    GetWeightForDealSet(rt Runtime, dealIDs abi.DealIDs) DealWeight
 
     // Terminate a set of deals in response to their containing sector being terminated.
     // Slash provider collateral, refund client collateral, and refund partial unpaid escrow
     // amount to client.
-    TerminateDealsOnSlashProviderSector(rt Runtime, dealIDs deal.DealIDs)
+    TerminateDealsOnSlashProviderSector(rt Runtime, dealIDs abi.DealIDs)
 
     // Should be registered with CronActor to be called at the end of each EpochTick iteration.
     // Processes any deals that have expired, as well as any deals for which the timeout

--- a/src/actors/builtin/storage_market/storage_market_actor_state.go
+++ b/src/actors/builtin/storage_market/storage_market_actor_state.go
@@ -16,7 +16,7 @@ const epochUndefined = abi.ChainEpoch(-1)
 // Deal state operations
 ////////////////////////////////////////////////////////////////////////////////
 
-func (st *StorageMarketActorState_I) _updatePendingDealStates(dealIDs []deal.DealID, epoch abi.ChainEpoch) (
+func (st *StorageMarketActorState_I) _updatePendingDealStates(dealIDs []abi.DealID, epoch abi.ChainEpoch) (
 	amountSlashedTotal abi.TokenAmount) {
 
 	IMPL_FINISH() // BigInt arithmetic
@@ -30,7 +30,7 @@ func (st *StorageMarketActorState_I) _updatePendingDealStates(dealIDs []deal.Dea
 	return
 }
 
-func (st *StorageMarketActorState_I) _updatePendingDealState(dealID deal.DealID, epoch abi.ChainEpoch) (
+func (st *StorageMarketActorState_I) _updatePendingDealState(dealID abi.DealID, epoch abi.ChainEpoch) (
 	amountSlashed abi.TokenAmount) {
 
 	IMPL_FINISH() // BigInt arithmetic
@@ -89,7 +89,7 @@ func (st *StorageMarketActorState_I) _updatePendingDealState(dealID deal.DealID,
 	return
 }
 
-func (st *StorageMarketActorState_I) _deleteDeal(dealID deal.DealID) {
+func (st *StorageMarketActorState_I) _deleteDeal(dealID abi.DealID) {
 	_, dealP := st._getOnChainDealAssert(dealID)
 	delete(st.Deals(), dealID)
 	delete(st.CachedDealIDsByParty()[dealP.Provider()], dealID)
@@ -97,7 +97,7 @@ func (st *StorageMarketActorState_I) _deleteDeal(dealID deal.DealID) {
 }
 
 // Note: only processes deal payments, not deal expiration (even if the deal has expired).
-func (st *StorageMarketActorState_I) _processDealPaymentEpochsElapsed(dealID deal.DealID, numEpochsElapsed abi.ChainEpoch) {
+func (st *StorageMarketActorState_I) _processDealPaymentEpochsElapsed(dealID abi.DealID, numEpochsElapsed abi.ChainEpoch) {
 	deal, dealP := st._getOnChainDealAssert(dealID)
 	Assert(deal.SectorStartEpoch() != epochUndefined)
 
@@ -107,7 +107,7 @@ func (st *StorageMarketActorState_I) _processDealPaymentEpochsElapsed(dealID dea
 	st._transferBalance(dealP.Client(), dealP.Provider(), abi.TokenAmount(totalPayment))
 }
 
-func (st *StorageMarketActorState_I) _processDealSlashed(dealID deal.DealID) (amountSlashed abi.TokenAmount) {
+func (st *StorageMarketActorState_I) _processDealSlashed(dealID abi.DealID) (amountSlashed abi.TokenAmount) {
 	deal, dealP := st._getOnChainDealAssert(dealID)
 	Assert(deal.SectorStartEpoch() != epochUndefined)
 
@@ -130,7 +130,7 @@ func (st *StorageMarketActorState_I) _processDealSlashed(dealID deal.DealID) (am
 // Deal start deadline elapsed without appearing in a proven sector.
 // Delete deal, slash a portion of provider's collateral, and unlock remaining collaterals
 // for both provider and client.
-func (st *StorageMarketActorState_I) _processDealInitTimedOut(dealID deal.DealID) (amountSlashed abi.TokenAmount) {
+func (st *StorageMarketActorState_I) _processDealInitTimedOut(dealID abi.DealID) (amountSlashed abi.TokenAmount) {
 	deal, dealP := st._getOnChainDealAssert(dealID)
 	Assert(deal.SectorStartEpoch() == epochUndefined)
 
@@ -147,7 +147,7 @@ func (st *StorageMarketActorState_I) _processDealInitTimedOut(dealID deal.DealID
 }
 
 // Normal expiration. Delete deal and unlock collaterals for both miner and client.
-func (st *StorageMarketActorState_I) _processDealExpired(dealID deal.DealID) {
+func (st *StorageMarketActorState_I) _processDealExpired(dealID abi.DealID) {
 	deal, dealP := st._getOnChainDealAssert(dealID)
 	Assert(deal.SectorStartEpoch() != epochUndefined)
 
@@ -158,9 +158,9 @@ func (st *StorageMarketActorState_I) _processDealExpired(dealID deal.DealID) {
 	st._deleteDeal(dealID)
 }
 
-func (st *StorageMarketActorState_I) _generateStorageDealID(storageDeal deal.StorageDeal) deal.DealID {
+func (st *StorageMarketActorState_I) _generateStorageDealID(storageDeal deal.StorageDeal) abi.DealID {
 	ret := st.NextID()
-	st.NextID_ = st.NextID_ + deal.DealID(1)
+	st.NextID_ = st.NextID_ + abi.DealID(1)
 	return ret
 }
 
@@ -306,7 +306,7 @@ func _dealGetPaymentRemaining(deal deal.OnChainDeal, epoch abi.ChainEpoch) abi.T
 	return abi.TokenAmount(int(durationRemaining) * int(dealP.StoragePricePerEpoch()))
 }
 
-func (st *StorageMarketActorState_I) _getOnChainDeal(dealID deal.DealID) (
+func (st *StorageMarketActorState_I) _getOnChainDeal(dealID abi.DealID) (
 	deal deal.OnChainDeal, dealP deal.StorageDealProposal, ok bool) {
 
 	var found bool
@@ -320,7 +320,7 @@ func (st *StorageMarketActorState_I) _getOnChainDeal(dealID deal.DealID) (
 	return
 }
 
-func (st *StorageMarketActorState_I) _getOnChainDealAssert(dealID deal.DealID) (
+func (st *StorageMarketActorState_I) _getOnChainDealAssert(dealID abi.DealID) (
 	deal deal.OnChainDeal, dealP deal.StorageDealProposal) {
 
 	var ok bool

--- a/src/actors/builtin/storage_miner/storage_miner_actor.id
+++ b/src/actors/builtin/storage_miner/storage_miner_actor.id
@@ -1,10 +1,7 @@
 import abi "github.com/filecoin-project/specs/actors/abi"
 import autil "github.com/filecoin-project/specs/actors/util"
 import address "github.com/filecoin-project/go-address"
-import deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
 import filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
-import sealing "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
-import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 import peer "github.com/libp2p/go-libp2p-core/peer"
 
 type MinerPoStState union {
@@ -18,7 +15,7 @@ type MinerPoStState union {
     // and as a result, the system has fallen back to proving storage via SurprisePoSt.
     Challenged struct {
         SurpriseChallengeEpoch  abi.ChainEpoch
-        ChallengedSectors       [sector.SectorNumber]
+        ChallengedSectors       [abi.SectorNumber]
         NumConsecutiveFailures  int
     }
 
@@ -39,7 +36,7 @@ type SectorState enum {
 
 type SectorOnChainInfo struct {
     State                       SectorState
-    Info                        sealing.SectorPreCommitInfo  // Also contains Expiration field.
+    Info                        SectorPreCommitInfo  // Also contains Expiration field.
     PreCommitDeposit            abi.TokenAmount
     PreCommitEpoch              abi.ChainEpoch
     ActivationEpoch             abi.ChainEpoch  // -1 if still in PreCommit state.
@@ -55,9 +52,25 @@ type SectorOnChainInfo struct {
     Is_TemporaryFault()         bool
 }
 
-type SectorsAMT {sector.SectorNumber: SectorOnChainInfo}
+type SectorPreCommitInfo struct {
+    SectorNumber  abi.SectorNumber
+    SealedCID     abi.SealedSectorCID  // CommR
+    SealEpoch     abi.ChainEpoch
+    DealIDs       abi.DealIDs
+    Expiration    abi.ChainEpoch
+}
 
-type SectorNumberSetHAMT {sector.SectorNumber: bool}
+type SectorProveCommitInfo struct {
+    SectorNumber      abi.SectorNumber
+    RegisteredProof   abi.RegisteredProof
+    Proof             abi.SealProof
+    InteractiveEpoch  abi.ChainEpoch
+    Expiration        abi.ChainEpoch
+}
+
+type SectorsAMT {abi.SectorNumber: SectorOnChainInfo}
+
+type SectorNumberSetHAMT {abi.SectorNumber: bool}
 
 // Balance of a StorageMinerActor should equal exactly the sum of PreCommit deposits
 // that are not yet returned or burned.
@@ -67,13 +80,13 @@ type StorageMinerActorState struct {
     ProvingSet  SectorNumberSetHAMT
     Info        MinerInfo
 
-    GetStorageWeightDescForSectorMaybe(sectorNumber sector.SectorNumber) (ret autil.SectorStorageWeightDesc, ok bool)
-    _getStorageWeightDescForSector(sectorNumber sector.SectorNumber) autil.SectorStorageWeightDesc
-    _getStorageWeightDescsForSectors(sectorNumbers [sector.SectorNumber]) [autil.SectorStorageWeightDesc]
+    GetStorageWeightDescForSectorMaybe(sectorNumber abi.SectorNumber) (ret autil.SectorStorageWeightDesc, ok bool)
+    _getStorageWeightDescForSector(sectorNumber abi.SectorNumber) autil.SectorStorageWeightDesc
+    _getStorageWeightDescsForSectors(sectorNumbers [abi.SectorNumber]) [autil.SectorStorageWeightDesc]
 
-    _getSectorDealIDsAssert(sectorNumber sector.SectorNumber) deal.DealIDs
+    _getSectorDealIDsAssert(sectorNumber abi.SectorNumber) abi.DealIDs
 
-    VerifySurprisePoStMeetsTargetReq(candidate sector.PoStCandidate) bool
+    VerifySurprisePoStMeetsTargetReq(candidate abi.PoStCandidate) bool
 }
 
 type StorageMinerActorCode struct {
@@ -98,7 +111,7 @@ type MinerInfo struct {
     PeerId                  peer.ID
 
     // Amount of space in each sector committed to the network by this miner.
-    SectorSize              sector.SectorSize
+    SectorSize              abi.SectorSize
     SealPartitions          UVarint
     ElectionPoStPartitions  UVarint
     SurprisePoStPartitions  UVarint

--- a/src/actors/builtin/storage_miner/storage_miner_actor_code.go
+++ b/src/actors/builtin/storage_miner/storage_miner_actor_code.go
@@ -11,8 +11,6 @@ import (
 	serde "github.com/filecoin-project/specs/actors/serde"
 	autil "github.com/filecoin-project/specs/actors/util"
 	filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
-	deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
-	sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 	node_base "github.com/filecoin-project/specs/systems/filecoin_nodes/node_base"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 )
@@ -66,11 +64,11 @@ func (a *StorageMinerActorCode_I) OnSurprisePoStChallenge(rt Runtime) {
 
 	// Request deferred Cron check for SurprisePoSt challenge expiry.
 	provingPeriod := indices.StorageMining_SurprisePoStProvingPeriod()
-	a._rtEnrollCronEvent(rt, rt.CurrEpoch()+provingPeriod, []sector.SectorNumber{})
+	a._rtEnrollCronEvent(rt, rt.CurrEpoch()+provingPeriod, []abi.SectorNumber{})
 }
 
 // Invoked by miner's worker address to submit a response to a pending SurprisePoSt challenge.
-func (a *StorageMinerActorCode_I) SubmitSurprisePoStResponse(rt Runtime, onChainInfo sector.OnChainSurprisePoStVerifyInfo) {
+func (a *StorageMinerActorCode_I) SubmitSurprisePoStResponse(rt Runtime, onChainInfo abi.OnChainSurprisePoStVerifyInfo) {
 	h, st := a.State(rt)
 	rt.ValidateImmediateCallerIs(st.Info().Worker())
 
@@ -80,7 +78,7 @@ func (a *StorageMinerActorCode_I) SubmitSurprisePoStResponse(rt Runtime, onChain
 
 	Release(rt, h, st)
 
-	a._rtVerifySurprisePoStOrAbort(rt, onChainInfo)
+	a._rtVerifySurprisePoStOrAbort(rt, &onChainInfo)
 	a._rtUpdatePoStState(rt, MinerPoStState_New_OK(rt.CurrEpoch()))
 
 	rt.Send(
@@ -126,7 +124,7 @@ func (a *StorageMinerActorCode_I) OnVerifiedElectionPoSt(rt Runtime) {
 
 // Deals must be posted on chain via sma.PublishStorageDeals before PreCommitSector.
 // Optimization: PreCommitSector could contain a list of deals that are not published yet.
-func (a *StorageMinerActorCode_I) PreCommitSector(rt Runtime, info sector.SectorPreCommitInfo) {
+func (a *StorageMinerActorCode_I) PreCommitSector(rt Runtime, info SectorPreCommitInfo) {
 	h, st := a.State(rt)
 	rt.ValidateImmediateCallerIs(st.Info().Worker())
 
@@ -167,16 +165,16 @@ func (a *StorageMinerActorCode_I) PreCommitSector(rt Runtime, info sector.Sector
 
 	// Request deferred Cron check for PreCommit expiry check.
 	expiryBound := rt.CurrEpoch() + node_base.MAX_PROVE_COMMIT_SECTOR_EPOCH + 1
-	a._rtEnrollCronEvent(rt, expiryBound, []sector.SectorNumber{info.SectorNumber()})
+	a._rtEnrollCronEvent(rt, expiryBound, []abi.SectorNumber{info.SectorNumber()})
 
 	if info.Expiration() <= rt.CurrEpoch() {
 		rt.AbortArgMsg("PreCommit sector must have positive lifetime")
 	}
 
-	a._rtEnrollCronEvent(rt, info.Expiration(), []sector.SectorNumber{info.SectorNumber()})
+	a._rtEnrollCronEvent(rt, info.Expiration(), []abi.SectorNumber{info.SectorNumber()})
 }
 
-func (a *StorageMinerActorCode_I) ProveCommitSector(rt Runtime, info sector.SectorProveCommitInfo) {
+func (a *StorageMinerActorCode_I) ProveCommitSector(rt Runtime, info SectorProveCommitInfo) {
 	h, st := a.State(rt)
 	workerAddr := st.Info().Worker()
 	rt.ValidateImmediateCallerIs(workerAddr)
@@ -194,14 +192,14 @@ func (a *StorageMinerActorCode_I) ProveCommitSector(rt Runtime, info sector.Sect
 	// TODO: How are SealEpoch, InteractiveEpoch determined (and intended to be used)?
 	// Presumably they cannot be derived from the SectorProveCommitInfo provided by an untrusted party.
 
-	a._rtVerifySealOrAbort(rt, &sector.OnChainSealVerifyInfo_I{
-		SealedCID_:        preCommitSector.Info().SealedCID(),
-		SealEpoch_:        preCommitSector.Info().SealEpoch(),
-		InteractiveEpoch_: info.InteractiveEpoch(),
-		RegisteredProof_:  info.RegisteredProof(),
-		Proof_:            info.Proof(),
-		DealIDs_:          preCommitSector.Info().DealIDs(),
-		SectorNumber_:     preCommitSector.Info().SectorNumber(),
+	a._rtVerifySealOrAbort(rt, &abi.OnChainSealVerifyInfo{
+		SealedCID:        preCommitSector.Info().SealedCID(),
+		SealEpoch:        preCommitSector.Info().SealEpoch(),
+		InteractiveEpoch: info.InteractiveEpoch(),
+		RegisteredProof:  info.RegisteredProof(),
+		Proof:            info.Proof(),
+		DealIDs:          preCommitSector.Info().DealIDs(),
+		SectorNumber:     preCommitSector.Info().SectorNumber(),
 	})
 
 	UpdateRelease(rt, h, st)
@@ -244,7 +242,7 @@ func (a *StorageMinerActorCode_I) ProveCommitSector(rt Runtime, info sector.Sect
 
 	// Request deferred Cron check for sector expiry.
 	a._rtEnrollCronEvent(
-		rt, preCommitSector.Info().Expiration(), []sector.SectorNumber{info.SectorNumber()})
+		rt, preCommitSector.Info().Expiration(), []abi.SectorNumber{info.SectorNumber()})
 
 	// Notify SPA to update power associated to newly activated sector.
 	storageWeightDesc := a._rtGetStorageWeightDescForSector(rt, info.SectorNumber())
@@ -265,7 +263,7 @@ func (a *StorageMinerActorCode_I) ProveCommitSector(rt Runtime, info sector.Sect
 // Sector Modification //
 /////////////////////////
 
-func (a *StorageMinerActorCode_I) ExtendSectorExpiration(rt Runtime, sectorNumber sector.SectorNumber, newExpiration abi.ChainEpoch) {
+func (a *StorageMinerActorCode_I) ExtendSectorExpiration(rt Runtime, sectorNumber abi.SectorNumber, newExpiration abi.ChainEpoch) {
 	storageWeightDescPrev := a._rtGetStorageWeightDescForSector(rt, sectorNumber)
 
 	h, st := a.State(rt)
@@ -299,7 +297,7 @@ func (a *StorageMinerActorCode_I) ExtendSectorExpiration(rt Runtime, sectorNumbe
 	)
 }
 
-func (a *StorageMinerActorCode_I) TerminateSector(rt Runtime, sectorNumber sector.SectorNumber) {
+func (a *StorageMinerActorCode_I) TerminateSector(rt Runtime, sectorNumber abi.SectorNumber) {
 	h, st := a.State(rt)
 	rt.ValidateImmediateCallerIs(st.Info().Worker())
 	Release(rt, h, st)
@@ -311,7 +309,7 @@ func (a *StorageMinerActorCode_I) TerminateSector(rt Runtime, sectorNumber secto
 // Faults //
 ////////////
 
-func (a *StorageMinerActorCode_I) DeclareTemporaryFaults(rt Runtime, sectorNumbers []sector.SectorNumber, duration abi.ChainEpoch) {
+func (a *StorageMinerActorCode_I) DeclareTemporaryFaults(rt Runtime, sectorNumbers []abi.SectorNumber, duration abi.ChainEpoch) {
 	if duration <= abi.ChainEpoch(0) {
 		rt.AbortArgMsg("Temporary fault duration must be positive")
 	}
@@ -351,7 +349,7 @@ func (a *StorageMinerActorCode_I) DeclareTemporaryFaults(rt Runtime, sectorNumbe
 // Cron //
 //////////
 
-func (a *StorageMinerActorCode_I) OnDeferredCronEvent(rt Runtime, sectorNumbers []sector.SectorNumber) {
+func (a *StorageMinerActorCode_I) OnDeferredCronEvent(rt Runtime, sectorNumbers []abi.SectorNumber) {
 	rt.ValidateImmediateCallerIs(builtin.StoragePowerActorAddr)
 
 	for _, sectorNumber := range sectorNumbers {
@@ -367,7 +365,7 @@ func (a *StorageMinerActorCode_I) OnDeferredCronEvent(rt Runtime, sectorNumbers 
 /////////////////
 
 func (a *StorageMinerActorCode_I) Constructor(
-	rt Runtime, ownerAddr addr.Address, workerAddr addr.Address, sectorSize sector.SectorSize, peerId peer.ID) {
+	rt Runtime, ownerAddr addr.Address, workerAddr addr.Address, sectorSize abi.SectorSize, peerId peer.ID) {
 
 	rt.ValidateImmediateCallerIs(builtin.StoragePowerActorAddr)
 	h := rt.AcquireState()
@@ -386,7 +384,7 @@ func (a *StorageMinerActorCode_I) Constructor(
 // Method utility functions
 ////////////////////////////////////////////////////////////////////////////////
 
-func (a *StorageMinerActorCode_I) _rtCheckTemporaryFaultEvents(rt Runtime, sectorNumber sector.SectorNumber) {
+func (a *StorageMinerActorCode_I) _rtCheckTemporaryFaultEvents(rt Runtime, sectorNumber abi.SectorNumber) {
 	h, st := a.State(rt)
 	checkSector, found := st.Sectors()[sectorNumber]
 	Release(rt, h, st)
@@ -434,7 +432,7 @@ func (a *StorageMinerActorCode_I) _rtCheckTemporaryFaultEvents(rt Runtime, secto
 	UpdateRelease(rt, h, st)
 }
 
-func (a *StorageMinerActorCode_I) _rtCheckSectorExpiry(rt Runtime, sectorNumber sector.SectorNumber) {
+func (a *StorageMinerActorCode_I) _rtCheckSectorExpiry(rt Runtime, sectorNumber abi.SectorNumber) {
 	h, st := a.State(rt)
 	checkSector, found := st.Sectors()[sectorNumber]
 	Release(rt, h, st)
@@ -458,7 +456,7 @@ func (a *StorageMinerActorCode_I) _rtCheckSectorExpiry(rt Runtime, sectorNumber 
 	}
 }
 
-func (a *StorageMinerActorCode_I) _rtTerminateSector(rt Runtime, sectorNumber sector.SectorNumber, terminationType SectorTerminationType) {
+func (a *StorageMinerActorCode_I) _rtTerminateSector(rt Runtime, sectorNumber abi.SectorNumber, terminationType SectorTerminationType) {
 	h, st := a.State(rt)
 	checkSector, found := st.Sectors()[sectorNumber]
 	Assert(found)
@@ -518,7 +516,7 @@ func (a *StorageMinerActorCode_I) _rtCheckSurprisePoStExpiry(rt Runtime) {
 	if numConsecutiveFailures > indices.StoragePower_SurprisePoStMaxConsecutiveFailures() {
 		// Terminate all sectors, notify power and market actors to terminate
 		// associated storage deals, and reset miner's PoSt state to OK.
-		terminatedSectors := []sector.SectorNumber{}
+		terminatedSectors := []abi.SectorNumber{}
 		for sectorNumber := range st.Sectors() {
 			terminatedSectors = append(terminatedSectors, sectorNumber)
 		}
@@ -540,7 +538,7 @@ func (a *StorageMinerActorCode_I) _rtCheckSurprisePoStExpiry(rt Runtime) {
 }
 
 func (a *StorageMinerActorCode_I) _rtEnrollCronEvent(
-	rt Runtime, eventEpoch abi.ChainEpoch, sectorNumbers []sector.SectorNumber) {
+	rt Runtime, eventEpoch abi.ChainEpoch, sectorNumbers []abi.SectorNumber) {
 
 	rt.Send(
 		builtin.StoragePowerActorAddr,
@@ -553,7 +551,7 @@ func (a *StorageMinerActorCode_I) _rtEnrollCronEvent(
 	)
 }
 
-func (a *StorageMinerActorCode_I) _rtDeleteSectorEntry(rt Runtime, sectorNumber sector.SectorNumber) {
+func (a *StorageMinerActorCode_I) _rtDeleteSectorEntry(rt Runtime, sectorNumber abi.SectorNumber) {
 	h, st := a.State(rt)
 	delete(st.Sectors(), sectorNumber)
 	UpdateRelease(rt, h, st)
@@ -566,7 +564,7 @@ func (a *StorageMinerActorCode_I) _rtUpdatePoStState(rt Runtime, state MinerPoSt
 }
 
 func (a *StorageMinerActorCode_I) _rtGetStorageWeightDescForSector(
-	rt Runtime, sectorNumber sector.SectorNumber) autil.SectorStorageWeightDesc {
+	rt Runtime, sectorNumber abi.SectorNumber) autil.SectorStorageWeightDesc {
 
 	h, st := a.State(rt)
 	ret := st._getStorageWeightDescForSector(sectorNumber)
@@ -575,7 +573,7 @@ func (a *StorageMinerActorCode_I) _rtGetStorageWeightDescForSector(
 }
 
 func (a *StorageMinerActorCode_I) _rtGetStorageWeightDescsForSectors(
-	rt Runtime, sectorNumbers []sector.SectorNumber) []autil.SectorStorageWeightDesc {
+	rt Runtime, sectorNumbers []abi.SectorNumber) []autil.SectorStorageWeightDesc {
 
 	h, st := a.State(rt)
 	ret := st._getStorageWeightDescsForSectors(sectorNumbers)
@@ -583,13 +581,13 @@ func (a *StorageMinerActorCode_I) _rtGetStorageWeightDescsForSectors(
 	return ret
 }
 
-func (a *StorageMinerActorCode_I) _rtNotifyMarketForTerminatedSectors(rt Runtime, sectorNumbers []sector.SectorNumber) {
+func (a *StorageMinerActorCode_I) _rtNotifyMarketForTerminatedSectors(rt Runtime, sectorNumbers []abi.SectorNumber) {
 	h, st := a.State(rt)
-	dealIDItems := []deal.DealID{}
+	dealIDItems := []abi.DealID{}
 	for _, sectorNo := range sectorNumbers {
-		dealIDItems = append(dealIDItems, st._getSectorDealIDsAssert(sectorNo).Items()...)
+		dealIDItems = append(dealIDItems, st._getSectorDealIDsAssert(sectorNo).Items...)
 	}
-	dealIDs := &deal.DealIDs_I{Items_: dealIDItems}
+	dealIDs := &abi.DealIDs{Items: dealIDItems}
 
 	Release(rt, h, st)
 
@@ -603,7 +601,7 @@ func (a *StorageMinerActorCode_I) _rtNotifyMarketForTerminatedSectors(rt Runtime
 	)
 }
 
-func (a *StorageMinerActorCode_I) _rtVerifySurprisePoStOrAbort(rt Runtime, onChainInfo sector.OnChainSurprisePoStVerifyInfo) {
+func (a *StorageMinerActorCode_I) _rtVerifySurprisePoStOrAbort(rt Runtime, onChainInfo *abi.OnChainSurprisePoStVerifyInfo) {
 	h, st := a.State(rt)
 	Assert(st.PoStState().Is_Challenged())
 	sectorSize := st.Info().SectorSize()
@@ -611,12 +609,12 @@ func (a *StorageMinerActorCode_I) _rtVerifySurprisePoStOrAbort(rt Runtime, onCha
 	challengedSectors := st.PoStState().As_Challenged().ChallengedSectors()
 
 	// verify no duplicate tickets
-	challengeIndices := make(map[uint64]bool)
-	for _, tix := range onChainInfo.Candidates() {
-		if _, ok := challengeIndices[tix.ChallengeIndex()]; ok {
+	challengeIndices := make(map[int64]bool)
+	for _, tix := range onChainInfo.Candidates {
+		if _, ok := challengeIndices[tix.ChallengeIndex]; ok {
 			rt.AbortStateMsg("Invalid Surprise PoSt. Duplicate ticket included.")
 		}
-		challengeIndices[tix.ChallengeIndex()] = true
+		challengeIndices[tix.ChallengeIndex] = true
 	}
 
 	TODO(challengedSectors)
@@ -638,45 +636,47 @@ func (a *StorageMinerActorCode_I) _rtVerifySurprisePoStOrAbort(rt Runtime, onCha
 
 	// Get public inputs
 
-	pvInfo := sector.PoStVerifyInfo_I{
-		OnChain_:    onChainInfo,
-		Randomness_: sector.PoStRandomness(postRandomness),
+	pvInfo := abi.PoStVerifyInfo{
+		Candidates: onChainInfo.Candidates,
+		Proofs:     onChainInfo.Proofs,
+		Randomness: abi.PoStRandomness(postRandomness),
 		// EligibleSectors_: FIXME: verification needs these.
 	}
 
 	// Verify the PoSt Proof
-	isVerified := rt.Syscalls().VerifyPoSt(sectorSize, &pvInfo)
+	isVerified := rt.Syscalls().VerifyPoSt(sectorSize, pvInfo)
 
 	if !isVerified {
 		rt.AbortStateMsg("Surprise PoSt failed to verify")
 	}
 }
 
-func (a *StorageMinerActorCode_I) _rtVerifySealOrAbort(rt Runtime, onChainInfo sector.OnChainSealVerifyInfo) {
+func (a *StorageMinerActorCode_I) _rtVerifySealOrAbort(rt Runtime, onChainInfo *abi.OnChainSealVerifyInfo) {
 	h, st := a.State(rt)
 	info := st.Info()
 	sectorSize := info.SectorSize()
 	Release(rt, h, st)
 
-	pieceInfos, err := sector.Deserialize_PieceInfos(rt.SendQuery(
+	var pieceInfos abi.PieceInfos
+	err := serde.Deserialize(rt.SendQuery(
 		builtin.StorageMarketActorAddr,
 		builtin.Method_StorageMarketActor_GetPieceInfosForDealIDs,
 		serde.MustSerializeParams(
 			sectorSize,
-			onChainInfo.DealIDs(),
+			onChainInfo.DealIDs,
 		),
-	))
+	), &pieceInfos)
 	Assert(err == nil)
 
 	// Unless we enforce a minimum padding amount, this totalPieceSize calculation can be removed.
 	// Leaving for now until that decision is entirely finalized.
-	var totalPieceSize uint64
-	for _, pieceInfo := range pieceInfos.Items() {
-		pieceSize := pieceInfo.Size()
+	var totalPieceSize int64
+	for _, pieceInfo := range pieceInfos.Items {
+		pieceSize := pieceInfo.Size
 		totalPieceSize += pieceSize
 	}
 
-	unsealedCID, err := rt.Syscalls().ComputeUnsealedSectorCID(sectorSize, pieceInfos.Items())
+	unsealedCID, err := rt.Syscalls().ComputeUnsealedSectorCID(sectorSize, pieceInfos.Items)
 	if err != nil {
 		rt.AbortStateMsg("invalid sector piece infos")
 	}
@@ -690,26 +690,26 @@ func (a *StorageMinerActorCode_I) _rtVerifySealOrAbort(rt Runtime, onChainInfo s
 	var svInfoRandomness abi.Randomness
 	var svInfoInteractiveRandomness abi.Randomness
 
-	svInfo := sector.SealVerifyInfo_I{
-		SectorID_: &sector.SectorID_I{
-			Miner_:  abi.ActorID(minerActorID),
-			Number_: onChainInfo.SectorNumber(),
+	svInfo := abi.SealVerifyInfo{
+		SectorID: abi.SectorID{
+			Miner:  abi.ActorID(minerActorID),
+			Number: onChainInfo.SectorNumber,
 		},
-		OnChain_:               onChainInfo,
-		Randomness_:            sector.SealRandomness(svInfoRandomness),
-		InteractiveRandomness_: sector.InteractiveSealRandomness(svInfoInteractiveRandomness),
-		UnsealedCID_:           unsealedCID,
+		OnChain:               *onChainInfo,
+		Randomness:            abi.SealRandomness(svInfoRandomness),
+		InteractiveRandomness: abi.InteractiveSealRandomness(svInfoInteractiveRandomness),
+		UnsealedCID:           unsealedCID,
 	}
 
-	isVerified := rt.Syscalls().VerifySeal(sectorSize, &svInfo)
+	isVerified := rt.Syscalls().VerifySeal(sectorSize, svInfo)
 
 	if !isVerified {
 		rt.AbortStateMsg("Sector seal failed to verify")
 	}
 }
 
-func getSectorNums(m map[sector.SectorNumber]SectorOnChainInfo) []sector.SectorNumber {
-	var l []sector.SectorNumber
+func getSectorNums(m map[abi.SectorNumber]SectorOnChainInfo) []abi.SectorNumber {
+	var l []abi.SectorNumber
 	for i, _ := range m {
 		l = append(l, i)
 	}
@@ -717,7 +717,7 @@ func getSectorNums(m map[sector.SectorNumber]SectorOnChainInfo) []sector.SectorN
 }
 
 func _surprisePoStSampleChallengedSectors(
-	sampleRandomness abi.Randomness, provingSet []sector.SectorNumber) []sector.SectorNumber {
+	sampleRandomness abi.Randomness, provingSet []abi.SectorNumber) []abi.SectorNumber {
 
 	IMPL_TODO()
 	panic("")

--- a/src/actors/builtin/storage_miner/storage_miner_actor_state.go
+++ b/src/actors/builtin/storage_miner/storage_miner_actor_state.go
@@ -5,12 +5,10 @@ import (
 	abi "github.com/filecoin-project/specs/actors/abi"
 	indices "github.com/filecoin-project/specs/actors/runtime/indices"
 	actor_util "github.com/filecoin-project/specs/actors/util"
-	deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
-	sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 )
 
-func (st *StorageMinerActorState_I) _getSectorOnChainInfo(sectorNo sector.SectorNumber) (info SectorOnChainInfo, ok bool) {
+func (st *StorageMinerActorState_I) _getSectorOnChainInfo(sectorNo abi.SectorNumber) (info SectorOnChainInfo, ok bool) {
 	sectorInfo, found := st.Sectors()[sectorNo]
 	if !found {
 		return nil, false
@@ -18,7 +16,7 @@ func (st *StorageMinerActorState_I) _getSectorOnChainInfo(sectorNo sector.Sector
 	return sectorInfo, true
 }
 
-func (st *StorageMinerActorState_I) _getSectorDealIDsAssert(sectorNo sector.SectorNumber) deal.DealIDs {
+func (st *StorageMinerActorState_I) _getSectorDealIDsAssert(sectorNo abi.SectorNumber) abi.DealIDs {
 	sectorInfo, found := st._getSectorOnChainInfo(sectorNo)
 	Assert(found)
 	return sectorInfo.Info().DealIDs()
@@ -34,7 +32,7 @@ func SectorNumberSetHAMT_Empty() SectorNumberSetHAMT {
 	panic("")
 }
 
-func (st *StorageMinerActorState_I) GetStorageWeightDescForSectorMaybe(sectorNumber sector.SectorNumber) (ret SectorStorageWeightDesc, ok bool) {
+func (st *StorageMinerActorState_I) GetStorageWeightDescForSectorMaybe(sectorNumber abi.SectorNumber) (ret SectorStorageWeightDesc, ok bool) {
 	sectorInfo, found := st.Sectors()[sectorNumber]
 	if !found {
 		ret = nil
@@ -51,13 +49,13 @@ func (st *StorageMinerActorState_I) GetStorageWeightDescForSectorMaybe(sectorNum
 	return
 }
 
-func (st *StorageMinerActorState_I) _getStorageWeightDescForSector(sectorNumber sector.SectorNumber) SectorStorageWeightDesc {
+func (st *StorageMinerActorState_I) _getStorageWeightDescForSector(sectorNumber abi.SectorNumber) SectorStorageWeightDesc {
 	ret, found := st.GetStorageWeightDescForSectorMaybe(sectorNumber)
 	Assert(found)
 	return ret
 }
 
-func (st *StorageMinerActorState_I) _getStorageWeightDescsForSectors(sectorNumbers []sector.SectorNumber) []SectorStorageWeightDesc {
+func (st *StorageMinerActorState_I) _getStorageWeightDescsForSectors(sectorNumbers []abi.SectorNumber) []SectorStorageWeightDesc {
 	ret := []SectorStorageWeightDesc{}
 	for _, sectorNumber := range sectorNumbers {
 		ret = append(ret, st._getStorageWeightDescForSector(sectorNumber))
@@ -73,7 +71,7 @@ func MinerPoStState_New_OK(lastSuccessfulPoSt abi.ChainEpoch) MinerPoStState {
 
 func MinerPoStState_New_Challenged(
 	surpriseChallengeEpoch abi.ChainEpoch,
-	challengedSectors []sector.SectorNumber,
+	challengedSectors []abi.SectorNumber,
 	numConsecutiveFailures int,
 ) MinerPoStState {
 	return MinerPoStState_Make_Challenged(&MinerPoStState_Challenged_I{
@@ -109,7 +107,7 @@ func (x *SectorOnChainInfo_I) EffectiveFaultEndEpoch() abi.ChainEpoch {
 }
 
 func MinerInfo_New(
-	ownerAddr addr.Address, workerAddr addr.Address, sectorSize sector.SectorSize, peerId peer.ID) MinerInfo {
+	ownerAddr addr.Address, workerAddr addr.Address, sectorSize abi.SectorSize, peerId peer.ID) MinerInfo {
 
 	ret := &MinerInfo_I{
 		Owner_:      ownerAddr,
@@ -123,13 +121,13 @@ func MinerInfo_New(
 	return ret
 }
 
-func (st *StorageMinerActorState_I) VerifySurprisePoStMeetsTargetReq(candidate sector.PoStCandidate) bool {
+func (st *StorageMinerActorState_I) VerifySurprisePoStMeetsTargetReq(candidate abi.PoStCandidate) bool {
 	// TODO: Determine what should be the acceptance criterion for sector numbers proven in SurprisePoSt proofs.
 	TODO()
 	panic("")
 }
 
-func SectorNumberSetHAMT_Items(x SectorNumberSetHAMT) []sector.SectorNumber {
+func SectorNumberSetHAMT_Items(x SectorNumberSetHAMT) []abi.SectorNumber {
 	IMPL_FINISH()
 	panic("")
 }

--- a/src/actors/builtin/storage_power/storage_power_actor_code.go
+++ b/src/actors/builtin/storage_power/storage_power_actor_code.go
@@ -11,7 +11,6 @@ import (
 	serde "github.com/filecoin-project/specs/actors/serde"
 	autil "github.com/filecoin-project/specs/actors/util"
 	filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
-	sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 )
 
@@ -63,7 +62,7 @@ func (a *StoragePowerActorCode_I) WithdrawBalance(rt Runtime, minerAddr addr.Add
 	rt.SendFunds(recipientAddr, amountExtracted)
 }
 
-func (a *StoragePowerActorCode_I) CreateMiner(rt Runtime, workerAddr addr.Address, sectorSize sector.SectorSize, peerId peer.ID) addr.Address {
+func (a *StoragePowerActorCode_I) CreateMiner(rt Runtime, workerAddr addr.Address, sectorSize abi.SectorSize, peerId peer.ID) addr.Address {
 	vmr.RT_ValidateImmediateCallerIsSignable(rt)
 	ownerAddr := rt.ImmediateCaller()
 
@@ -189,7 +188,7 @@ func (a *StoragePowerActorCode_I) OnMinerSurprisePoStFailure(rt Runtime, numCons
 	}
 }
 
-func (a *StoragePowerActorCode_I) OnMinerEnrollCronEvent(rt Runtime, eventEpoch abi.ChainEpoch, sectorNumbers []sector.SectorNumber) {
+func (a *StoragePowerActorCode_I) OnMinerEnrollCronEvent(rt Runtime, eventEpoch abi.ChainEpoch, sectorNumbers []abi.SectorNumber) {
 	rt.ValidateImmediateCallerAcceptAnyOfType(builtin.StorageMinerActorCodeID)
 	minerAddr := rt.ImmediateCaller()
 	minerEvent := &autil.MinerEvent_I{

--- a/src/actors/runtime/indices/indices.go
+++ b/src/actors/runtime/indices/indices.go
@@ -4,6 +4,7 @@ import (
 	abi "github.com/filecoin-project/specs/actors/abi"
 	actor_util "github.com/filecoin-project/specs/actors/util"
 	deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
+	"math/big"
 )
 
 var PARAM_FINISH = actor_util.PARAM_FINISH
@@ -76,13 +77,13 @@ func (inds *Indices_I) PledgeCollateralReq(minerNominalPower abi.StoragePower) a
 	panic("")
 }
 
-func (inds *Indices_I) SectorWeightProportion(minerActiveSectorWeight abi.SectorWeight) abi.SectorWeight {
+func (inds *Indices_I) SectorWeightProportion(minerActiveSectorWeight abi.SectorWeight) big.Int {
 	// return proportion of SectorWeight for miner
 	PARAM_FINISH()
 	panic("")
 }
 
-func (inds *Indices_I) PledgeCollateralProportion(minerPledgeCollateral abi.TokenAmount) abi.TokenAmount {
+func (inds *Indices_I) PledgeCollateralProportion(minerPledgeCollateral abi.TokenAmount) big.Int {
 	// return proportion of Pledge Collateral for miner
 	PARAM_FINISH()
 	panic("")
@@ -101,7 +102,7 @@ func (inds *Indices_I) StoragePower(
 
 func (inds *Indices_I) StoragePowerProportion(
 	minerStoragePower abi.StoragePower,
-) abi.StoragePower {
+) big.Int {
 	PARAM_FINISH()
 	panic("")
 }

--- a/src/actors/runtime/indices/indices.go
+++ b/src/actors/runtime/indices/indices.go
@@ -3,13 +3,10 @@ package indices
 import (
 	abi "github.com/filecoin-project/specs/actors/abi"
 	actor_util "github.com/filecoin-project/specs/actors/util"
-	piece "github.com/filecoin-project/specs/systems/filecoin_files/piece"
 	deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
-	sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
-	util "github.com/filecoin-project/specs/util"
 )
 
-var PARAM_FINISH = util.PARAM_FINISH
+var PARAM_FINISH = actor_util.PARAM_FINISH
 
 func StorageDeal_ProviderInitTimedOutSlashAmount(deal deal.OnChainDeal) abi.TokenAmount {
 	// placeholder
@@ -18,7 +15,7 @@ func StorageDeal_ProviderInitTimedOutSlashAmount(deal deal.OnChainDeal) abi.Toke
 }
 
 func (inds *Indices_I) StorageDeal_DurationBounds(
-	pieceSize piece.PieceSize,
+	pieceSize abi.PieceSize,
 	startEpoch abi.ChainEpoch,
 ) (minDuration abi.ChainEpoch, maxDuration abi.ChainEpoch) {
 
@@ -30,7 +27,7 @@ func (inds *Indices_I) StorageDeal_DurationBounds(
 }
 
 func (inds *Indices_I) StorageDeal_StoragePricePerEpochBounds(
-	pieceSize piece.PieceSize,
+	pieceSize abi.PieceSize,
 	startEpoch abi.ChainEpoch,
 	endEpoch abi.ChainEpoch,
 ) (minPrice abi.TokenAmount, maxPrice abi.TokenAmount) {
@@ -41,7 +38,7 @@ func (inds *Indices_I) StorageDeal_StoragePricePerEpochBounds(
 }
 
 func (inds *Indices_I) StorageDeal_ProviderCollateralBounds(
-	pieceSize piece.PieceSize,
+	pieceSize abi.PieceSize,
 	startEpoch abi.ChainEpoch,
 	endEpoch abi.ChainEpoch,
 ) (minProviderCollateral abi.TokenAmount, maxProviderCollateral abi.TokenAmount) {
@@ -52,7 +49,7 @@ func (inds *Indices_I) StorageDeal_ProviderCollateralBounds(
 }
 
 func (inds *Indices_I) StorageDeal_ClientCollateralBounds(
-	pieceSize piece.PieceSize,
+	pieceSize abi.PieceSize,
 	startEpoch abi.ChainEpoch,
 	endEpoch abi.ChainEpoch,
 ) (minClientCollateral abi.TokenAmount, maxClientCollateral abi.TokenAmount) {
@@ -63,7 +60,7 @@ func (inds *Indices_I) StorageDeal_ClientCollateralBounds(
 }
 
 func (inds *Indices_I) SectorWeight(
-	sectorSize sector.SectorSize,
+	sectorSize abi.SectorSize,
 	startEpoch abi.ChainEpoch,
 	endEpoch abi.ChainEpoch,
 	dealWeight deal.DealWeight,
@@ -79,13 +76,13 @@ func (inds *Indices_I) PledgeCollateralReq(minerNominalPower abi.StoragePower) a
 	panic("")
 }
 
-func (inds *Indices_I) SectorWeightProportion(minerActiveSectorWeight abi.SectorWeight) util.BigInt {
+func (inds *Indices_I) SectorWeightProportion(minerActiveSectorWeight abi.SectorWeight) abi.SectorWeight {
 	// return proportion of SectorWeight for miner
 	PARAM_FINISH()
 	panic("")
 }
 
-func (inds *Indices_I) PledgeCollateralProportion(minerPledgeCollateral abi.TokenAmount) util.BigInt {
+func (inds *Indices_I) PledgeCollateralProportion(minerPledgeCollateral abi.TokenAmount) abi.TokenAmount {
 	// return proportion of Pledge Collateral for miner
 	PARAM_FINISH()
 	panic("")
@@ -104,7 +101,7 @@ func (inds *Indices_I) StoragePower(
 
 func (inds *Indices_I) StoragePowerProportion(
 	minerStoragePower abi.StoragePower,
-) util.BigInt {
+) abi.StoragePower {
 	PARAM_FINISH()
 	panic("")
 }
@@ -145,7 +142,7 @@ func (inds *Indices_I) StoragePower_PledgeSlashForSurprisePoStFailure(
 }
 
 func (inds *Indices_I) StorageMining_PreCommitDeposit(
-	sectorSize sector.SectorSize,
+	sectorSize abi.SectorSize,
 	expirationEpoch abi.ChainEpoch,
 ) abi.TokenAmount {
 	PARAM_FINISH()

--- a/src/actors/runtime/indices/indices.id
+++ b/src/actors/runtime/indices/indices.id
@@ -1,7 +1,5 @@
 import abi "github.com/filecoin-project/specs/actors/abi"
 import actor_util "github.com/filecoin-project/specs/actors/util"
-import piece "github.com/filecoin-project/specs/systems/filecoin_files/piece"
-import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 import deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
 
 // Data in Indices are populated at instantiation with data from the state tree
@@ -27,18 +25,18 @@ type Indices struct {
     StorageDeal_ProviderInitTimedOutSlashAmount(deal deal.OnChainDeal) abi.TokenAmount
 
     StorageDeal_DurationBounds(
-        pieceSize   piece.PieceSize
+        pieceSize   abi.PieceSize
         startEpoch  abi.ChainEpoch
     ) (minDuration abi.ChainEpoch, maxDuration abi.ChainEpoch)
 
     StorageDeal_StoragePricePerEpochBounds(
-        pieceSize   piece.PieceSize
+        pieceSize   abi.PieceSize
         startEpoch  abi.ChainEpoch
         endEpoch    abi.ChainEpoch
     ) (minPrice abi.TokenAmount, maxPrice abi.TokenAmount)
 
     StorageDeal_ProviderCollateralBounds(
-        pieceSize   piece.PieceSize
+        pieceSize   abi.PieceSize
         startEpoch  abi.ChainEpoch
         endEpoch    abi.ChainEpoch
     ) (
@@ -47,7 +45,7 @@ type Indices struct {
     )
 
     StorageDeal_ClientCollateralBounds(
-        pieceSize   piece.PieceSize
+        pieceSize   abi.PieceSize
         startEpoch  abi.ChainEpoch
         endEpoch    abi.ChainEpoch
     ) (
@@ -56,7 +54,7 @@ type Indices struct {
     )
 
     SectorWeight(
-        sectorSize  sector.SectorSize
+        sectorSize  abi.SectorSize
         startEpoch  abi.ChainEpoch
         endEpoch    abi.ChainEpoch
         dealWeight  deal.DealWeight
@@ -92,7 +90,7 @@ type Indices struct {
     ) abi.TokenAmount
 
     StorageMining_PreCommitDeposit(
-        sectorSize       sector.SectorSize
+        sectorSize       abi.SectorSize
         expirationEpoch  abi.ChainEpoch
     ) abi.TokenAmount
 

--- a/src/actors/runtime/runtime.id
+++ b/src/actors/runtime/runtime.id
@@ -4,7 +4,6 @@ import exitcode "github.com/filecoin-project/specs/actors/runtime/exitcode"
 import addr "github.com/filecoin-project/go-address"
 import indices "github.com/filecoin-project/specs/actors/runtime/indices"
 import ipld "github.com/filecoin-project/specs/libraries/ipld"
-import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 import cid "github.com/ipfs/go-cid"
 
 // Runtime is the VM's internal runtime object.
@@ -126,11 +125,11 @@ type Syscalls interface {
     // Verifies that a signature is valid for an address and plaintext.
     VerifySignature(signature [byte], signer addr.Address, plaintext [byte]) bool
     // Computes an unsealed sector CID (CommD) from its constituent piece CIDs (CommPs) and sizes.
-    ComputeUnsealedSectorCID(sectorSize sector.SectorSize, pieces [sector.PieceInfo]) (sector.UnsealedSectorCID, error)
+    ComputeUnsealedSectorCID(sectorSize abi.SectorSize, pieces [abi.PieceInfo]) (abi.UnsealedSectorCID, error)
     // Verifies a sector seal proof.
-    VerifySeal(sectorSize sector.SectorSize, vi sector.SealVerifyInfo) bool
+    VerifySeal(sectorSize abi.SectorSize, vi abi.SealVerifyInfo) bool
     // Verifies a proof of spacetime.
-    VerifyPoSt(sectorSize sector.SectorSize, vi sector.PoStVerifyInfo) bool
+    VerifyPoSt(sectorSize abi.SectorSize, vi abi.PoStVerifyInfo) bool
 }
 
 type InvocInput struct {

--- a/src/actors/runtime/runtime_util.go
+++ b/src/actors/runtime/runtime_util.go
@@ -8,7 +8,6 @@ import (
 	builtin "github.com/filecoin-project/specs/actors/builtin"
 	autil "github.com/filecoin-project/specs/actors/util"
 	filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
-	ai "github.com/filecoin-project/specs/systems/filecoin_vm/actor_interfaces"
 )
 
 // TODO: most of this file doesn't need to be part of runtime, just generic actor shared code.

--- a/src/actors/runtime/runtime_util.go
+++ b/src/actors/runtime/runtime_util.go
@@ -6,16 +6,15 @@ import (
 	addr "github.com/filecoin-project/go-address"
 	abi "github.com/filecoin-project/specs/actors/abi"
 	builtin "github.com/filecoin-project/specs/actors/builtin"
+	autil "github.com/filecoin-project/specs/actors/util"
 	filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
-	util "github.com/filecoin-project/specs/util"
+	ai "github.com/filecoin-project/specs/systems/filecoin_vm/actor_interfaces"
 )
 
 // TODO: most of this file doesn't need to be part of runtime, just generic actor shared code.
 
-var Assert = util.Assert
-var IMPL_TODO = util.IMPL_TODO
-
-type Any = util.Any
+var Assert = autil.Assert
+var IMPL_TODO = autil.IMPL_TODO
 
 // Name should be set per unique filecoin network
 var Name = "mainnet"
@@ -77,7 +76,7 @@ func InvocInput_Make(to addr.Address, method abi.MethodNum, params abi.MethodPar
 	}
 }
 
-func InvocOutput_Make(returnValue util.Bytes) InvocOutput {
+func InvocOutput_Make(returnValue []byte) InvocOutput {
 	return &InvocOutput_I{
 		ReturnValue_: returnValue,
 	}
@@ -100,12 +99,12 @@ func RT_GetMinerAccountsAssert(rt Runtime, minerAddr addr.Address) (ownerAddr ad
 	raw := rt.SendQuery(minerAddr, builtin.Method_StorageMinerActor_GetOwnerAddr, nil)
 	r := bytes.NewReader(raw)
 	err := ownerAddr.UnmarshalCBOR(r)
-	util.Assert(err == nil)
+	autil.AssertNoError(err)
 
 	raw = rt.SendQuery(minerAddr, builtin.Method_StorageMinerActor_GetWorkerAddr, nil)
 	r = bytes.NewReader(raw)
 	err = workerAddr.UnmarshalCBOR(r)
-	util.Assert(err == nil)
+	autil.AssertNoError(err)
 
 	return
 }
@@ -137,6 +136,6 @@ func RT_ConfirmFundsReceiptOrAbort_RefundRemainder(rt Runtime, fundsRequired abi
 }
 
 func RT_VerifySignature(rt Runtime, pk filcrypto.PublicKey, sig filcrypto.Signature, m filcrypto.Message) bool {
-	ret := rt.Compute(ComputeFunctionID_VerifySignature, []Any{pk, sig, m})
+	ret := rt.Compute(ComputeFunctionID_VerifySignature, []interface{}{pk, sig, m})
 	return ret.(bool)
 }

--- a/src/actors/util/actor_util.go
+++ b/src/actors/util/actor_util.go
@@ -3,7 +3,6 @@ package util
 import (
 	addr "github.com/filecoin-project/go-address"
 	abi "github.com/filecoin-project/specs/actors/abi"
-	deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
 )
 
 // Create a new entry in the balance table, with the specified initial balance.
@@ -114,17 +113,17 @@ func DealIDQueue_Empty() DealIDQueue {
 	}
 }
 
-func (x *DealIDQueue_I) Enqueue(dealID deal.DealID) {
+func (x *DealIDQueue_I) Enqueue(dealID abi.DealID) {
 	nextIndex := x.EndIndex()
 	x.Values()[nextIndex] = dealID
 	x.EndIndex_ = nextIndex + 1
 }
 
-func (x *DealIDQueue_I) Dequeue() (dealID deal.DealID, ok bool) {
+func (x *DealIDQueue_I) Dequeue() (dealID abi.DealID, ok bool) {
 	AssertMsg(x.StartIndex() <= x.EndIndex(), "index %d > end %d", x.StartIndex(), x.EndIndex())
 
 	if x.StartIndex() == x.EndIndex() {
-		dealID = deal.DealID(-1)
+		dealID = abi.DealID(-1)
 		ok = false
 		return
 	} else {

--- a/src/actors/util/actor_util.id
+++ b/src/actors/util/actor_util.id
@@ -1,20 +1,18 @@
 import abi "github.com/filecoin-project/specs/actors/abi"
 import addr "github.com/filecoin-project/go-address"
-import deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
-import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 
 type BalanceTableHAMT {addr.Address: abi.TokenAmount}
 
-type DealIDSetHAMT {deal.DealID: bool}
-type IntToDealIDHAMT {Int: deal.DealID}
+type DealIDSetHAMT {abi.DealID: bool}
+type IntToDealIDHAMT {Int: abi.DealID}
 
 type DealIDQueue struct {
     Values      IntToDealIDHAMT
     StartIndex  Int
     EndIndex    Int
 
-    Enqueue(dealID deal.DealID)
-    Dequeue() (dealID deal.DealID, ok bool)
+    Enqueue(dealID abi.DealID)
+    Dequeue() (dealID abi.DealID, ok bool)
 }
 
 type MinerSetHAMT {addr.Address: bool}
@@ -23,13 +21,13 @@ type ActorIDSetHAMT {abi.ActorID: bool}
 
 type MinerEvent struct {
     MinerAddr  addr.Address
-    Sectors    [sector.SectorNumber]  // Empty for global events, such as SurprisePoSt expiration.
+    Sectors    [abi.SectorNumber]  // Empty for global events, such as SurprisePoSt expiration.
 }
 
 type MinerEventSetHAMT {MinerEvent: bool}
 
 type SectorStorageWeightDesc struct {
-    SectorSize  sector.SectorSize
+    SectorSize  abi.SectorSize
     Duration    abi.ChainEpoch
     DealWeight  BigInt
 }

--- a/src/actors/util/assert.go
+++ b/src/actors/util/assert.go
@@ -14,6 +14,10 @@ func Assert(b bool) {
 	AssertMsg(b, "assertion failed")
 }
 
+func AssertNoError(e error) {
+	AssertMsg(e == nil, e.Error())
+}
+
 // Indicating behavior not yet specified, and may require other spec changes.
 func TODO(...interface{}) {
 	// Indirection to prevent the compiler from ignoring unreachable code
@@ -29,5 +33,11 @@ func IMPL_TODO(...interface{}) {
 // Version of TODO() indicating that the operation is believed to be unambiguous,
 // but is not yet implemented as code in the spec repository.
 func IMPL_FINISH(...interface{}) {
+	panic("Not yet implemented in the spec")
+}
+
+// Version of TODO() indicating that the operation is believed to be unambiguous,
+// but is not yet implemented as code in the spec repository.
+func PARAM_FINISH(...interface{}) {
 	panic("Not yet implemented in the spec")
 }

--- a/src/actors/util/assert.go
+++ b/src/actors/util/assert.go
@@ -38,6 +38,7 @@ func IMPL_FINISH(...interface{}) {
 
 // Version of TODO() indicating that the operation is believed to be unambiguous,
 // but is not yet implemented as code in the spec repository.
+// Some parameters still need to be set for mainnet and implementations can slot in the parameters when decisions are finalized
 func PARAM_FINISH(...interface{}) {
 	panic("Not yet implemented in the spec")
 }

--- a/src/libraries/filcrypto/filproofs/algorithms.go
+++ b/src/libraries/filcrypto/filproofs/algorithms.go
@@ -12,20 +12,17 @@ import (
 
 	abi "github.com/filecoin-project/specs/actors/abi"
 	file "github.com/filecoin-project/specs/systems/filecoin_files/file"
-	piece "github.com/filecoin-project/specs/systems/filecoin_files/piece"
 	sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 	sector_index "github.com/filecoin-project/specs/systems/filecoin_mining/sector_index"
 	util "github.com/filecoin-project/specs/util"
-	"github.com/ipfs/go-cid"
+	cid "github.com/ipfs/go-cid"
 )
 
 type Bytes32 []byte
 type UInt = util.UInt
-type PieceInfo = sector.PieceInfo
+type PieceInfo = abi.PieceInfo
 type Label Bytes32
 type Commitment = sector.Commitment
-
-type PrivatePostCandidateProof = sector.PrivatePoStCandidateProof
 
 const WRAPPER_LAYER_WINDOW_INDEX = -1
 
@@ -37,7 +34,7 @@ const POST_CHALLENGE_RANGE_SIZE = 1
 
 const GIB_32 = 32 * 1024 * 1024 * 1024
 
-func PoStCfg(pType sector.PoStType, sectorSize sector.SectorSize, partitions UInt) *sector.PoStInstanceCfg_I {
+func PoStCfg(pType sector.PoStType, sectorSize abi.SectorSize, partitions UInt) *sector.PoStInstanceCfg_I {
 	nodes := UInt(sectorSize / NODE_SIZE)
 
 	return sector.PoStInstanceCfg_Make_PoStCfgV1(&sector.PoStCfgV1_I{
@@ -55,11 +52,11 @@ func MakeSealVerifier(cfg sector.SealInstanceCfg) *SealVerifier_I {
 	}
 }
 
-func SurprisePoStCfg(sectorSize sector.SectorSize) *sector.PoStInstanceCfg_I {
+func SurprisePoStCfg(sectorSize abi.SectorSize) *sector.PoStInstanceCfg_I {
 	return PoStCfg(sector.PoStType_SurprisePoSt, sectorSize, SURPRISE_POST_PARTITIONS)
 }
 
-func ElectionPoStCfg(sectorSize sector.SectorSize) *sector.PoStInstanceCfg_I {
+func ElectionPoStCfg(sectorSize abi.SectorSize) *sector.PoStInstanceCfg_I {
 	return PoStCfg(sector.PoStType_ElectionPoSt, sectorSize, ELECTION_POST_PARTITIONS)
 }
 
@@ -163,9 +160,9 @@ func getProverID(minerID abi.ActorID) []byte {
 	panic("TODO")
 }
 
-func computeSealSeed(sid sector.SectorID, randomness sector.SealRandomness, commD sector.UnsealedSectorCID) sector.SealSeed {
-	proverId := getProverID(sid.Miner())
-	sectorNumber := sid.Number()
+func computeSealSeed(sid abi.SectorID, randomness abi.SealRandomness, commD abi.UnsealedSectorCID) sector.SealSeed {
+	proverId := getProverID(sid.Miner)
+	sectorNumber := sid.Number
 
 	var preimage []byte
 	preimage = append(preimage, proverId...)
@@ -435,7 +432,7 @@ func (proof *SDRColumnProof) Verify(root []byte, challenge UInt) bool {
 	return proof.InclusionProof.Verify(root, challenge)
 }
 
-func generateOfflineChallenges(challengeRange int, sealSeed sector.SealSeed, randomness sector.InteractiveSealRandomness, challengeCount int) []UInt {
+func generateOfflineChallenges(challengeRange int, sealSeed sector.SealSeed, randomness abi.InteractiveSealRandomness, challengeCount int) []UInt {
 	var challenges []UInt
 	challengeRangeSize := challengeRange - 1 // Never challenge the first node.
 	challengeModulus := new(big.Int)
@@ -480,15 +477,15 @@ func addEncode(data []byte, key []byte, modulus *big.Int, nodeSize int) []byte {
 ////////////////////////////////////////////////////////////////////////////////
 // Seal Verification
 
-func (sv *SealVerifier_I) VerifySeal(svi sector.SealVerifyInfo) bool {
-	switch svi.OnChain().RegisteredProof() {
-	case sector.RegisteredProof_WinStackedDRG32GiBSeal:
+func (sv *SealVerifier_I) VerifySeal(svi abi.SealVerifyInfo) bool {
+	switch svi.OnChain.RegisteredProof {
+	case abi.RegisteredProof_WinStackedDRG32GiBSeal:
 		{
-			sdr := WinSDRParams(sector.RegisteredProofInstance(svi.OnChain().RegisteredProof()).Cfg().As_SealCfg())
+			sdr := WinSDRParams(sector.RegisteredProofInstance(svi.OnChain.RegisteredProof).Cfg().As_SealCfg())
 
 			return sdr.VerifySeal(svi)
 		}
-	case sector.RegisteredProof_StackedDRG32GiBSeal:
+	case abi.RegisteredProof_StackedDRG32GiBSeal:
 		{
 			panic("TODO")
 		}
@@ -497,15 +494,15 @@ func (sv *SealVerifier_I) VerifySeal(svi sector.SealVerifyInfo) bool {
 	return false
 }
 
-func ComputeUnsealedSectorCIDFromPieceInfos(sectorSize sector.SectorSize, pieceInfos []PieceInfo) (unsealedCID sector.UnsealedSectorCID, err error) {
+func ComputeUnsealedSectorCIDFromPieceInfos(sectorSize abi.SectorSize, pieceInfos []PieceInfo) (unsealedCID abi.UnsealedSectorCID, err error) {
 	rootPieceInfo := computeRootPieceInfo(pieceInfos)
-	rootSize := rootPieceInfo.Size()
+	rootSize := uint64(rootPieceInfo.Size)
 
 	if rootSize != uint64(sectorSize) {
 		return unsealedCID, errors.New("Wrong sector size.")
 	}
 
-	return UnsealedSectorCID(AsBytes_PieceCID(rootPieceInfo.PieceCID())), nil
+	return UnsealedSectorCID(rootPieceInfo.PieceCID.Bytes()), nil
 }
 
 func computeRootPieceInfo(pieceInfos []PieceInfo) PieceInfo {
@@ -530,7 +527,7 @@ func computeRootPieceInfo(pieceInfos []PieceInfo) PieceInfo {
 		return stack[len(stack)-1]
 	}
 	reduce1 := func() bool {
-		if len(stack) > 1 && peek().Size() == peek2().Size() {
+		if len(stack) > 1 && peek().Size == peek2().Size {
 			right := pop()
 			left := pop()
 			joined := joinPieceInfos(left, right)
@@ -553,11 +550,11 @@ func computeRootPieceInfo(pieceInfos []PieceInfo) PieceInfo {
 
 	// Consume the remainder.
 	for _, pieceInfo := range pieceInfos[1:] {
-		// TODO: Assert that pieceInfo.Size() is a power of 2.
+		// TODO: Assert that pieceInfo.Size is a power of 2.
 
 		// Add padding until top of stack is large enough to receive current pieceInfo.
-		for peek().Size() < pieceInfo.Size() {
-			shiftReduce(zeroPadding(peek().Size()))
+		for peek().Size < pieceInfo.Size {
+			shiftReduce(zeroPadding(peek().Size))
 		}
 
 		// Add the current piece.
@@ -566,39 +563,39 @@ func computeRootPieceInfo(pieceInfos []PieceInfo) PieceInfo {
 
 	// Add any necessary final padding.
 	for len(stack) > 1 {
-		shiftReduce(zeroPadding(peek().Size()))
+		shiftReduce(zeroPadding(peek().Size))
 	}
 	util.Assert(len(stack) == 1)
 
 	return pop()
 }
 
-func zeroPadding(size UInt) PieceInfo {
-	return &sector.PieceInfo_I{
-		Size_: size,
+func zeroPadding(size int64) PieceInfo {
+	return abi.PieceInfo{
+		Size: size,
 		// CommP_: FIXME: Implement.
 	}
 }
 
 func joinPieceInfos(left PieceInfo, right PieceInfo) PieceInfo {
-	util.Assert(left.Size() == right.Size())
+	util.Assert(left.Size == right.Size)
 
 	// FIXME: make this whole function generic?
 	// Note: cid.Bytes() isn't actually the payload data that we want input to the binary hash function, for more
 	// information see discussion: https://filecoinproject.slack.com/archives/CHMNDCK9P/p1578629688082700
-	sectorPieceCID, err := cid.Cast(BinaryHash_SHA256Hash(cid.Cid(left.PieceCID()).Bytes(), cid.Cid(right.PieceCID()).Bytes()))
+	sectorPieceCID, err := cid.Cast(BinaryHash_SHA256Hash(cid.Cid(left.PieceCID).Bytes(), cid.Cid(right.PieceCID).Bytes()))
 	util.Assert(err == nil)
 
-	return &sector.PieceInfo_I{
-		Size_:     left.Size() + right.Size(),
-		PieceCID_: piece.PieceCID(sectorPieceCID),
+	return abi.PieceInfo{
+		Size:     left.Size + right.Size,
+		PieceCID: abi.PieceCID(sectorPieceCID),
 	}
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 // PoSt
 
-func getChallengedSectors(cfg sector.PoStInstanceCfg, sectorIDs []sector.SectorID, randomness sector.PoStRandomness, eligibleSectors []sector.SectorID, candidateCount int) (sectors []sector.SectorID) {
+func getChallengedSectors(cfg sector.PoStInstanceCfg, sectorIDs []abi.SectorID, randomness abi.PoStRandomness, eligibleSectors []abi.SectorID, candidateCount int) (sectors []abi.SectorID) {
 	for i := 0; i < candidateCount; i++ {
 		sector := generateSectorChallenge(randomness, i, sectorIDs)
 		sectors = append(sectors, sector)
@@ -607,7 +604,7 @@ func getChallengedSectors(cfg sector.PoStInstanceCfg, sectorIDs []sector.SectorI
 	return sectors
 }
 
-func generateSectorChallenge(randomness sector.PoStRandomness, n int, sectorIDs []sector.SectorID) (sector sector.SectorID) {
+func generateSectorChallenge(randomness abi.PoStRandomness, n int, sectorIDs []abi.SectorID) (sector abi.SectorID) {
 	preimage := append(randomness, littleEndianBytesFromInt(n, 8)...)
 	hash := SHA256Hash(preimage)
 	sectorChallenge := bigIntFromLittleEndianBytes(hash)
@@ -619,7 +616,7 @@ func generateSectorChallenge(randomness sector.PoStRandomness, n int, sectorIDs 
 	return sectorIDs[int(sectorIndex.Uint64())]
 }
 
-func generateLeafChallenge(randomness sector.PoStRandomness, sectorChallengeIndex UInt, leafChallengeIndex int, nodes int, challengeRangeSize int) UInt {
+func generateLeafChallenge(randomness abi.PoStRandomness, sectorChallengeIndex UInt, leafChallengeIndex int, nodes int, challengeRangeSize int) UInt {
 	preimage := append(randomness, littleEndianBytesFromUInt(sectorChallengeIndex, 8)...)
 	preimage = append(preimage, littleEndianBytesFromInt(leafChallengeIndex, 8)...)
 	hash := SHA256Hash(preimage)
@@ -634,39 +631,39 @@ func generateLeafChallenge(randomness sector.PoStRandomness, sectorChallengeInde
 	return leafChallenge.Uint64()
 }
 
-func generateCandidate(algorithm sector.ProofAlgorithm, cfg sector.PoStInstanceCfg, randomness sector.PoStRandomness, aux sector.PersistentProofAux, sectorID sector.SectorID, sectorChallengeIndex UInt) sector.PoStCandidate {
-	var candidate sector.PoStCandidate
+func generateCandidate(algorithm abi.ProofAlgorithm, cfg sector.PoStInstanceCfg, randomness abi.PoStRandomness, aux sector.PersistentProofAux, sectorID abi.SectorID, sectorChallengeIndex UInt) abi.PoStCandidate {
+	var candidate abi.PoStCandidate
 	switch algorithm {
-	case sector.ProofAlgorithm_StackedDRGSeal:
+	case abi.ProofAlgorithm_StackedDRGSeal:
 		panic("TODO")
-	case sector.ProofAlgorithm_WinStackedDRGSeal:
+	case abi.ProofAlgorithm_WinStackedDRGSeal:
 		sdr := WinStackedDRG_I{}
 		candidate = sdr._generateCandidate(cfg, randomness, aux, sectorID, sectorChallengeIndex)
 	}
 	return candidate
 }
 
-func computePartialTicket(randomness sector.PoStRandomness, sectorID sector.SectorID, data []byte) sector.PartialTicket {
+func computePartialTicket(randomness abi.PoStRandomness, sectorID abi.SectorID, data []byte) abi.PartialTicket {
 	preimage := randomness
-	preimage = append(preimage, getProverID(sectorID.Miner())...)
-	preimage = append(preimage, littleEndianBytesFromUInt(UInt(sectorID.Number()), 8)...)
+	preimage = append(preimage, getProverID(sectorID.Miner)...)
+	preimage = append(preimage, littleEndianBytesFromUInt(UInt(sectorID.Number), 8)...)
 	preimage = append(preimage, data...)
-	partialTicket := sector.PartialTicket(HashBytes_PedersenHash(preimage))
+	partialTicket := abi.PartialTicket(HashBytes_PedersenHash(preimage))
 
 	return partialTicket
 }
 
-type PoStCandidatesMap map[sector.ProofAlgorithm][]sector.PoStCandidate
+type PoStCandidatesMap map[abi.ProofAlgorithm][]abi.PoStCandidate
 
-func CreatePoStProof(cfg sector.PoStInstanceCfg, privateCandidateProofs []PrivatePostCandidateProof, challengeSeed sector.PoStRandomness) []sector.PoStProof {
-	var proofsMap map[sector.ProofAlgorithm][]PrivatePostCandidateProof
+func CreatePoStProof(cfg sector.PoStInstanceCfg, privateCandidateProofs []abi.PrivatePoStCandidateProof, challengeSeed abi.PoStRandomness) []abi.PoStProof {
+	var proofsMap map[abi.ProofAlgorithm][]abi.PrivatePoStCandidateProof
 
 	for _, proof := range privateCandidateProofs {
-		algorithm := proof.Algorithm()
+		algorithm := proof.Algorithm
 		proofsMap[algorithm] = append(proofsMap[algorithm], proof)
 	}
 
-	var circuitProofs []sector.PoStProof
+	var circuitProofs []abi.PoStProof
 	for algorithm, proofs := range proofsMap {
 		privateProof := createPrivatePoStProof(algorithm, proofs, challengeSeed)
 		circuitProof := createPoStCircuitProof(cfg, algorithm, privateProof)
@@ -677,12 +674,12 @@ func CreatePoStProof(cfg sector.PoStInstanceCfg, privateCandidateProofs []Privat
 }
 
 type PrivatePoStProof struct {
-	Algorithm       sector.ProofAlgorithm
-	ChallengeSeed   sector.PoStRandomness
-	CandidateProofs []PrivatePostCandidateProof
+	Algorithm       abi.ProofAlgorithm
+	ChallengeSeed   abi.PoStRandomness
+	CandidateProofs []abi.PrivatePoStCandidateProof
 }
 
-func createPrivatePoStProof(algorithm sector.ProofAlgorithm, candidateProofs []PrivatePostCandidateProof, challengeSeed sector.PoStRandomness) PrivatePoStProof {
+func createPrivatePoStProof(algorithm abi.ProofAlgorithm, candidateProofs []abi.PrivatePoStCandidateProof, challengeSeed abi.PoStRandomness) PrivatePoStProof {
 	// TODO: Verify that all candidateProofs share algorithm.
 	return PrivatePoStProof{
 		Algorithm:       algorithm,
@@ -697,28 +694,28 @@ type InternalPrivateCandidateProof struct {
 
 // This exists because we need to pass private proofs out of filproofs for winner selection.
 // Actually implementing it would (will?) be tedious, since it means doing the same for InclusionProofs.
-func (p *InternalPrivateCandidateProof) externalize(algorithm sector.ProofAlgorithm) sector.PrivatePoStCandidateProof {
-	return &sector.PrivatePoStCandidateProof_I{
-		Algorithm_:    algorithm,
-		Externalized_: []byte{}, // Unimplemented.
+func (p *InternalPrivateCandidateProof) externalize(algorithm abi.ProofAlgorithm) abi.PrivatePoStCandidateProof {
+	return abi.PrivatePoStCandidateProof{
+		Algorithm:    algorithm,
+		Externalized: []byte{}, // Unimplemented.
 	}
 }
 
 // This is the inverse of InternalPrivateCandidateProof.externalize and equally tedious.
-func newInternalPrivateProof(externalPrivateProof PrivatePostCandidateProof) InternalPrivateCandidateProof {
+func newInternalPrivateProof(externalPrivateProof abi.PrivatePoStCandidateProof) InternalPrivateCandidateProof {
 	return InternalPrivateCandidateProof{}
 }
 
-func createPoStCircuitProof(postCfg sector.PoStInstanceCfg, algorithm sector.ProofAlgorithm, privateProof PrivatePoStProof) (proof sector.PoStProof) {
+func createPoStCircuitProof(postCfg sector.PoStInstanceCfg, algorithm abi.ProofAlgorithm, privateProof PrivatePoStProof) (proof abi.PoStProof) {
 	switch algorithm {
-	case sector.ProofAlgorithm_WinStackedDRGSeal:
+	case abi.ProofAlgorithm_WinStackedDRGSeal:
 		sdr := WinStackedDRG_I{}
 		proof = sdr._createPoStCircuitProof(postCfg, privateProof)
 	}
 	return proof
 }
 
-func (pv *PoStVerifier_I) _verifyPoStProof(sv sector.PoStVerifyInfo) bool {
+func (pv *PoStVerifier_I) _verifyPoStProof(sv abi.PoStVerifyInfo) bool {
 	// commT := sv.CommT()
 	// candidates := sv.Candidates()
 	// randomness := sv.Randomness()
@@ -731,7 +728,7 @@ func (pv *PoStVerifier_I) _verifyPoStProof(sv sector.PoStVerifyInfo) bool {
 ////////////////////////////////////////////////////////////////////////////////
 // General PoSt
 
-func generatePoStCandidates(cfg sector.PoStInstanceCfg, challengeSeed sector.PoStRandomness, eligibleSectors []sector.SectorID, candidateCount int, sectorStore sector_index.SectorStore) (candidates []sector.PoStCandidate) {
+func generatePoStCandidates(cfg sector.PoStInstanceCfg, challengeSeed abi.PoStRandomness, eligibleSectors []abi.SectorID, candidateCount int, sectorStore sector_index.SectorStore) (candidates []abi.PoStCandidate) {
 	challengedSectors := getChallengedSectors(cfg, eligibleSectors, challengeSeed, eligibleSectors, candidateCount)
 
 	for i, sectorID := range challengedSectors {
@@ -749,29 +746,29 @@ func generatePoStCandidates(cfg sector.PoStInstanceCfg, challengeSeed sector.PoS
 ////////////////////////////////////////////////////////////////////////////////
 // Election PoSt
 
-func GenerateElectionPoStCandidates(cfg sector.PoStInstanceCfg, challengeSeed sector.PoStRandomness, eligibleSectors []sector.SectorID, candidateCount int, sectorStore sector_index.SectorStore) (candidates []sector.PoStCandidate) {
+func GenerateElectionPoStCandidates(cfg sector.PoStInstanceCfg, challengeSeed abi.PoStRandomness, eligibleSectors []abi.SectorID, candidateCount int, sectorStore sector_index.SectorStore) (candidates []abi.PoStCandidate) {
 	return generatePoStCandidates(cfg, challengeSeed, eligibleSectors, candidateCount, sectorStore)
 }
 
-func CreateElectionPoStProof(cfg sector.PoStInstanceCfg, privateCandidateProofs []PrivatePostCandidateProof, challengeSeed sector.PoStRandomness) []sector.PoStProof {
+func CreateElectionPoStProof(cfg sector.PoStInstanceCfg, privateCandidateProofs []abi.PrivatePoStCandidateProof, challengeSeed abi.PoStRandomness) []abi.PoStProof {
 	return CreatePoStProof(cfg, privateCandidateProofs, challengeSeed)
 }
 
-func (pv *PoStVerifier_I) VerifyElectionPoSt(sv sector.PoStVerifyInfo) bool {
+func (pv *PoStVerifier_I) VerifyElectionPoSt(sv abi.PoStVerifyInfo) bool {
 	return pv._verifyPoStProof(sv)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 // Surprise PoSt
 
-func GenerateSurprisePoStCandidates(challengeSeed sector.PoStRandomness, eligibleSectors []sector.SectorID, candidateCount int, sectorStore sector_index.SectorStore) []sector.PoStCandidate {
+func GenerateSurprisePoStCandidates(challengeSeed abi.PoStRandomness, eligibleSectors []abi.SectorID, candidateCount int, sectorStore sector_index.SectorStore) []abi.PoStCandidate {
 	panic("TODO")
 }
 
-func CreateSurprisePoStProof(cfg sector.PoStInstanceCfg, privateCandidateProofs []PrivatePostCandidateProof, challengeSeed sector.PoStRandomness) []sector.PoStProof {
+func CreateSurprisePoStProof(cfg sector.PoStInstanceCfg, privateCandidateProofs []abi.PrivatePoStCandidateProof, challengeSeed abi.PoStRandomness) []abi.PoStProof {
 	return CreatePoStProof(cfg, privateCandidateProofs, challengeSeed)
 }
 
-func (pv *PoStVerifier_I) VerifySurprisePoSt(sv sector.PoStVerifyInfo) bool {
+func (pv *PoStVerifier_I) VerifySurprisePoSt(sv abi.PoStVerifyInfo) bool {
 	return pv._verifyPoStProof(sv)
 }

--- a/src/libraries/filcrypto/filproofs/algorithms.id
+++ b/src/libraries/filcrypto/filproofs/algorithms.id
@@ -1,3 +1,4 @@
+import abi "github.com/filecoin-project/specs/actors/abi"
 import file "github.com/filecoin-project/specs/systems/filecoin_files/file"
 import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 import sectorIndex "github.com/filecoin-project/specs/systems/filecoin_mining/sector_index"
@@ -52,7 +53,7 @@ type SealAlgorithmArtifacts struct {
 // per-sector setup artifacts go here
 type SealSetupArtifacts struct {
     CommD              sector.Commitment
-    CommR              sector.SealedSectorCID
+    CommR              abi.SealedSectorCID
     CommC              sector.Commitment
     CommQ              sector.Commitment
     CommRLast          sector.Commitment
@@ -84,7 +85,7 @@ type WinStackedDRG struct {
     WindowExpanderGraphCfg  ExpanderGraphCfg
     // invariant: DRGCfg.Nodes == ExpanderGraphCfg.Nodes
     Curve                   EllipticCurve
-    RegisteredProof         sector.RegisteredProof
+    RegisteredProof         abi.RegisteredProof
     Cfg                     sector.SealInstanceCfg
 
     Drg()                   DRG
@@ -94,58 +95,58 @@ type WinStackedDRG struct {
     WindowExpander()        ExpanderGraph
 
     Seal(
-        registeredProof  sector.RegisteredProof
-        sid              sector.SectorID
+        registeredProof  abi.RegisteredProof
+        sid              abi.SectorID
         data             Bytes
-        randomness       sector.SealRandomness
+        randomness       abi.SealRandomness
     ) SealSetupArtifacts
     CreateSealProof(
-        challengeSeed  sector.InteractiveSealRandomness
+        challengeSeed  abi.InteractiveSealRandomness
         aux            sector.ProofAuxTmp
-    ) sector.SealProof
+    ) abi.SealProof
     CreatePrivateSealProof(
-        randomness  sector.InteractiveSealRandomness
+        randomness  abi.InteractiveSealRandomness
         aux         sector.ProofAuxTmp
     ) PrivateOfflineProof
 
     CreateOfflineCircuitProof(
         challengeProofs  [OfflineWindowProof]
         aux              sector.ProofAuxTmp
-    ) sector.SealProof
+    ) abi.SealProof
     VerifyPrivateSealProof(
         privateProof  [OfflineWindowProof]
         sealSeeds     [sector.SealSeed]
-        randomness    sector.InteractiveSealRandomness
+        randomness    abi.InteractiveSealRandomness
         commD         Commitment
-        commR         sector.SealedSectorCID
+        commR         abi.SealedSectorCID
     ) bool
-    VerifySeal(sv sector.SealVerifyInfo) bool
+    VerifySeal(sv abi.SealVerifyInfo) bool
 
     GenerateElectionPoStCandidates(
-        challengeSeed    sector.PoStRandomness
-        eligibleSectors  [sector.SectorNumber]
+        challengeSeed    abi.PoStRandomness
+        eligibleSectors  [abi.SectorNumber]
         candidateCount   int
         sectorStore      sectorIndex.SectorStore
-    ) [sector.PoStCandidate]
-    CreateElectionPoStProof(privateProofs [PrivatePoStProof]) sector.PoStProof
-    VerifyElectionPoSt(sv sector.PoStVerifyInfo) bool
+    ) [abi.PoStCandidate]
+    CreateElectionPoStProof(privateProofs [PrivatePoStProof]) abi.PoStProof
+    VerifyElectionPoSt(sv abi.PoStVerifyInfo) bool
 
     GenerateSurprisePoStCandidates(
-        challengeSeed    sector.PoStRandomness
-        eligibleSectors  [sector.SectorNumber]
+        challengeSeed    abi.PoStRandomness
+        eligibleSectors  [abi.SectorNumber]
         candidateCount   int
         sectorStore      sectorIndex.SectorStore
-    ) [sector.PoStCandidate]
-    CreateSurprisePoStProof(privateProofs [PrivatePoStProof]) sector.PoStProof
-    VerifySurprisePoSt(sv sector.PoStVerifyInfo) bool
+    ) [abi.PoStCandidate]
+    CreateSurprisePoStProof(privateProofs [PrivatePoStProof]) abi.PoStProof
+    VerifySurprisePoSt(sv abi.PoStVerifyInfo) bool
     CreatePrivatePoStProof(
-        candidateProofs  [sector.PrivatePoStCandidateProof]
-        challengeSeed    sector.PoStRandomness
+        candidateProofs  [abi.PrivatePoStCandidateProof]
+        challengeSeed    abi.PoStRandomness
         aux              sector.PersistentProofAux
     ) PrivatePoStProof
     VerifyPrivatePoStProof(
         privateProof  PrivatePoStProof
-        candidates    [sector.PoStCandidate]
+        candidates    [abi.PoStCandidate]
         commRLast     sector.Commitment
     ) bool
 }

--- a/src/libraries/filcrypto/filproofs/filecoin_proofs_subsystem.go
+++ b/src/libraries/filcrypto/filproofs/filecoin_proofs_subsystem.go
@@ -1,9 +1,10 @@
 package filproofs
 
+import abi "github.com/filecoin-project/specs/actors/abi"
 import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 
-func (fps *FilecoinProofsSubsystem_I) VerifySeal(sealVerifyInfo sector.SealVerifyInfo) bool {
-	cfg := sector.RegisteredProofInstance(sealVerifyInfo.OnChain().RegisteredProof()).Cfg().As_SealCfg()
+func (fps *FilecoinProofsSubsystem_I) VerifySeal(sealVerifyInfo abi.SealVerifyInfo) bool {
+	cfg := sector.RegisteredProofInstance(sealVerifyInfo.OnChain.RegisteredProof).Cfg().As_SealCfg()
 	sdr := WinSDRParams(cfg)
 	return sdr.VerifySeal(sealVerifyInfo)
 }

--- a/src/libraries/filcrypto/filproofs/filecoin_proofs_subsystem.id
+++ b/src/libraries/filcrypto/filproofs/filecoin_proofs_subsystem.id
@@ -1,10 +1,10 @@
-import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
+import abi "github.com/filecoin-project/specs/actors/abi"
 
 type SectorInfo struct {}
 type Block struct {}
 type SectorID struct {}
 
 type FilecoinProofsSubsystem struct {
-    VerifySeal(sealVerifyInfo sector.SealVerifyInfo) bool
+    VerifySeal(sealVerifyInfo abi.SealVerifyInfo) bool
     ValidateBlock(block Block) bool
 }

--- a/src/libraries/filcrypto/filproofs/util.go
+++ b/src/libraries/filcrypto/filproofs/util.go
@@ -4,9 +4,8 @@ import (
 	"encoding/binary"
 	big "math/big"
 
+	abi "github.com/filecoin-project/specs/actors/abi"
 	file "github.com/filecoin-project/specs/systems/filecoin_files/file"
-	piece "github.com/filecoin-project/specs/systems/filecoin_files/piece"
-	sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 	util "github.com/filecoin-project/specs/util"
 )
 
@@ -70,19 +69,19 @@ func AsBytes_T(t util.T) []byte {
 	return []byte{}
 }
 
-func AsBytes_UnsealedSectorCID(cid sector.UnsealedSectorCID) []byte {
+func AsBytes_UnsealedSectorCID(cid abi.UnsealedSectorCID) []byte {
 	panic("Unimplemented for UnsealedSectorCID")
 
 	return []byte{}
 }
 
-func AsBytes_SealedSectorCID(CID sector.SealedSectorCID) []byte {
+func AsBytes_SealedSectorCID(CID abi.SealedSectorCID) []byte {
 	panic("Unimplemented for SealedSectorCID")
 
 	return []byte{}
 }
 
-func AsBytes_PieceCID(CID piece.PieceCID) []byte {
+func AsBytes_PieceCID(CID abi.PieceCID) []byte {
 	panic("Unimplemented for PieceCID")
 
 	return []byte{}
@@ -93,7 +92,7 @@ func fromBytes_T(_ interface{}) util.T {
 	return util.T{}
 }
 
-func fromBytes_PieceCID(_ interface{}) piece.PieceCID {
+func fromBytes_PieceCID(_ interface{}) abi.PieceCID {
 	panic("Unimplemented for PieceCID")
 }
 
@@ -125,30 +124,30 @@ func trimToFr32(data []byte) []byte {
 	return data
 }
 
-func UnsealedSectorCID(h SHA256Hash) sector.UnsealedSectorCID {
+func UnsealedSectorCID(h SHA256Hash) abi.UnsealedSectorCID {
 	panic("not implemented -- re-arrange bits")
 }
 
-func SealedSectorCID(h PedersenHash) sector.SealedSectorCID {
+func SealedSectorCID(h PedersenHash) abi.SealedSectorCID {
 	panic("not implemented -- re-arrange bits")
 }
 
-func Commitment_UnsealedSectorCID(cid sector.UnsealedSectorCID) Commitment {
+func Commitment_UnsealedSectorCID(cid abi.UnsealedSectorCID) Commitment {
 	panic("not implemented -- re-arrange bits")
 }
 
-func Commitment_SealedSectorCID(cid sector.SealedSectorCID) Commitment {
+func Commitment_SealedSectorCID(cid abi.SealedSectorCID) Commitment {
 	panic("not implemented -- re-arrange bits")
 }
 
-func ComputeDataCommitment(data []byte) (sector.UnsealedSectorCID, file.Path) {
+func ComputeDataCommitment(data []byte) (abi.UnsealedSectorCID, file.Path) {
 	// TODO: make hash parameterizable
 	hash, path := BuildTree_SHA256Hash(data)
 	return UnsealedSectorCID(hash), path
 }
 
 // Compute CommP or CommD.
-func ComputeUnsealedSectorCID(data []byte) (sector.UnsealedSectorCID, file.Path) {
+func ComputeUnsealedSectorCID(data []byte) (abi.UnsealedSectorCID, file.Path) {
 	// TODO: check that len(data) > minimum piece size and is a power of 2.
 	hash, treePath := BuildTree_SHA256Hash(data)
 	return UnsealedSectorCID(hash), treePath

--- a/src/libraries/filcrypto/filproofs/win_stacked_sdr.go
+++ b/src/libraries/filcrypto/filproofs/win_stacked_sdr.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	big "math/big"
 
+	abi "github.com/filecoin-project/specs/actors/abi"
 	file "github.com/filecoin-project/specs/systems/filecoin_files/file"
 	sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 	util "github.com/filecoin-project/specs/util"
@@ -103,7 +104,7 @@ func (sdr *WinStackedDRG_I) WindowExpander() *ExpanderGraph_I {
 	}
 }
 
-func (sdr *WinStackedDRG_I) Seal(registeredProof sector.RegisteredProof, sid sector.SectorID, data []byte, randomness sector.SealRandomness) SealSetupArtifacts {
+func (sdr *WinStackedDRG_I) Seal(registeredProof abi.RegisteredProof, sid abi.SectorID, data []byte, randomness abi.SealRandomness) SealSetupArtifacts {
 
 	windowCount := int(sdr.WindowCount())
 	nodeSize := int(sdr.NodeSize())
@@ -156,7 +157,7 @@ func (sdr *WinStackedDRG_I) Seal(registeredProof sector.RegisteredProof, sid sec
 	return &result
 }
 
-func (sdr *WinStackedDRG_I) _generateWindowKey(sealSeed sector.SealSeed, windowIndex int, sid sector.SectorID, commD sector.UnsealedSectorCID, nodes int, randomness sector.SealRandomness) [][]byte {
+func (sdr *WinStackedDRG_I) _generateWindowKey(sealSeed sector.SealSeed, windowIndex int, sid abi.SectorID, commD abi.UnsealedSectorCID, nodes int, randomness abi.SealRandomness) [][]byte {
 	nodeSize := int(sdr.NodeSize())
 	curveModulus := sdr.Curve().FieldModulus()
 	layers := int(sdr.Layers())
@@ -175,7 +176,7 @@ func (sdr *WinStackedDRG_I) GenerateCommitments(replica []byte, windowKeyLayers 
 	return commC, commQ, commRLast, commR, commCTreePath, commQTreePath, commRLastTreePath
 }
 
-func (sdr *WinStackedDRG_I) CreateSealProof(challengeSeed sector.InteractiveSealRandomness, aux sector.ProofAuxTmp) sector.SealProof {
+func (sdr *WinStackedDRG_I) CreateSealProof(challengeSeed abi.InteractiveSealRandomness, aux sector.ProofAuxTmp) abi.SealProof {
 	privateProof := sdr.CreatePrivateSealProof(challengeSeed, aux)
 
 	// Sanity check: newly-created proofs must pass verification.
@@ -184,7 +185,7 @@ func (sdr *WinStackedDRG_I) CreateSealProof(challengeSeed sector.InteractiveSeal
 	return sdr.CreateOfflineCircuitProof(privateProof, aux)
 }
 
-func (sdr *WinStackedDRG_I) CreatePrivateSealProof(randomness sector.InteractiveSealRandomness, aux sector.ProofAuxTmp) (privateProof PrivateOfflineProof) {
+func (sdr *WinStackedDRG_I) CreatePrivateSealProof(randomness abi.InteractiveSealRandomness, aux sector.ProofAuxTmp) (privateProof PrivateOfflineProof) {
 	sealSeed := aux.Seed()
 	nodeSize := UInt(sdr.NodeSize())
 	wrapperChallenges, windowChallenges := sdr._generateOfflineChallenges(sealSeed, randomness, sdr.Challenges(), sdr.WindowChallenges())
@@ -217,7 +218,7 @@ func (sdr *WinStackedDRG_I) CreatePrivateSealProof(randomness sector.Interactive
 // NOTE: Verification of a private proof is exactly the computation we will prove we have performed in a zk-SNARK.
 // If we can verifiably prove that we have performed the verification of a private proof, then we need not reveal the proof itself.
 // Since the zk-SNARK circuit proof is much smaller than the private proof, this allows us to save space on the chain (at the cost of increased computation to generate the zk-SNARK proof).
-func (sdr *WinStackedDRG_I) VerifyPrivateSealProof(privateProof PrivateOfflineProof, sealSeed sector.SealSeed, randomness sector.InteractiveSealRandomness, commD Commitment, commR sector.SealedSectorCID) bool {
+func (sdr *WinStackedDRG_I) VerifyPrivateSealProof(privateProof PrivateOfflineProof, sealSeed sector.SealSeed, randomness abi.InteractiveSealRandomness, commD Commitment, commR abi.SealedSectorCID) bool {
 	nodeSize := int(sdr.NodeSize())
 	windowCount := int(sdr.WindowCount())
 	windowSize := int(UInt(sdr.Cfg().As_WinStackedDRGCfgV1().SectorSize()) / UInt(sdr.WindowCount())) // TOOD: Make this a function.
@@ -338,7 +339,7 @@ func (sdr *WinStackedDRG_I) VerifyPrivateSealProof(privateProof PrivateOfflinePr
 	return true
 }
 
-func (sdr *WinStackedDRG_I) CreateOfflineCircuitProof(proof PrivateOfflineProof, aux sector.ProofAuxTmp) sector.SealProof {
+func (sdr *WinStackedDRG_I) CreateOfflineCircuitProof(proof PrivateOfflineProof, aux sector.ProofAuxTmp) abi.SealProof {
 	// partitions := sdr.Partitions()
 	// publicInputs := GeneratePublicInputs()
 
@@ -346,14 +347,14 @@ func (sdr *WinStackedDRG_I) CreateOfflineCircuitProof(proof PrivateOfflineProof,
 	var proofBytes []byte
 	panic("TODO")
 
-	sealProof := sector.SealProof_I{
-		ProofBytes_: proofBytes,
+	sealProof := abi.SealProof{
+		ProofBytes: proofBytes,
 	}
 
-	return &sealProof
+	return sealProof
 }
 
-func (sdr *WinStackedDRG_I) _generateOfflineChallenges(sealSeed sector.SealSeed, randomness sector.InteractiveSealRandomness, wrapperChallengeCount WinStackedDRGChallenges, windowChallengeCount WinStackedDRGWindowChallenges) (windowChallenges []UInt, wrapperChallenges []UInt) {
+func (sdr *WinStackedDRG_I) _generateOfflineChallenges(sealSeed sector.SealSeed, randomness abi.InteractiveSealRandomness, wrapperChallengeCount WinStackedDRGChallenges, windowChallengeCount WinStackedDRGWindowChallenges) (windowChallenges []UInt, wrapperChallenges []UInt) {
 	wrapperChallenges = generateOfflineChallenges(int(sdr.Nodes()), sealSeed, randomness, int(wrapperChallengeCount))
 	windowChallenges = generateOfflineChallenges(int(sdr.WindowDRGCfg().Nodes()), sealSeed, randomness, int(windowChallengeCount))
 
@@ -363,18 +364,18 @@ func (sdr *WinStackedDRG_I) _generateOfflineChallenges(sealSeed sector.SealSeed,
 ////////////////////////////////////////////////////////////////////////////////
 // Seal Verification
 
-func (sdr *WinStackedDRG_I) VerifySeal(sv sector.SealVerifyInfo) bool {
-	onChain := sv.OnChain()
-	sealProof := onChain.Proof()
-	commR := sector.SealedSectorCID(onChain.SealedCID())
-	commD := sector.UnsealedSectorCID(sv.UnsealedCID())
-	sealSeed := computeSealSeed(sv.SectorID(), sv.Randomness(), commD)
+func (sdr *WinStackedDRG_I) VerifySeal(sv abi.SealVerifyInfo) bool {
+	onChain := sv.OnChain
+	sealProof := onChain.Proof
+	commR := abi.SealedSectorCID(onChain.SealedCID)
+	commD := abi.UnsealedSectorCID(sv.UnsealedCID)
+	sealSeed := computeSealSeed(sv.SectorID, sv.Randomness, commD)
 
-	wrapperChallenges, windowChallenges := sdr._generateOfflineChallenges(sealSeed, sv.InteractiveRandomness(), sdr.Challenges(), sdr.WindowChallenges())
+	wrapperChallenges, windowChallenges := sdr._generateOfflineChallenges(sealSeed, sv.InteractiveRandomness, sdr.Challenges(), sdr.WindowChallenges())
 	return sdr._verifyOfflineCircuitProof(commD, commR, sealSeed, windowChallenges, wrapperChallenges, sealProof)
 }
 
-func (sdr *WinStackedDRG_I) _verifyOfflineCircuitProof(commD sector.UnsealedSectorCID, commR sector.SealedSectorCID, sealSeed sector.SealSeed, windowChallenges []UInt, wrapperChallenges []UInt, sv sector.SealProof) bool {
+func (sdr *WinStackedDRG_I) _verifyOfflineCircuitProof(commD abi.UnsealedSectorCID, commR abi.SealedSectorCID, sealSeed sector.SealSeed, windowChallenges []UInt, wrapperChallenges []UInt, sv abi.SealProof) bool {
 	//publicInputs := GeneratePublicInputs()
 	panic("TODO")
 }
@@ -382,7 +383,7 @@ func (sdr *WinStackedDRG_I) _verifyOfflineCircuitProof(commD sector.UnsealedSect
 ////////////////////////////////////////////////////////////////////////////////
 // PoSt
 
-func (sdr *WinStackedDRG_I) _generateCandidate(postCfg sector.PoStInstanceCfg, randomness sector.PoStRandomness, aux sector.PersistentProofAux, sectorID sector.SectorID, sectorChallengeIndex UInt) sector.PoStCandidate {
+func (sdr *WinStackedDRG_I) _generateCandidate(postCfg sector.PoStInstanceCfg, randomness abi.PoStRandomness, aux sector.PersistentProofAux, sectorID abi.SectorID, sectorChallengeIndex uint64) abi.PoStCandidate {
 	cfg := postCfg.As_PoStCfgV1()
 
 	nodes := int(cfg.Nodes())
@@ -410,23 +411,23 @@ func (sdr *WinStackedDRG_I) _generateCandidate(postCfg sector.PoStInstanceCfg, r
 		InclusionProofs: inclusionProofs,
 	}
 
-	candidate := sector.PoStCandidate_I{
-		PartialTicket_:  partialTicket,
-		PrivateProof_:   privateProof.externalize(sector.ProofAlgorithm_WinStackedDRGSeal),
-		SectorID_:       sectorID,
-		ChallengeIndex_: sectorChallengeIndex,
+	candidate := abi.PoStCandidate{
+		PartialTicket:  partialTicket,
+		PrivateProof:   privateProof.externalize(abi.ProofAlgorithm_WinStackedDRGSeal),
+		SectorID:       sectorID,
+		ChallengeIndex: int64(sectorChallengeIndex),
 	}
-	return &candidate
+	return candidate
 }
 
-func (sdr *WinStackedDRG_I) VerifyInternalPrivateCandidateProof(postCfg sector.PoStInstanceCfg, p *InternalPrivateCandidateProof, challengeSeed sector.PoStRandomness, candidate sector.PoStCandidate, commRLast Commitment) bool {
+func (sdr *WinStackedDRG_I) VerifyInternalPrivateCandidateProof(postCfg sector.PoStInstanceCfg, p *InternalPrivateCandidateProof, challengeSeed abi.PoStRandomness, candidate abi.PoStCandidate, commRLast Commitment) bool {
 	cfg := postCfg.As_PoStCfgV1()
-	util.Assert(candidate.PrivateProof() == nil)
+	//util.Assert(candidate.PrivateProof == nil)
 	nodes := int(cfg.Nodes())
 	challengeRangeSize := int(cfg.ChallengeRangeSize())
 
-	sectorID := candidate.SectorID()
-	claimedPartialTicket := candidate.PartialTicket()
+	sectorID := candidate.SectorID
+	claimedPartialTicket := candidate.PartialTicket
 
 	allInclusionProofs := p.InclusionProofs
 
@@ -461,7 +462,7 @@ func (sdr *WinStackedDRG_I) VerifyInternalPrivateCandidateProof(postCfg sector.P
 
 	// Check all inclusion proofs.
 	for i := 0; i < int(cfg.LeafChallengeCount()); i++ {
-		leafChallenge := generateLeafChallenge(challengeSeed, candidate.ChallengeIndex(), i, nodes, challengeRangeSize)
+		leafChallenge := generateLeafChallenge(challengeSeed, UInt(candidate.ChallengeIndex), i, nodes, challengeRangeSize)
 		for j := 0; j < challengeRangeSize; j++ {
 			leafIndex := leafChallenge + UInt(j)
 			proof := next()
@@ -478,7 +479,7 @@ func (sdr *WinStackedDRG_I) VerifyInternalPrivateCandidateProof(postCfg sector.P
 	return true
 }
 
-func (sdr *WinStackedDRG_I) VerifyPrivatePoStProof(cfg sector.PoStInstanceCfg, privateProof PrivatePoStProof, candidates []sector.PoStCandidate, sectorIDs []sector.SectorID, sectorCommitments sector.SectorCommitments) bool {
+func (sdr *WinStackedDRG_I) VerifyPrivatePoStProof(cfg sector.PoStInstanceCfg, privateProof PrivatePoStProof, candidates []abi.PoStCandidate, sectorIDs []abi.SectorID, sectorCommitments sector.SectorCommitments) bool {
 	// This is safe by construction.
 	challengeSeed := privateProof.ChallengeSeed
 
@@ -486,7 +487,7 @@ func (sdr *WinStackedDRG_I) VerifyPrivatePoStProof(cfg sector.PoStInstanceCfg, p
 		proof := newInternalPrivateProof(p)
 
 		candidate := candidates[i]
-		ci := candidate.ChallengeIndex()
+		ci := candidate.ChallengeIndex
 		expectedSectorID := sectorIDs[ci]
 
 		challengedSectorID := generateSectorChallenge(challengeSeed, i, sectorIDs)
@@ -504,15 +505,15 @@ func (sdr *WinStackedDRG_I) VerifyPrivatePoStProof(cfg sector.PoStInstanceCfg, p
 	return true
 }
 
-func (sdr *WinStackedDRG_I) _createPoStCircuitProof(postCfg sector.PoStInstanceCfg, privateProof PrivatePoStProof) sector.PoStProof {
+func (sdr *WinStackedDRG_I) _createPoStCircuitProof(postCfg sector.PoStInstanceCfg, privateProof PrivatePoStProof) abi.PoStProof {
 	panic("TODO")
 
 	var proofBytes []byte
 	panic("TODO")
 
-	postProof := sector.PoStProof_I{
-		ProofBytes_: proofBytes,
+	postProof := abi.PoStProof{
+		ProofBytes: proofBytes,
 	}
 
-	return &postProof
+	return postProof
 }

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_consensus_subsystem.go
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_consensus_subsystem.go
@@ -11,7 +11,6 @@ import (
 	filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
 	block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
 	chain "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/chain"
-	sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 	node_base "github.com/filecoin-project/specs/systems/filecoin_nodes/node_base"
 	stateTree "github.com/filecoin-project/specs/systems/filecoin_vm/state_tree"
 	util "github.com/filecoin-project/specs/util"
@@ -35,7 +34,7 @@ func (spc *StoragePowerConsensusSubsystem_I) ComputeChainWeight(tipset chain.Tip
 	return spc.ec().ComputeChainWeight(tipset)
 }
 
-func (spc *StoragePowerConsensusSubsystem_I) IsWinningPartialTicket(stateTree stateTree.StateTree, inds inds.Indices, partialTicket sector.PartialTicket, sectorUtilization abi.StoragePower, numSectors util.UVarint) bool {
+func (spc *StoragePowerConsensusSubsystem_I) IsWinningPartialTicket(stateTree stateTree.StateTree, inds inds.Indices, partialTicket abi.PartialTicket, sectorUtilization abi.StoragePower, numSectors util.UVarint) bool {
 
 	// finalize the partial ticket
 	challengeTicket := filcrypto.SHA256(partialTicket)

--- a/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_consensus_subsystem.id
+++ b/src/systems/filecoin_blockchain/storage_power_consensus/storage_power_consensus_subsystem.id
@@ -4,7 +4,6 @@ import block "github.com/filecoin-project/specs/systems/filecoin_blockchain/stru
 import chain "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/chain"
 import st "github.com/filecoin-project/specs/systems/filecoin_vm/state_tree"
 import filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
-import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 import blockchain "github.com/filecoin-project/specs/systems/filecoin_blockchain"
 import spowact "github.com/filecoin-project/specs/actors/builtin/storage_power"
 import node_base "github.com/filecoin-project/specs/systems/filecoin_nodes/node_base"
@@ -21,7 +20,7 @@ type StoragePowerConsensusSubsystem struct {//(@mutable)
 
     IsWinningPartialTicket(
         st                 st.StateTree
-        partialTicket      sector.PartialTicket
+        partialTicket      abi.PartialTicket
         sectorUtilization  abi.StoragePower
         numSectors         util.UVarint
     ) bool

--- a/src/systems/filecoin_blockchain/struct/block_producer/block_producer.id
+++ b/src/systems/filecoin_blockchain/struct/block_producer/block_producer.id
@@ -1,7 +1,7 @@
+import abi "github.com/filecoin-project/specs/actors/abi"
 import block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
 import addr "github.com/filecoin-project/go-address"
 import msg "github.com/filecoin-project/specs/systems/filecoin_vm/message"
-import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 import chain "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/chain"
 import cid "github.com/ipfs/go-cid"
 
@@ -11,7 +11,7 @@ type BlockProducer struct {
     // and then get back the messages and call AssembleBlock
     // TODO minerAddr is of type StorageMiner.Address
     GenerateBlock(
-        ePoStInfo  sector.OnChainElectionPoStVerifyInfo
+        ePoStInfo  abi.OnChainElectionPoStVerifyInfo
         newTicket  block.Ticket
         chainHead  chain.Tipset
         minerAddr  addr.Address
@@ -19,7 +19,7 @@ type BlockProducer struct {
 
     // call by BlockProducer itself after getting back messages
     AssembleBlock(
-        ePoStInfo  sector.OnChainElectionPoStVerifyInfo
+        ePoStInfo  abi.OnChainElectionPoStVerifyInfo
         T0         block.Ticket
         tipset     chain.Tipset
         minerAddr  addr.Address

--- a/src/systems/filecoin_files/piece/piece.id
+++ b/src/systems/filecoin_files/piece/piece.id
@@ -1,24 +1,10 @@
-import cid "github.com/ipfs/go-cid"
-
-// PieceCID is the main reference to pieces in Filecoin. It is the CID
-// of the Piece.
-type PieceCID cid.Cid
-
-type NumBytes UVarint  // TODO: move into util
-
-// PieceSize is the size of a piece, in bytes
-type PieceSize struct {
-    PayloadSize   NumBytes
-    OverheadSize  NumBytes
-
-    Total()       NumBytes
-}
+import abi "github.com/filecoin-project/specs/actors/abi"
 
 // PieceInfo is an object that describes details about a piece, and allows
 // decoupling storage of this information from the piece itself.
 type PieceInfo struct {
     ID    PieceID
-    Size  PieceSize
+    Size  abi.PieceSize
     // TODO: store which algorithms were used to construct this piece.
 }
 

--- a/src/systems/filecoin_markets/retrieval_market/retrieval_client.id
+++ b/src/systems/filecoin_markets/retrieval_market/retrieval_client.id
@@ -1,6 +1,5 @@
 import abi "github.com/filecoin-project/specs/actors/abi"
 import addr "github.com/filecoin-project/go-address"
-import piece "github.com/filecoin-project/specs/systems/filecoin_files/piece"
 import peer "github.com/libp2p/go-libp2p-core/peer"
 
 type RetrievalClientDealState struct {
@@ -31,14 +30,14 @@ type RetrievalClientSubscriber struct {
 
 type RetrievalClient struct {
     // V0
-    FindProviders(pieceCID piece.PieceCID) [RetrievalPeer]
+    FindProviders(pieceCID abi.PieceCID) [RetrievalPeer]
     Query(
         p         RetrievalPeer
-        pieceCID  piece.PieceCID
+        pieceCID  abi.PieceCID
         params    RetrievalQueryParams
     ) RetrievalQueryResponse
     Retrieve(
-        pieceCID      piece.PieceCID
+        pieceCID      abi.PieceCID
         params        RetrievalParams
         totalFunds    abi.TokenAmount
         miner         peer.ID

--- a/src/systems/filecoin_markets/retrieval_market/retrieval_peer_resolver.id
+++ b/src/systems/filecoin_markets/retrieval_market/retrieval_peer_resolver.id
@@ -1,5 +1,5 @@
-import piece "github.com/filecoin-project/specs/systems/filecoin_files/piece"
+import abi "github.com/filecoin-project/specs/actors/abi"
 
 type RetrievalPeerResolver struct {
-    GetPeers(PieceCID piece.PieceCID) [RetrievalPeer]
+    GetPeers(PieceCID abi.PieceCID) [RetrievalPeer]
 }

--- a/src/systems/filecoin_markets/retrieval_market/types.id
+++ b/src/systems/filecoin_markets/retrieval_market/types.id
@@ -1,7 +1,6 @@
 import ipld "github.com/filecoin-project/specs/libraries/ipld"
 import addr "github.com/filecoin-project/go-address"
 import abi "github.com/filecoin-project/specs/actors/abi"
-import piece "github.com/filecoin-project/specs/systems/filecoin_files/piece"
 import peer "github.com/libp2p/go-libp2p-core/peer"
 import cid "github.com/ipfs/go-cid"
 
@@ -36,7 +35,7 @@ type RetrievalQueryParams struct {
 }
 
 type RetrievalQuery struct {
-    PieceCID piece.PieceCID  // V0
+    PieceCID abi.PieceCID  // V0
     RetrievalQueryParams  // V1
 }
 
@@ -90,7 +89,7 @@ type RetrievalParams struct {
 type RetrievalDealID UInt
 
 type RetrievalDealProposal struct {
-    PieceCID         piece.PieceCID
+    PieceCID         abi.PieceCID
     ID               RetrievalDealID  // V1 - an identifier for the retrieval
     RetrievalParams
 }

--- a/src/systems/filecoin_markets/storage_market/storage_client.id
+++ b/src/systems/filecoin_markets/storage_market/storage_client.id
@@ -14,7 +14,7 @@ type ClientLocalDealInfo struct {
     State           StorageDealStatus
     MinerPeerID     peer.ID
     MinerWorker     addr.Address
-    DealID          deal.DealID
+    DealID          abi.DealID
     PublishMessage  &message.SignedMessage
 }
 

--- a/src/systems/filecoin_markets/storage_market/storage_deal/storage_deal.id
+++ b/src/systems/filecoin_markets/storage_market/storage_deal/storage_deal.id
@@ -2,12 +2,7 @@ import abi "github.com/filecoin-project/specs/actors/abi"
 import addr "github.com/filecoin-project/go-address"
 import filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
 import msg "github.com/filecoin-project/specs/systems/filecoin_vm/message"
-import piece "github.com/filecoin-project/specs/systems/filecoin_files/piece"
 
-type DealID Int
-type DealIDs struct {
-    Items [DealID]
-}
 type DealWeight int  // should be BigInt
 
 // Note: Deal Collateral is only released and returned to clients and miners
@@ -19,8 +14,8 @@ type DealWeight int  // should be BigInt
 // Note: ClientCollateralPerEpoch may not be needed and removed pending future confirmation.
 // There will be a Minimum value for both client and provider deal collateral.
 type StorageDealProposal struct {
-    PieceCID                      piece.PieceCID  // 35 bytes CommP
-    PieceSize                     piece.PieceSize
+    PieceCID                      abi.PieceCID  // CommP
+    PieceSize                     abi.PieceSize
     Client                        addr.Address
     Provider                      addr.Address
     ClientSignature               filcrypto.Signature
@@ -55,7 +50,7 @@ type StorageDeal struct {
 }
 
 type OnChainDeal struct {
-    ID                DealID
+    ID                abi.DealID
     Deal              StorageDeal
     SectorStartEpoch  abi.ChainEpoch  // -1 if not yet included in proven sector
     LastUpdatedEpoch  abi.ChainEpoch  // -1 if deal state never updated

--- a/src/systems/filecoin_markets/storage_market/storage_market.id
+++ b/src/systems/filecoin_markets/storage_market/storage_market.id
@@ -3,7 +3,6 @@ import addr "github.com/filecoin-project/go-address"
 import deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
 import filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
 import message "github.com/filecoin-project/specs/systems/filecoin_vm/message"
-import piece "github.com/filecoin-project/specs/systems/filecoin_files/piece"
 import cid "github.com/ipfs/go-cid"
 
 type StorageDealStatus uint64
@@ -14,7 +13,7 @@ type StorageAsk struct {
     Price             abi.TokenAmount  // attoFIL per GiB per epoch
     Collateral        abi.TokenAmount  // attoFIL per GiB per epoch
 
-    MinPieceSize      piece.PieceSize
+    MinPieceSize      abi.PieceSize
     // address of miner actor for deals
     Miner             addr.Address
     // the epoch at the time this ask was published

--- a/src/systems/filecoin_markets/storage_market/storage_provider.id
+++ b/src/systems/filecoin_markets/storage_market/storage_provider.id
@@ -3,7 +3,6 @@ import deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_
 import abi "github.com/filecoin-project/specs/actors/abi"
 import addr "github.com/filecoin-project/go-address"
 import dt "github.com/filecoin-project/specs/systems/filecoin_files/data_transfer"
-import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 import peer "github.com/libp2p/go-libp2p-core/peer"
 import cid "github.com/ipfs/go-cid"
 
@@ -20,8 +19,8 @@ type ProviderLocalDealInfo struct {
 
     PayloadID     cid.Cid
 
-    DealID        deal.DealID
-    SectorID      sector.SectorID  // Set when State >= DealStaged
+    DealID        abi.DealID
+    SectorID      abi.SectorID  // Set when State >= DealStaged
 }
 
 // The interface provided for storage providers

--- a/src/systems/filecoin_mining/sector/posting.go
+++ b/src/systems/filecoin_mining/sector/posting.go
@@ -1,3 +1,5 @@
 package sector
 
-type SectorCommitments map[SectorID]Commitment
+import abi "github.com/filecoin-project/specs/actors/abi"
+
+type SectorCommitments map[abi.SectorID]Commitment

--- a/src/systems/filecoin_mining/sector/posting.id
+++ b/src/systems/filecoin_mining/sector/posting.id
@@ -1,11 +1,4 @@
-type PartialTicket Bytes  // 32 bytes
-type ChallengeTicketsCommitment Bytes
-type PoStRandomness Bytes
-
-// type PoStCfg struct {
-//     InstanceCfg PoStInstanceCfg
-//     ProofInstance
-// }
+import abi "github.com/filecoin-project/specs/actors/abi"
 
 // New proof ProofInstances can add new cfg types if needed.
 type PoStInstanceCfg union {
@@ -33,51 +26,6 @@ type PoStType enum {
     SurprisePoSt
 }
 
-// TODO: refactor these types to get rid of the squishy optional fields.
-type PoStVerifyInfo struct {
-    Randomness       PoStRandomness
-    CommR            SealedSectorCID
-    OnChain          OnChainPoStVerifyInfo
-    EligibleSectors  {SectorID: SealedSectorCID}
-}
-
-type PoStCandidate struct {
-    PartialTicket  // Optional —  will eventually be omitted for SurprisePoSt verification, needed for now.
-    PrivateProof    PrivatePoStCandidateProof  // Optional — should be ommitted for verification.
-    SectorID
-    ChallengeIndex  UInt
-}
-
-// implemented by both OnChainElectionPoStVerifyInfo and OnChainSurprisePoStVerifyInfo
-type OnChainPoStVerifyInfo interface {
-    Candidates()  [PoStCandidate]
-    Proofs()      [PoStProof]
-}
-
-type OnChainElectionPoStVerifyInfo struct {
-    // There should be one RegisteredProof for each PoSt Candi
-    RegisteredProofs  [RegisteredProof]
-    Candidates        [PoStCandidate]
-    Proofs            [PoStProof]
-    Randomness        PoStRandomness
-}
-
-type OnChainSurprisePoStVerifyInfo struct {
-    RegisteredProof
-    Candidates       [PoStCandidate]
-    Proofs           [PoStProof]
-    CommT            ChallengeTicketsCommitment
-}
-
 type PoStWitness struct {
-    Candidates [PoStCandidate]
-}
-
-type PoStProof struct {//<curve, system> {
-    ProofBytes Bytes
-}
-
-type PrivatePoStCandidateProof struct {
-    Algorithm     ProofAlgorithm
-    Externalized  Bytes
+    Candidates [abi.PoStCandidate]
 }

--- a/src/systems/filecoin_mining/sector/sealing.go
+++ b/src/systems/filecoin_mining/sector/sealing.go
@@ -1,6 +1,6 @@
 package sector
 
-import util "github.com/filecoin-project/specs/util"
+import abi "github.com/filecoin-project/specs/actors/abi"
 
 // NOTE: It's fairly unclear how any of this should interface/cooperate with filcrypto/filproofs.
 // Leaving now to preserve some historical intent for later refactoring.
@@ -19,18 +19,7 @@ var SealSeedHash = SHA256
 // 	return SealSeed(h)
 // }
 
-func (x PieceInfo_I) Ref() *PieceInfo_I {
-	return &x
-}
-
-func (svi *OnChainSealVerifyInfo_I) IsValidAtSealEpoch() bool {
-	// We can just hardcode logic for the range of epochs at which each circuit type is valid.
-	switch PROOFS[util.UInt(svi.RegisteredProof())].CircuitType() {
-	}
-	panic("TODO")
-}
-
-func (cfg *SealInstanceCfg_I) SectorSize() SectorSize {
+func (cfg *SealInstanceCfg_I) SectorSize() abi.SectorSize {
 	switch cfg.Which() {
 	case SealInstanceCfg_Case_WinStackedDRGCfgV1:
 		{

--- a/src/systems/filecoin_mining/sector/sealing.id
+++ b/src/systems/filecoin_mining/sector/sealing.id
@@ -1,22 +1,12 @@
 import abi "github.com/filecoin-project/specs/actors/abi"
 import file "github.com/filecoin-project/specs/systems/filecoin_files/file"
-import piece "github.com/filecoin-project/specs/systems/filecoin_files/piece"
-import deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
 
 type Path struct {}  // TODO
 
-type SealRandomness Bytes
-type InteractiveSealRandomness Bytes
-
 // SealSeed is unique to each Sector
 // SealSeed is:
-//    SealSeedHash(MinerID, SectorNumber, SealRandomness, UnsealedSectorCID)
+//    SealSeedHash(MinerID, SectorNumber, SealRandomness, abi.UnsealedSectorCID)
 type SealSeed Bytes
-
-// type SealCfg struct {
-//     InstanceCfg    SealInstanceCfg
-//     ProofInstance
-// }
 
 // New proof ProofInstances can add new cfg types if needed.
 type SealInstanceCfg union {
@@ -24,58 +14,16 @@ type SealInstanceCfg union {
 }
 
 type WinStackedDRGCfgV1 struct {
-    SectorSize
-    WindowCount UInt
-}
-
-// SealVerifyInfo is the structure of all the information a verifier
-// needs to verify a Seal.
-type SealVerifyInfo struct {
-    SectorID
-    OnChain                OnChainSealVerifyInfo
-    Randomness             SealRandomness
-    InteractiveRandomness  InteractiveSealRandomness
-    UnsealedCID            UnsealedSectorCID  // CommD
-}
-
-// OnChainSealVerifyInfo is the structure of information that must be sent with
-// a message to commit a sector. Most of this information is not needed in the
-// state tree but will be verified in sm.CommitSector. See SealCommitment for
-// data stored on the state tree for each sector.
-type OnChainSealVerifyInfo struct {
-    SealedCID             SealedSectorCID  // CommR
-    SealEpoch             abi.ChainEpoch
-    InteractiveEpoch      abi.ChainEpoch
-    RegisteredProof
-    Proof                 SealProof
-    DealIDs               deal.DealIDs
-    SectorNumber
-
-    IsValidAtSealEpoch()  bool
+    SectorSize   abi.SectorSize
+    WindowCount  UInt
 }
 
 // SealCommitment is the information kept in the state tree about a sector.
 // SealCommitment is a subset of OnChainSealVerifyInfo.
 type SealCommitment struct {
-    SealedCID   SealedSectorCID  // CommR
-    DealIDs     deal.DealIDs
+    SealedCID   abi.SealedSectorCID  // CommR
+    DealIDs     abi.DealIDs
     Expiration  abi.ChainEpoch
-}
-
-type SectorPreCommitInfo struct {
-    SectorNumber
-    SealedCID     SealedSectorCID  // CommR
-    SealEpoch     abi.ChainEpoch
-    DealIDs       deal.DealIDs
-    Expiration    abi.ChainEpoch
-}
-
-type SectorProveCommitInfo struct {
-    SectorNumber
-    RegisteredProof
-    Proof             SealProof
-    InteractiveEpoch  abi.ChainEpoch
-    Expiration        abi.ChainEpoch
 }
 
 // PersistentProofAux is meta data required to generate certain proofs
@@ -92,12 +40,12 @@ type PersistentProofAux struct {
 }
 
 type ProofAuxTmp struct {
-    RegisteredProof  // FIXME: Make sure this is supplied.
+    RegisteredProof  abi.RegisteredProof  // FIXME: Make sure this is supplied.
     PersistentAux    PersistentProofAux  // TODO: Move this to sealer.SealOutputs.
 
-    SectorID
+    SectorID         abi.SectorID
     CommD            Commitment
-    CommR            SealedSectorCID
+    CommR            abi.SealedSectorCID
     CommDTreePath    file.Path
     CommCTreePath    file.Path
     CommQTreePath    file.Path
@@ -107,13 +55,9 @@ type ProofAuxTmp struct {
 }
 
 type SealArguments struct {
-    RegisteredProof
-    Algorithm        ProofAlgorithm
+    RegisteredProof  abi.RegisteredProof
+    Algorithm        abi.ProofAlgorithm
     OutputArtifacts  SealOutputArtifacts
-}
-
-type SealProof struct {//<curve, system> {
-    ProofBytes Bytes
 }
 
 // TODO: move into proofs lib
@@ -121,14 +65,3 @@ type FilecoinSNARKProof struct {}  //<bls12-381, Groth16>
 
 // TODO
 type SealOutputArtifacts struct {}
-
-// TODO: PieceInfo is the name used by proofs for this struct, but there also exists a piece.PieceInfo type, which is different.
-// We should probably rename one of them, since this is quite confusing. Or, if we can put `PieceCID` into pieces.PieceInfo, we can just use that.
-type PieceInfo struct {
-    Size      UVarint  // Size in nodes. For BLS12-381 (capacity 254 bits), must be >= 16. (16 * 8 = 128)
-    PieceCID  piece.PieceCID
-}
-
-type PieceInfos struct {
-    Items [PieceInfo]
-}

--- a/src/systems/filecoin_mining/sector/sector.go
+++ b/src/systems/filecoin_mining/sector/sector.go
@@ -1,6 +1,7 @@
 package sector
 
 import (
+	abi "github.com/filecoin-project/specs/actors/abi"
 	util "github.com/filecoin-project/specs/util"
 )
 
@@ -14,42 +15,42 @@ const (
 	TerminatedFault
 )
 
-var PROOFS ProofRegistry = ProofRegistry(map[util.UInt]ProofInstance{util.UInt(RegisteredProof_WinStackedDRG32GiBSeal): &ProofInstance_I{
-	ID_:        RegisteredProof_WinStackedDRG32GiBSeal,
+var PROOFS ProofRegistry = ProofRegistry(map[abi.RegisteredProof]ProofInstance{abi.RegisteredProof_WinStackedDRG32GiBSeal: &ProofInstance_I{
+	ID_:        abi.RegisteredProof_WinStackedDRG32GiBSeal,
 	Type_:      ProofType_SealProof,
-	Algorithm_: ProofAlgorithm_WinStackedDRGSeal,
+	Algorithm_: abi.ProofAlgorithm_WinStackedDRGSeal,
 	CircuitType_: &ConcreteCircuit_I{
 		Name_: "HASHOFCIRCUITDEFINITION1",
 	},
 },
-	util.UInt(RegisteredProof_WinStackedDRG32GiBPoSt): &ProofInstance_I{
-		ID_:        RegisteredProof_WinStackedDRG32GiBPoSt,
+	abi.RegisteredProof_WinStackedDRG32GiBPoSt: &ProofInstance_I{
+		ID_:        abi.RegisteredProof_WinStackedDRG32GiBPoSt,
 		Type_:      ProofType_PoStProof,
-		Algorithm_: ProofAlgorithm_WinStackedDRGPoSt,
+		Algorithm_: abi.ProofAlgorithm_WinStackedDRGPoSt,
 		CircuitType_: &ConcreteCircuit_I{
 			Name_: "HASHOFCIRCUITDEFINITION2",
 		},
 	},
-	util.UInt(RegisteredProof_StackedDRG32GiBSeal): &ProofInstance_I{
-		ID_:        RegisteredProof_StackedDRG32GiBSeal,
+	abi.RegisteredProof_StackedDRG32GiBSeal: &ProofInstance_I{
+		ID_:        abi.RegisteredProof_StackedDRG32GiBSeal,
 		Type_:      ProofType_SealProof,
-		Algorithm_: ProofAlgorithm_StackedDRGSeal,
+		Algorithm_: abi.ProofAlgorithm_StackedDRGSeal,
 		CircuitType_: &ConcreteCircuit_I{
 			Name_: "HASHOFCIRCUITDEFINITION3",
 		},
 	},
-	util.UInt(RegisteredProof_StackedDRG32GiBPoSt): &ProofInstance_I{
-		ID_:        RegisteredProof_StackedDRG32GiBPoSt,
+	abi.RegisteredProof_StackedDRG32GiBPoSt: &ProofInstance_I{
+		ID_:        abi.RegisteredProof_StackedDRG32GiBPoSt,
 		Type_:      ProofType_PoStProof,
-		Algorithm_: ProofAlgorithm_StackedDRGPoSt,
+		Algorithm_: abi.ProofAlgorithm_StackedDRGPoSt,
 		CircuitType_: &ConcreteCircuit_I{
 			Name_: "HASHOFCIRCUITDEFINITION4",
 		},
 	},
 })
 
-func RegisteredProofInstance(r RegisteredProof) ProofInstance {
-	return PROOFS[util.UInt(r)]
+func RegisteredProofInstance(r abi.RegisteredProof) ProofInstance {
+	return PROOFS[r]
 }
 
 func (c *ConcreteCircuit_I) GrothParameterFileName() string {

--- a/src/systems/filecoin_mining/sector/sector.id
+++ b/src/systems/filecoin_mining/sector/sector.id
@@ -1,37 +1,12 @@
+import abi "github.com/filecoin-project/specs/actors/abi"
 import piece "github.com/filecoin-project/specs/systems/filecoin_files/piece"
 import deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
-import abi "github.com/filecoin-project/specs/actors/abi"
-import cid "github.com/ipfs/go-cid"
 
 type Bytes32 Bytes
 type Commitment Bytes32  // TODO
-type UnsealedSectorCID cid.Cid
-type SealedSectorCID cid.Cid
-
-// SectorNumber is a numeric identifier for a sector. It is usually
-// relative to a Miner.
-type SectorNumber UInt
 
 type FaultSet CompactSectorSet
 type StorageFaultType int
-
-// SectorSize indicates one of a set of possible sizes in the network.
-type SectorSize UInt
-
-// Ideally, SectorSize would be an enum
-// type SectorSize enum {
-//   1KiB = UInt 1024
-//   1MiB = Uint 1048576
-//   1GiB = Uint 1073741824
-//   1TiB = Uint 1099511627776
-//   1PiB = Uint 1125899906842624
-// }
-
-// TODO make sure this is globally unique
-type SectorID struct {
-    Miner   abi.ActorID
-    Number  SectorNumber
-}
 
 // SectorInDetail describes all the bits of information associated
 // with each sector.
@@ -40,11 +15,11 @@ type SectorID struct {
 //
 // NOTE: do not use this struct. It is for illustrative purposes only.
 type SectorInDetail struct {
-    ID    SectorID
-    Size  SectorSize
+    ID    abi.SectorID
+    Size  abi.SectorSize
 
     Unsealed struct {
-        CID     UnsealedSectorCID
+        CID     abi.UnsealedSectorCID
         Deals   [deal.StorageDeal]
         Pieces  [piece.Piece]
         // Pieces Tree<Piece> // some tree for proofs
@@ -52,26 +27,26 @@ type SectorInDetail struct {
     }
 
     Sealed struct {
-        CID SealedSectorCID
+        CID              abi.SealedSectorCID
         Bytes
-        RegisteredProof
+        RegisteredProof  abi.RegisteredProof
     }
 }
 
 // SectorInfo is an object that gathers all the information miners know about their
 // sectors. This is meant to be used for a local index.
 type SectorInfo struct {
-    ID                  SectorID
+    ID                  abi.SectorID
     UnsealedInfo        UnsealedSectorInfo
     SealedInfo          SealedSectorInfo
-    SealVerifyInfo
+    SealVerifyInfo      abi.SealVerifyInfo
     PersistentProofAux
 }
 
 // UnsealedSectorInfo is an object that tracks the relevant data to keep in a sector
 type UnsealedSectorInfo struct {
-    UnsealedCID  UnsealedSectorCID  // CommD
-    Size         SectorSize
+    UnsealedCID  abi.UnsealedSectorCID  // CommD
+    Size         abi.SectorSize
     PieceCount   UVarint  // number of pieces in this sector (can get it from len(Pieces) too)
     Pieces       [piece.PieceInfo]  // wont get externalized easy, -- it's big
     // Deals       [deal.StorageDeal]
@@ -79,27 +54,17 @@ type UnsealedSectorInfo struct {
 
 // SealedSectorInfo keeps around information about a sector that has been sealed.
 type SealedSectorInfo struct {
-    SealedCID  SealedSectorCID
-    Size       SectorSize
+    SealedCID  abi.SealedSectorCID
+    Size       abi.SectorSize
     SealArgs   SealArguments
 }
 
-// This ordering, defines mappings to UInt in a way which MUST never change.
-// The commented assignments correspond to the code which will be generated
-// and are included here to facilitate maintaining their
-type RegisteredProof enum {
-    WinStackedDRG32GiBSeal  // = 1
-    WinStackedDRG32GiBPoSt  // = 2
-    StackedDRG32GiBSeal  // = 3
-    StackedDRG32GiBPoSt  // = 4
-}
-
-type ProofRegistry {UInt: ProofInstance}
+type ProofRegistry {abi.RegisteredProof: ProofInstance}
 
 type ProofInstance struct {
-    ID           RegisteredProof
+    ID           abi.RegisteredProof
     Type         ProofType
-    Algorithm    ProofAlgorithm
+    Algorithm    abi.ProofAlgorithm
     CircuitType  ConcreteCircuit
     Partitions   UInt
     Cfg          ProofCfg
@@ -113,13 +78,6 @@ type ProofCfg union {
 type ProofType enum {
     SealProof
     PoStProof
-}
-
-type ProofAlgorithm enum {
-    StackedDRGSeal
-    WinStackedDRGSeal
-    StackedDRGPoSt
-    WinStackedDRGPoSt
 }
 
 type ConcreteCircuit struct {

--- a/src/systems/filecoin_mining/sector/sectorset.go
+++ b/src/systems/filecoin_mining/sector/sectorset.go
@@ -1,25 +1,27 @@
 package sector
 
+import abi "github.com/filecoin-project/specs/actors/abi"
+
 // TODO
-func (css *CompactSectorSet) SectorsOn() []SectorNumber {
-	var sectorNo []SectorNumber
+func (css *CompactSectorSet) SectorsOn() []abi.SectorNumber {
+	var sectorNo []abi.SectorNumber
 	return sectorNo
 }
 
 // TODO
-func (css *CompactSectorSet) SectorsOff() []SectorNumber {
-	var sectorNo []SectorNumber
+func (css *CompactSectorSet) SectorsOff() []abi.SectorNumber {
+	var sectorNo []abi.SectorNumber
 	return sectorNo
 }
 
 // TODO
-func (css *CompactSectorSet) Add(sectorNo SectorNumber) CompactSectorSet {
+func (css *CompactSectorSet) Add(sectorNo abi.SectorNumber) CompactSectorSet {
 	var newCompactSectorSet CompactSectorSet
 	return newCompactSectorSet
 }
 
 // TODO
-func (css *CompactSectorSet) Remove(sectorNo SectorNumber) CompactSectorSet {
+func (css *CompactSectorSet) Remove(sectorNo abi.SectorNumber) CompactSectorSet {
 	var newCompactSectorSet CompactSectorSet
 	return newCompactSectorSet
 }
@@ -37,6 +39,6 @@ func (css *CompactSectorSet) Extend(css2 CompactSectorSet) CompactSectorSet {
 }
 
 // TODO
-func (css *CompactSectorSet) Contain(sectorNo SectorNumber) bool {
+func (css *CompactSectorSet) Contain(sectorNo abi.SectorNumber) bool {
 	return false
 }

--- a/src/systems/filecoin_mining/sector/sectorset.id
+++ b/src/systems/filecoin_mining/sector/sectorset.id
@@ -1,5 +1,7 @@
+import abi "github.com/filecoin-project/specs/actors/abi"
+
 // sector sets
-type SectorSet [SectorID]
+type SectorSet [abi.SectorID]
 type UnsealedSectorSet SectorSet
 type SealedSectorSet SectorSet
 

--- a/src/systems/filecoin_mining/sector_index/sector_builder.id
+++ b/src/systems/filecoin_mining/sector_index/sector_builder.id
@@ -1,5 +1,5 @@
+import abi "github.com/filecoin-project/specs/actors/abi"
 import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
-// import smkt "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market"
 import deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
 
 // SectorBuilder accumulates deals, keeping track of their
@@ -8,7 +8,7 @@ import deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_
 // will return a sector.
 
 type StageDealResponse struct {
-    SectorID sector.SectorID
+    SectorID abi.SectorID
 }
 
 type SectorBuilder struct {

--- a/src/systems/filecoin_mining/sector_index/sector_index_subsystem.go
+++ b/src/systems/filecoin_mining/sector_index/sector_index_subsystem.go
@@ -3,7 +3,6 @@ package sector_index
 import (
 	abi "github.com/filecoin-project/specs/actors/abi"
 	deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
-	sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 )
 
 func (sis *SectorIndexerSubsystem_I) AddNewDeal(deal deal.StorageDeal) StageDealResponse {
@@ -14,10 +13,10 @@ func (sis *SectorIndexerSubsystem_I) AddNewDeal(deal deal.StorageDeal) StageDeal
 // 	panic("TODO")
 // }
 
-func (sis *SectorIndexerSubsystem_I) SectorsExpiredAtEpoch(epoch abi.ChainEpoch) []sector.SectorID {
+func (sis *SectorIndexerSubsystem_I) SectorsExpiredAtEpoch(epoch abi.ChainEpoch) []abi.SectorID {
 	panic("TODO")
 }
 
-func (sis *SectorIndexerSubsystem_I) removeSectors(sectorIDs []sector.SectorID) {
+func (sis *SectorIndexerSubsystem_I) removeSectors(sectorIDs []abi.SectorID) {
 	panic("TODO")
 }

--- a/src/systems/filecoin_mining/sector_index/sector_index_subsystem.id
+++ b/src/systems/filecoin_mining/sector_index/sector_index_subsystem.id
@@ -5,11 +5,11 @@ import deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_
 
 // TODO import this from StorageMarket
 type SectorIndex struct {
-    BySectorID     {sector.SectorID: sector.SectorInfo}
-    ByUnsealedCID  {sector.UnsealedSectorCID: sector.SectorInfo}
-    BySealedCID    {sector.SealedSectorCID: sector.SectorInfo}
+    BySectorID     {abi.SectorID: sector.SectorInfo}
+    ByUnsealedCID  {abi.UnsealedSectorCID: sector.SectorInfo}
+    BySealedCID    {abi.SealedSectorCID: sector.SectorInfo}
     ByPieceID      {piece.PieceID: sector.SectorInfo}
-    ByDealID       {deal.DealID: sector.SectorInfo}
+    ByDealID       {abi.DealID: sector.SectorInfo}
 }
 
 type SectorIndexerSubsystem struct {
@@ -27,8 +27,8 @@ type SectorIndexerSubsystem struct {
 
     // SectorsExpiredAtEpoch returns the set of sectors that expire
     // at a particular epoch.
-    SectorsExpiredAtEpoch(epoch abi.ChainEpoch) [sector.SectorID]
+    SectorsExpiredAtEpoch(epoch abi.ChainEpoch) [abi.SectorID]
 
     // removeSectors removes the given sectorIDs from storage.
-    removeSectors(sectorIDs [sector.SectorID])
+    removeSectors(sectorIDs [abi.SectorID])
 }

--- a/src/systems/filecoin_mining/sector_index/sector_store.id
+++ b/src/systems/filecoin_mining/sector_index/sector_store.id
@@ -1,3 +1,4 @@
+import abi "github.com/filecoin-project/specs/actors/abi"
 import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 import piece "github.com/filecoin-project/specs/systems/filecoin_files/piece"
 import file "github.com/filecoin-project/specs/systems/filecoin_files/file"
@@ -13,27 +14,27 @@ type SectorStore struct {
     // GetSectorFile returns the file for a given sector id.
     // If the SectorID does not have any sector files associated yet, GetSectorFiles
     // returns an error.
-    GetSectorFiles(id sector.SectorID) union {f SectorFiles, err error}
+    GetSectorFiles(id abi.SectorID) union {f SectorFiles, err error}
 
-    GetSectorSealAlgorithm(id sector.SectorID) union {a sector.ProofAlgorithm, err error}
+    GetSectorSealAlgorithm(id abi.SectorID) union {a abi.ProofAlgorithm, err error}
 
     // TODO: This needs to be called when a sector is sealed with the algorithm that was used.
-    SetSectorSealAlgorithm(id sector.SectorID, a sector.ProofAlgorithm) error
+    SetSectorSealAlgorithm(id abi.SectorID, a abi.ProofAlgorithm) error
 
     // Get information, including a merkle tree file/path, needed to generate PoSt for a sector.
-    GetSectorPersistentProofAux(id sector.SectorID) sector.PersistentProofAux
+    GetSectorPersistentProofAux(id abi.SectorID) sector.PersistentProofAux
 
-    StoreSectorPersistentProofAux(id sector.SectorID, proofAux sector.PersistentProofAux) union {proofAux sector.PersistentProofAux, err error}
+    StoreSectorPersistentProofAux(id abi.SectorID, proofAux sector.PersistentProofAux) union {proofAux sector.PersistentProofAux, err error}
 
     // CreateSectorFiles allocates two sector files, one for unsealed and one for
     // sealed sector.
-    CreateSectorFiles(id sector.SectorID) union {f SectorFiles, err error}
+    CreateSectorFiles(id abi.SectorID) union {f SectorFiles, err error}
 }
 
 // SectorFiles is a datastructure that groups two file objects and a sectorID.
 // These files are where unsealed and sealed sectors should go.
 type SectorFiles struct {
-    SectorID  sector.SectorID
+    SectorID  abi.SectorID
     Unsealed  file.File
     Sealed    file.File
 }

--- a/src/systems/filecoin_mining/storage_mining/storage_mining_subsystem.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_mining_subsystem.go
@@ -1,6 +1,5 @@
 package storage_mining
 
-// import sectoridx "github.com/filecoin-project/specs/systems/filecoin_mining/sector_index"
 import (
 	addr "github.com/filecoin-project/go-address"
 	abi "github.com/filecoin-project/specs/actors/abi"
@@ -13,7 +12,6 @@ import (
 	filproofs "github.com/filecoin-project/specs/libraries/filcrypto/filproofs"
 	block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
 	deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
-	sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 	msg "github.com/filecoin-project/specs/systems/filecoin_vm/message"
 	stateTree "github.com/filecoin-project/specs/systems/filecoin_vm/state_tree"
 	util "github.com/filecoin-project/specs/util"
@@ -108,7 +106,7 @@ func (sms *StorageMiningSubsystem_I) _runMiningCycle() {
 			randomness1 := sms._blockchain().BestChain().GetTicketProductionRandSeed(sms._blockchain().LatestEpoch())
 			newTicket := sms.PrepareNewTicket(randomness1, sms.Node().Repository().KeyStore().MinerAddress())
 
-			sms._blockProducer().GenerateBlock(ePoSt, newTicket, chainHead, sms.Node().Repository().KeyStore().MinerAddress())
+			sms._blockProducer().GenerateBlock(*ePoSt, newTicket, chainHead, sms.Node().Repository().KeyStore().MinerAddress())
 		}
 	} else if sma.PoStState().Is_Challenged() {
 		sPoSt := sms._trySurprisePoSt(chainHead.StateTree(), sma)
@@ -116,11 +114,11 @@ func (sms *StorageMiningSubsystem_I) _runMiningCycle() {
 		var gasLimit msg.GasAmount
 		var gasPrice = abi.TokenAmount(0)
 		util.IMPL_FINISH("read from consts (in this case user set param)")
-		sms._submitSurprisePoStMessage(chainHead.StateTree(), sPoSt, gasPrice, gasLimit)
+		sms._submitSurprisePoStMessage(chainHead.StateTree(), *sPoSt, gasPrice, gasLimit)
 	}
 }
 
-func (sms *StorageMiningSubsystem_I) _tryLeaderElection(currState stateTree.StateTree, sma sminact.StorageMinerActorState) sector.OnChainElectionPoStVerifyInfo {
+func (sms *StorageMiningSubsystem_I) _tryLeaderElection(currState stateTree.StateTree, sma sminact.StorageMinerActorState) *abi.OnChainElectionPoStVerifyInfo {
 	// Randomness for ElectionPoSt
 
 	randomnessK := sms._blockchain().BestChain().GetPoStChallengeRandSeed(sms._blockchain().LatestEpoch())
@@ -130,7 +128,7 @@ func (sms *StorageMiningSubsystem_I) _tryLeaderElection(currState stateTree.Stat
 
 	// TODO: add how sectors are actually stored in the SMS proving set
 	util.TODO()
-	provingSet := make([]sector.SectorID, 0)
+	provingSet := make([]abi.SectorID, 0)
 
 	candidates := sms.StorageProving().Impl().GenerateElectionPoStCandidates(postRandomness, provingSet)
 
@@ -138,20 +136,20 @@ func (sms *StorageMiningSubsystem_I) _tryLeaderElection(currState stateTree.Stat
 		return nil // fail to generate post candidates
 	}
 
-	winningCandidates := make([]sector.PoStCandidate, 0)
+	winningCandidates := make([]abi.PoStCandidate, 0)
 
 	var numMinerSectors uint64
 	TODO() // update
 	// numMinerSectors := uint64(len(sma.SectorTable().Impl().ActiveSectors_.SectorsOn()))
 
 	for _, candidate := range candidates {
-		sectorNum := candidate.SectorID().Number()
+		sectorNum := candidate.SectorID.Number
 		sectorWeightDesc, ok := sma.GetStorageWeightDescForSectorMaybe(sectorNum)
 		if !ok {
 			return nil
 		}
 		sectorPower := indices.ConsensusPowerForStorageWeight(sectorWeightDesc)
-		if sms._consensus().IsWinningPartialTicket(currState, candidate.PartialTicket(), sectorPower, numMinerSectors) {
+		if sms._consensus().IsWinningPartialTicket(currState, candidate.PartialTicket, sectorPower, numMinerSectors) {
 			winningCandidates = append(winningCandidates, candidate)
 		}
 	}
@@ -162,10 +160,10 @@ func (sms *StorageMiningSubsystem_I) _tryLeaderElection(currState stateTree.Stat
 
 	postProofs := sms.StorageProving().Impl().CreateElectionPoStProof(postRandomness, winningCandidates)
 
-	electionPoSt := &sector.OnChainElectionPoStVerifyInfo_I{
-		Candidates_: winningCandidates,
-		Randomness_: postRandomness,
-		Proofs_:     postProofs,
+	electionPoSt := &abi.OnChainElectionPoStVerifyInfo{
+		Candidates: winningCandidates,
+		Randomness: postRandomness,
+		Proofs:     postProofs,
 	}
 
 	return electionPoSt
@@ -232,7 +230,7 @@ func (sms *StorageMiningSubsystem_I) _getStoragePowerActorState(stateTree stateT
 	return st
 }
 
-func (sms *StorageMiningSubsystem_I) VerifyElectionPoSt(inds indices.Indices, header block.BlockHeader, onChainInfo sector.OnChainElectionPoStVerifyInfo) bool {
+func (sms *StorageMiningSubsystem_I) VerifyElectionPoSt(inds indices.Indices, header block.BlockHeader, onChainInfo abi.OnChainElectionPoStVerifyInfo) bool {
 	sma := sms._getStorageMinerActorState(header.ParentState(), header.Miner())
 	spa := sms._getStoragePowerActorState(header.ParentState())
 
@@ -248,12 +246,12 @@ func (sms *StorageMiningSubsystem_I) VerifyElectionPoSt(inds indices.Indices, he
 	}
 
 	// 2. verify no duplicate tickets included
-	challengeIndices := make(map[util.UInt]bool)
-	for _, tix := range onChainInfo.Candidates() {
-		if _, ok := challengeIndices[tix.ChallengeIndex()]; ok {
+	challengeIndices := make(map[int64]bool)
+	for _, tix := range onChainInfo.Candidates {
+		if _, ok := challengeIndices[tix.ChallengeIndex]; ok {
 			return false
 		}
-		challengeIndices[tix.ChallengeIndex()] = true
+		challengeIndices[tix.ChallengeIndex] = true
 	}
 
 	// 3. Verify partialTicket values are appropriate
@@ -268,7 +266,7 @@ func (sms *StorageMiningSubsystem_I) VerifyElectionPoSt(inds indices.Indices, he
 	input := filcrypto.DeriveRandWithMinerAddr(filcrypto.DomainSeparationTag_ElectionPoStChallengeSeed, randomness, header.Miner())
 
 	postRand := &filcrypto.VRFResult_I{
-		Output_: onChainInfo.Randomness(),
+		Output_: onChainInfo.Randomness,
 	}
 
 	// TODO if the workerAddress is secp then payload will be the blake2b hash of its public key
@@ -287,20 +285,21 @@ func (sms *StorageMiningSubsystem_I) VerifyElectionPoSt(inds indices.Indices, he
 
 	postCfg := filproofs.ElectionPoStCfg(sectorSize)
 
-	pvInfo := sector.PoStVerifyInfo_I{
-		OnChain_:    onChainInfo,
-		Randomness_: onChainInfo.Randomness(),
+	pvInfo := abi.PoStVerifyInfo{
+		Candidates: onChainInfo.Candidates,
+		Proofs:     onChainInfo.Proofs,
+		Randomness: onChainInfo.Randomness,
 	}
 
 	pv := filproofs.MakeElectionPoStVerifier(postCfg)
 
 	// 5. Verify the PoSt Proof
-	isPoStVerified := pv.VerifyElectionPoSt(&pvInfo)
+	isPoStVerified := pv.VerifyElectionPoSt(pvInfo)
 
 	return isPoStVerified
 }
 
-func (sms *StorageMiningSubsystem_I) _verifyElection(header block.BlockHeader, onChainInfo sector.OnChainElectionPoStVerifyInfo) bool {
+func (sms *StorageMiningSubsystem_I) _verifyElection(header block.BlockHeader, onChainInfo abi.OnChainElectionPoStVerifyInfo) bool {
 	st := sms._getStorageMinerActorState(header.ParentState(), header.Miner())
 
 	var numMinerSectors uint64
@@ -308,21 +307,21 @@ func (sms *StorageMiningSubsystem_I) _verifyElection(header block.BlockHeader, o
 	// TODO: Decide whether to sample sectors uniformly for EPoSt (the cleanest),
 	// or to sample weighted by nominal power.
 
-	for _, info := range onChainInfo.Candidates() {
-		sectorNum := info.SectorID().Number()
+	for _, info := range onChainInfo.Candidates {
+		sectorNum := info.SectorID.Number
 		sectorWeightDesc, ok := st.GetStorageWeightDescForSectorMaybe(sectorNum)
 		if !ok {
 			return false
 		}
 		sectorPower := indices.ConsensusPowerForStorageWeight(sectorWeightDesc)
-		if !sms._consensus().IsWinningPartialTicket(header.ParentState(), info.PartialTicket(), sectorPower, numMinerSectors) {
+		if !sms._consensus().IsWinningPartialTicket(header.ParentState(), info.PartialTicket, sectorPower, numMinerSectors) {
 			return false
 		}
 	}
 	return true
 }
 
-func (sms *StorageMiningSubsystem_I) _trySurprisePoSt(currState stateTree.StateTree, sma sminact.StorageMinerActorState) sector.OnChainSurprisePoStVerifyInfo {
+func (sms *StorageMiningSubsystem_I) _trySurprisePoSt(currState stateTree.StateTree, sma sminact.StorageMinerActorState) *abi.OnChainSurprisePoStVerifyInfo {
 	if !sma.PoStState().Is_Challenged() {
 		return nil
 	}
@@ -335,34 +334,34 @@ func (sms *StorageMiningSubsystem_I) _trySurprisePoSt(currState stateTree.StateT
 
 	// TODO: add how sectors are actually stored in the SMS proving set
 	util.TODO()
-	provingSet := make([]sector.SectorID, 0)
+	provingSet := make([]abi.SectorID, 0)
 
-	candidates := sms.StorageProving().Impl().GenerateSurprisePoStCandidates(sector.PoStRandomness(postRandomness), provingSet)
+	candidates := sms.StorageProving().Impl().GenerateSurprisePoStCandidates(abi.PoStRandomness(postRandomness), provingSet)
 
 	if len(candidates) <= 0 {
 		// Error. Will fail this surprise post and must then redeclare faults
 		return nil // fail to generate post candidates
 	}
 
-	winningCandidates := make([]sector.PoStCandidate, 0)
+	winningCandidates := make([]abi.PoStCandidate, 0)
 	for _, candidate := range candidates {
 		if sma.VerifySurprisePoStMeetsTargetReq(candidate) {
 			winningCandidates = append(winningCandidates, candidate)
 		}
 	}
 
-	postProofs := sms.StorageProving().Impl().CreateSurprisePoStProof(sector.PoStRandomness(postRandomness), winningCandidates)
+	postProofs := sms.StorageProving().Impl().CreateSurprisePoStProof(abi.PoStRandomness(postRandomness), winningCandidates)
 
 	// var ctc sector.ChallengeTicketsCommitment // TODO: proofs to fix when complete
-	surprisePoSt := &sector.OnChainSurprisePoStVerifyInfo_I{
+	surprisePoSt := &abi.OnChainSurprisePoStVerifyInfo{
 		// CommT_:      ctc,
-		Candidates_: winningCandidates,
-		Proofs_:     postProofs,
+		Candidates: winningCandidates,
+		Proofs:     postProofs,
 	}
 	return surprisePoSt
 }
 
-func (sms *StorageMiningSubsystem_I) _submitSurprisePoStMessage(state stateTree.StateTree, sPoSt sector.OnChainSurprisePoStVerifyInfo, gasPrice abi.TokenAmount, gasLimit msg.GasAmount) error {
+func (sms *StorageMiningSubsystem_I) _submitSurprisePoStMessage(state stateTree.StateTree, sPoSt abi.OnChainSurprisePoStVerifyInfo, gasPrice abi.TokenAmount, gasLimit msg.GasAmount) error {
 	// TODO if workerAddr is not a secp key (e.g. BLS) then this will need to be handled differently
 	workerAddr, err := addr.NewSecp256k1Address(sms.Node().Repository().KeyStore().WorkerKey().VRFPublicKey())
 	if err != nil {

--- a/src/systems/filecoin_mining/storage_mining/storage_mining_subsystem.id
+++ b/src/systems/filecoin_mining/storage_mining/storage_mining_subsystem.id
@@ -10,7 +10,6 @@ import blockproducer "github.com/filecoin-project/specs/systems/filecoin_blockch
 import deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
 import storage_proving "github.com/filecoin-project/specs/systems/filecoin_mining/storage_proving"
 import node_base "github.com/filecoin-project/specs/systems/filecoin_nodes/node_base"
-import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 import stateTree "github.com/filecoin-project/specs/systems/filecoin_vm/state_tree"
 import msg "github.com/filecoin-project/specs/systems/filecoin_vm/message"
 import peer "github.com/libp2p/go-libp2p-core/peer"
@@ -71,22 +70,22 @@ type StorageMiningSubsystem struct {
     OnNewRound()
 
     _runMiningCycle()
-    _tryLeaderElection(st stateTree.StateTree, sma sminact.StorageMinerActorState) sector.OnChainElectionPoStVerifyInfo
+    _tryLeaderElection(st stateTree.StateTree, sma sminact.StorageMinerActorState) abi.OnChainElectionPoStVerifyInfo
     _trySurprisePoSt(st stateTree.StateTree, sma sminact.StorageMinerActorState) error
     _submitSurprisePoStMessage(
         state     stateTree.StateTree
-        sPoSt     sector.OnChainSurprisePoStVerifyInfo
+        sPoSt     abi.OnChainSurprisePoStVerifyInfo
         gasPrice  abi.TokenAmount
         gasLimit  msg.GasAmount
     ) error
 
     VerifyElectionPoSt(
         header       block.BlockHeader
-        onChainInfo  sector.OnChainElectionPoStVerifyInfo
+        onChainInfo  abi.OnChainElectionPoStVerifyInfo
     ) bool
 
     _verifyElection(
         header       block.BlockHeader
-        onChainInfo  sector.OnChainElectionPoStVerifyInfo
+        onChainInfo  abi.OnChainElectionPoStVerifyInfo
     ) bool
 }

--- a/src/systems/filecoin_mining/storage_proving/poster/post_generator.go
+++ b/src/systems/filecoin_mining/storage_proving/poster/post_generator.go
@@ -1,9 +1,9 @@
 package poster
 
 import (
+	abi "github.com/filecoin-project/specs/actors/abi"
 	filproofs "github.com/filecoin-project/specs/libraries/filcrypto/filproofs"
 	sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
-
 	util "github.com/filecoin-project/specs/util"
 )
 
@@ -13,7 +13,7 @@ type Serialization = util.Serialization
 // TODO: Unify with orient model.
 const POST_CHALLENGE_DEADLINE = uint(480)
 
-func (pg *PoStGenerator_I) GeneratePoStCandidates(challengeSeed sector.PoStRandomness, candidateCount int, sectors []sector.SectorID) []sector.PoStCandidate {
+func (pg *PoStGenerator_I) GeneratePoStCandidates(challengeSeed abi.PoStRandomness, candidateCount int, sectors []abi.SectorID) []abi.PoStCandidate {
 	// Question: Should we pass metadata into FilProofs so it can interact with SectorStore directly?
 	// Like this:
 	// PoStReponse := SectorStorageSubsystem.GeneratePoSt(sectorSize, challenge, faults, sectorsMetatada);
@@ -30,21 +30,21 @@ func (pg *PoStGenerator_I) GeneratePoStCandidates(challengeSeed sector.PoStRando
 	return filproofs.GenerateElectionPoStCandidates(pg.PoStCfg(), challengeSeed, sectors, candidateCount, pg.SectorStore())
 }
 
-func (pg *PoStGenerator_I) CreateElectionPoStProof(randomness sector.PoStRandomness, witness sector.PoStWitness) []sector.PoStProof {
-	var privateProofs []sector.PrivatePoStCandidateProof
+func (pg *PoStGenerator_I) CreateElectionPoStProof(randomness abi.PoStRandomness, witness sector.PoStWitness) []abi.PoStProof {
+	var privateProofs []abi.PrivatePoStCandidateProof
 
 	for _, candidate := range witness.Candidates() {
-		privateProofs = append(privateProofs, candidate.PrivateProof())
+		privateProofs = append(privateProofs, candidate.PrivateProof)
 	}
 
 	return filproofs.CreateElectionPoStProof(pg.PoStCfg(), privateProofs, randomness)
 }
 
-func (pg *PoStGenerator_I) CreateSurprisePoStProof(postCfg sector.PoStInstanceCfg, randomness sector.PoStRandomness, witness sector.PoStWitness) []sector.PoStProof {
-	var privateProofs []sector.PrivatePoStCandidateProof
+func (pg *PoStGenerator_I) CreateSurprisePoStProof(postCfg sector.PoStInstanceCfg, randomness abi.PoStRandomness, witness sector.PoStWitness) []abi.PoStProof {
+	var privateProofs []abi.PrivatePoStCandidateProof
 
 	for _, candidate := range witness.Candidates() {
-		privateProofs = append(privateProofs, candidate.PrivateProof())
+		privateProofs = append(privateProofs, candidate.PrivateProof)
 	}
 
 	return filproofs.CreateSurprisePoStProof(pg.PoStCfg(), privateProofs, randomness)

--- a/src/systems/filecoin_mining/storage_proving/poster/post_generator.id
+++ b/src/systems/filecoin_mining/storage_proving/poster/post_generator.id
@@ -9,7 +9,7 @@ type UInt64 UInt
 // - filproofs - may have to learn about Sectors (and if we move Seal stuff, Deals)
 // - "blockchain/builtins" or something like that - a component in the blockchain that handles storage verification
 type PoStSubmission struct {
-    PostProof   sector.PoStProof
+    PostProof   abi.PoStProof
     ChainEpoch  abi.ChainEpoch
 }
 
@@ -18,24 +18,24 @@ type PoStGenerator struct {
     SectorStore  sector_index.SectorStore
 
     GeneratePoStCandidates(
-        challengeSeed   sector.PoStRandomness
+        challengeSeed   abi.PoStRandomness
         candidateCount  UInt
-        sectors         [sector.SectorID]
-    ) [sector.PoStCandidate]
+        sectors         [abi.SectorID]
+    ) [abi.PoStCandidate]
 
     CreateElectionPoStProof(
-        randomness  sector.PoStRandomness
+        randomness  abi.PoStRandomness
         witness     sector.PoStWitness
-    ) [sector.PoStProof]
+    ) [abi.PoStProof]
 
     CreateSurprisePoStProof(
-        randomness  sector.PoStRandomness
+        randomness  abi.PoStRandomness
         witness     sector.PoStWitness
-    ) [sector.PoStProof]
+    ) [abi.PoStProof]
 
     // FIXME: Verification shouldn't require a PoStGenerator. Move this.
     VerifyPoStProof(
-        Proof          sector.PoStProof
-        challengeSeed  sector.PoStRandomness
+        Proof          abi.PoStProof
+        challengeSeed  abi.PoStRandomness
     ) bool
 }

--- a/src/systems/filecoin_mining/storage_proving/sealer/sealer.go
+++ b/src/systems/filecoin_mining/storage_proving/sealer/sealer.go
@@ -2,6 +2,7 @@ package sealer
 
 import "errors"
 
+import abi "github.com/filecoin-project/specs/actors/abi"
 import util "github.com/filecoin-project/specs/util"
 import filproofs "github.com/filecoin-project/specs/libraries/filcrypto/filproofs"
 import file "github.com/filecoin-project/specs/systems/filecoin_files/file"
@@ -77,18 +78,18 @@ func (s *SectorSealer_I) CreateSealProof(si CreateSealProofInputs) *SectorSealer
 	sdr := filproofs.WinSDRParams(cfg)
 	proof := sdr.CreateSealProof(randomSeed, auxTmp)
 
-	onChain := sector.OnChainSealVerifyInfo_I{
-		SealedCID_: auxTmp.CommR(),
+	onChain := abi.OnChainSealVerifyInfo{
+		SealedCID: auxTmp.CommR(),
 		// Epoch_:  ? // TODO
-		Proof_: proof,
+		Proof: proof,
 	}
 
 	return SectorSealer_CreateSealProof_FunRet_Make_so(
 		SectorSealer_CreateSealProof_FunRet_so(
 			&CreateSealProofOutputs_I{
-				SealInfo_: &sector.SealVerifyInfo_I{
-					SectorID_: sid,
-					OnChain_:  &onChain,
+				SealInfo_: abi.SealVerifyInfo{
+					SectorID: sid,
+					OnChain:  onChain,
 				},
 				ProofAux_: aux,
 			})).Impl()

--- a/src/systems/filecoin_mining/storage_proving/sealer/sealer.id
+++ b/src/systems/filecoin_mining/storage_proving/sealer/sealer.id
@@ -1,23 +1,23 @@
+import abi "github.com/filecoin-project/specs/actors/abi"
 import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 import file "github.com/filecoin-project/specs/systems/filecoin_files/file"
 import addr "github.com/filecoin-project/go-address"
-import deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
 
 type SealInputs struct {
-    RegisteredProof  sector.RegisteredProof  // FIXME: Ensure this is provided.
-    SectorID         sector.SectorID
+    RegisteredProof  abi.RegisteredProof  // FIXME: Ensure this is provided.
+    SectorID         abi.SectorID
     SealCfg          sector.SealInstanceCfg
     MinerID          addr.Address
-    RandomSeed       sector.SealRandomness
+    RandomSeed       abi.SealRandomness
     UnsealedPath     file.Path
     SealedPath       file.Path
-    DealIDs          [deal.DealID]
+    DealIDs          [abi.DealID]
 }
 
 type CreateSealProofInputs struct {
-    SectorID               sector.SectorID
+    SectorID               abi.SectorID
     SealCfg                sector.SealInstanceCfg
-    InteractiveRandomSeed  sector.InteractiveSealRandomness
+    InteractiveRandomSeed  abi.InteractiveSealRandomness
     SealedPaths            [file.Path]
     SealOutputs
 }
@@ -27,7 +27,7 @@ type SealOutputs struct {
 }
 
 type CreateSealProofOutputs struct {
-    SealInfo  sector.SealVerifyInfo
+    SealInfo  abi.SealVerifyInfo
     ProofAux  sector.PersistentProofAux
 }
 

--- a/src/systems/filecoin_mining/storage_proving/storage_proving_subsystem.go
+++ b/src/systems/filecoin_mining/storage_proving/storage_proving_subsystem.go
@@ -1,14 +1,15 @@
 package storage_proving
 
 import (
+	abi "github.com/filecoin-project/specs/actors/abi"
 	filproofs "github.com/filecoin-project/specs/libraries/filcrypto/filproofs"
 	sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 	node_base "github.com/filecoin-project/specs/systems/filecoin_nodes/node_base"
 	util "github.com/filecoin-project/specs/util"
 )
 
-func (sps *StorageProvingSubsystem_I) VerifySeal(sv sector.SealVerifyInfo) StorageProvingSubsystem_VerifySeal_FunRet {
-	registeredProof := sv.OnChain().RegisteredProof()
+func (sps *StorageProvingSubsystem_I) VerifySeal(sv abi.SealVerifyInfo) StorageProvingSubsystem_VerifySeal_FunRet {
+	registeredProof := sv.OnChain.RegisteredProof
 	proofInstance := sector.RegisteredProofInstance(registeredProof)
 
 	var result bool
@@ -16,14 +17,14 @@ func (sps *StorageProvingSubsystem_I) VerifySeal(sv sector.SealVerifyInfo) Stora
 	// TODO: Presumably this can be done with interfaces or whatever method we intend for such things,
 	// but for now this expresses intent simply enough.
 	switch proofInstance.Algorithm() {
-	case sector.ProofAlgorithm_WinStackedDRGSeal:
+	case abi.ProofAlgorithm_WinStackedDRGSeal:
 		result = filproofs.WinSDRParams(proofInstance.Cfg().As_SealCfg()).VerifySeal(sv)
 	}
 
 	return StorageProvingSubsystem_VerifySeal_FunRet_Make_ok(StorageProvingSubsystem_VerifySeal_FunRet_ok(result)) //,
 }
 
-func (sps *StorageProvingSubsystem_I) ComputeUnsealedSectorCID(sectorSize sector.SectorSize, pieceInfos []sector.PieceInfo) StorageProvingSubsystem_ComputeUnsealedSectorCID_FunRet {
+func (sps *StorageProvingSubsystem_I) ComputeUnsealedSectorCID(sectorSize abi.SectorSize, pieceInfos []abi.PieceInfo) StorageProvingSubsystem_ComputeUnsealedSectorCID_FunRet {
 	unsealedCID, err := filproofs.ComputeUnsealedSectorCIDFromPieceInfos(sectorSize, pieceInfos)
 
 	if err != nil {
@@ -35,7 +36,7 @@ func (sps *StorageProvingSubsystem_I) ComputeUnsealedSectorCID(sectorSize sector
 }
 
 // TODO also return error
-func (sps *StorageProvingSubsystem_I) GenerateElectionPoStCandidates(challengeSeed sector.PoStRandomness, sectorIDs []sector.SectorID) []sector.PoStCandidate {
+func (sps *StorageProvingSubsystem_I) GenerateElectionPoStCandidates(challengeSeed abi.PoStRandomness, sectorIDs []abi.SectorID) []abi.PoStCandidate {
 	numChallengeTickets := util.UInt(len(sectorIDs) * node_base.EPOST_SAMPLE_RATE_NUM / node_base.EPOST_SAMPLE_RATE_DENOM)
 
 	var poster = sps.PoStGenerator()
@@ -43,7 +44,7 @@ func (sps *StorageProvingSubsystem_I) GenerateElectionPoStCandidates(challengeSe
 	return poster.GeneratePoStCandidates(challengeSeed, numChallengeTickets, sectorIDs)
 }
 
-func (sps *StorageProvingSubsystem_I) CreateElectionPoStProof(challengeSeed sector.PoStRandomness, candidates []sector.PoStCandidate) []sector.PoStProof {
+func (sps *StorageProvingSubsystem_I) CreateElectionPoStProof(challengeSeed abi.PoStRandomness, candidates []abi.PoStCandidate) []abi.PoStProof {
 	witness := &sector.PoStWitness_I{
 		Candidates_: candidates,
 	}
@@ -53,7 +54,7 @@ func (sps *StorageProvingSubsystem_I) CreateElectionPoStProof(challengeSeed sect
 }
 
 // TODO also return error
-func (sps *StorageProvingSubsystem_I) GenerateSurprisePoStCandidates(challengeSeed sector.PoStRandomness, sectorIDs []sector.SectorID) []sector.PoStCandidate {
+func (sps *StorageProvingSubsystem_I) GenerateSurprisePoStCandidates(challengeSeed abi.PoStRandomness, sectorIDs []abi.SectorID) []abi.PoStCandidate {
 	numChallengeTickets := util.UInt(len(sectorIDs) * node_base.SPOST_SAMPLE_RATE_NUM / node_base.SPOST_SAMPLE_RATE_DENOM)
 
 	var poster = sps.PoStGenerator()
@@ -61,7 +62,7 @@ func (sps *StorageProvingSubsystem_I) GenerateSurprisePoStCandidates(challengeSe
 	return poster.GeneratePoStCandidates(challengeSeed, numChallengeTickets, sectorIDs)
 }
 
-func (sps *StorageProvingSubsystem_I) CreateSurprisePoStProof(challengeSeed sector.PoStRandomness, candidates []sector.PoStCandidate) []sector.PoStProof {
+func (sps *StorageProvingSubsystem_I) CreateSurprisePoStProof(challengeSeed abi.PoStRandomness, candidates []abi.PoStCandidate) []abi.PoStProof {
 	witness := &sector.PoStWitness_I{
 		Candidates_: candidates,
 	}

--- a/src/systems/filecoin_mining/storage_proving/storage_proving_subsystem.id
+++ b/src/systems/filecoin_mining/storage_proving/storage_proving_subsystem.id
@@ -1,4 +1,4 @@
-import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
+import abi "github.com/filecoin-project/specs/actors/abi"
 import poster "github.com/filecoin-project/specs/systems/filecoin_mining/storage_proving/poster"
 import sealer "github.com/filecoin-project/specs/systems/filecoin_mining/storage_proving/sealer"
 import block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
@@ -7,8 +7,8 @@ type StorageProvingSubsystem struct {
     SectorSealer   sealer.SectorSealer
     PoStGenerator  poster.PoStGenerator
 
-    VerifySeal(sv sector.SealVerifyInfo, pieceInfos [sector.PieceInfo]) union {ok bool, err error}
-    ComputeUnsealedSectorCID(sectorSize UInt, pieceInfos [sector.PieceInfo]) union {unsealedSectorCID sector.UnsealedSectorCID, err error}
+    VerifySeal(sv abi.SealVerifyInfo, pieceInfos [abi.PieceInfo]) union {ok bool, err error}
+    ComputeUnsealedSectorCID(sectorSize UInt, pieceInfos [abi.PieceInfo]) union {unsealedSectorCID abi.UnsealedSectorCID, err error}
 
     ValidateBlock(block block.Block)
 
@@ -16,22 +16,22 @@ type StorageProvingSubsystem struct {
     // GetPieceInclusionProof(pieceRef CID) union { PieceInclusionProofs, error }
 
     GenerateElectionPoStCandidates(
-        challengeSeed  sector.PoStRandomness
-        sectorIDs      [sector.SectorID]
-    ) [sector.PoStCandidate]
+        challengeSeed  abi.PoStRandomness
+        sectorIDs      [abi.SectorID]
+    ) [abi.PoStCandidate]
 
     GenerateSurprisePoStCandidates(
-        challengeSeed  sector.PoStRandomness
-        sectorIDs      [sector.SectorID]
-    ) [sector.PoStCandidate]
+        challengeSeed  abi.PoStRandomness
+        sectorIDs      [abi.SectorID]
+    ) [abi.PoStCandidate]
 
     CreateElectionPoStProof(
-        challengeSeed  sector.PoStRandomness
-        candidates     [sector.PoStCandidate]
-    ) [sector.PoStProof]
+        challengeSeed  abi.PoStRandomness
+        candidates     [abi.PoStCandidate]
+    ) [abi.PoStProof]
 
     CreateSurprisePoStProof(
-        challengeSeed  sector.PoStRandomness
-        candidates     [sector.PoStCandidate]
-    ) [sector.PoStProof]
+        challengeSeed  abi.PoStRandomness
+        candidates     [abi.PoStCandidate]
+    ) [abi.PoStProof]
 }


### PR DESCRIPTION
A bunch of types are used by multiple actors, so they moved to abi (I think with some refactoring some could move on to a single actor).

All the action is in the `actors/abi/*.go` files, and the various id files from which those types were yanked. The rest is mechanical update of imports and coping with conversion from `.id`.