### PR TITLE
refactor: replace PeerID and PeerInfo with go-libp2p-core/peer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: circleci/golang:1.12
+      - image: circleci/golang:1.13
     steps:
       - checkout
       - run:

--- a/src/actors/builtin/storage_miner/storage_miner_actor.id
+++ b/src/actors/builtin/storage_miner/storage_miner_actor.id
@@ -3,9 +3,9 @@ import autil "github.com/filecoin-project/specs/actors/util"
 import address "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
 import filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
-import libp2p "github.com/filecoin-project/specs/libraries/libp2p"
 import sealing "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
+import peer "github.com/libp2p/go-libp2p-core/peer"
 
 type MinerPoStState union {
     // Normal operation: The miner has passed either an ElectionPoSt or a SurprisePoSt
@@ -95,7 +95,7 @@ type MinerInfo struct {
     WorkerVRFKey            filcrypto.VRFPublicKey
 
     // Libp2p identity that should be used when connecting to this miner.
-    PeerId                  libp2p.PeerID
+    PeerId                  peer.ID
 
     // Amount of space in each sector committed to the network by this miner.
     SectorSize              sector.SectorSize

--- a/src/actors/builtin/storage_miner/storage_miner_actor_code.go
+++ b/src/actors/builtin/storage_miner/storage_miner_actor_code.go
@@ -9,12 +9,12 @@ import (
 	autil "github.com/filecoin-project/specs/actors/util"
 	filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
 	filproofs "github.com/filecoin-project/specs/libraries/filcrypto/filproofs"
-	libp2p "github.com/filecoin-project/specs/libraries/libp2p"
 	deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
 	sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 	node_base "github.com/filecoin-project/specs/systems/filecoin_nodes/node_base"
 	addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 	ai "github.com/filecoin-project/specs/systems/filecoin_vm/actor_interfaces"
+	peer "github.com/libp2p/go-libp2p-core/peer"
 )
 
 const epochUndefined = abi.ChainEpoch(-1)
@@ -372,7 +372,7 @@ func (a *StorageMinerActorCode_I) OnDeferredCronEvent(rt Runtime, sectorNumbers 
 /////////////////
 
 func (a *StorageMinerActorCode_I) Constructor(
-	rt Runtime, ownerAddr addr.Address, workerAddr addr.Address, sectorSize sector.SectorSize, peerId libp2p.PeerID) {
+	rt Runtime, ownerAddr addr.Address, workerAddr addr.Address, sectorSize sector.SectorSize, peerId peer.ID) {
 
 	rt.ValidateImmediateCallerIs(addr.StoragePowerActorAddr)
 	h := rt.AcquireState()

--- a/src/actors/builtin/storage_miner/storage_miner_actor_state.go
+++ b/src/actors/builtin/storage_miner/storage_miner_actor_state.go
@@ -4,10 +4,10 @@ import (
 	abi "github.com/filecoin-project/specs/actors/abi"
 	indices "github.com/filecoin-project/specs/actors/runtime/indices"
 	actor_util "github.com/filecoin-project/specs/actors/util"
-	libp2p "github.com/filecoin-project/specs/libraries/libp2p"
 	deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
 	sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 	addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
+	peer "github.com/libp2p/go-libp2p-core/peer"
 )
 
 func (st *StorageMinerActorState_I) _getSectorOnChainInfo(sectorNo sector.SectorNumber) (info SectorOnChainInfo, ok bool) {
@@ -109,7 +109,7 @@ func (x *SectorOnChainInfo_I) EffectiveFaultEndEpoch() abi.ChainEpoch {
 }
 
 func MinerInfo_New(
-	ownerAddr addr.Address, workerAddr addr.Address, sectorSize sector.SectorSize, peerId libp2p.PeerID) MinerInfo {
+	ownerAddr addr.Address, workerAddr addr.Address, sectorSize sector.SectorSize, peerId peer.ID) MinerInfo {
 
 	ret := &MinerInfo_I{
 		Owner_:      ownerAddr,

--- a/src/actors/builtin/storage_power/storage_power_actor_code.go
+++ b/src/actors/builtin/storage_power/storage_power_actor_code.go
@@ -10,10 +10,10 @@ import (
 	serde "github.com/filecoin-project/specs/actors/serde"
 	autil "github.com/filecoin-project/specs/actors/util"
 	filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
-	libp2p "github.com/filecoin-project/specs/libraries/libp2p"
 	sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 	addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 	ai "github.com/filecoin-project/specs/systems/filecoin_vm/actor_interfaces"
+	peer "github.com/libp2p/go-libp2p-core/peer"
 )
 
 type ConsensusFaultType int
@@ -64,7 +64,7 @@ func (a *StoragePowerActorCode_I) WithdrawBalance(rt Runtime, minerAddr addr.Add
 	rt.SendFunds(recipientAddr, amountExtracted)
 }
 
-func (a *StoragePowerActorCode_I) CreateMiner(rt Runtime, workerAddr addr.Address, sectorSize sector.SectorSize, peerId libp2p.PeerID) addr.Address {
+func (a *StoragePowerActorCode_I) CreateMiner(rt Runtime, workerAddr addr.Address, sectorSize sector.SectorSize, peerId peer.ID) addr.Address {
 	vmr.RT_ValidateImmediateCallerIsSignable(rt)
 	ownerAddr := rt.ImmediateCaller()
 

--- a/src/build_go.mod
+++ b/src/build_go.mod
@@ -1,3 +1,3 @@
 module github.com/filecoin-project/specs
 
-go 1.12
+go 1.13

--- a/src/libraries/libp2p/libp2p.id
+++ b/src/libraries/libp2p/libp2p.id
@@ -1,20 +1,17 @@
-import ipld "github.com/filecoin-project/specs/libraries/ipld"
 import mf "github.com/filecoin-project/specs/libraries/multiformats"
-
-// PeerID is the CID of the public key of this peer
-type PeerID ipld.CID
+import peer "github.com/libp2p/go-libp2p-core/peer"
 
 // PeerInfo is a simple datastructure that relates PeerIDs to corresponding partial Multiaddrs.
 // This is a convenience struct used in interfaces where we must specify both, or may specify
 // either.
 type PeerInfo struct {
-    PeerID
+    PeerID peer.ID
     Addrs [mf.Multiaddr]
 }
 
 type Node struct {
     // PeerID returns the PeerID associated with this libp2p Node
-    PeerID() PeerID
+    PeerID() peer.ID
 
     // MountProtocol adds given Protocol under specified protocol id.
     MountProtocol(path ProtocolPath, protocol Protocol)

--- a/src/libraries/libp2p/libp2p.id
+++ b/src/libraries/libp2p/libp2p.id
@@ -1,13 +1,4 @@
-import mf "github.com/filecoin-project/specs/libraries/multiformats"
 import peer "github.com/libp2p/go-libp2p-core/peer"
-
-// PeerInfo is a simple datastructure that relates PeerIDs to corresponding partial Multiaddrs.
-// This is a convenience struct used in interfaces where we must specify both, or may specify
-// either.
-type PeerInfo struct {
-    PeerID peer.ID
-    Addrs [mf.Multiaddr]
-}
 
 type Node struct {
     // PeerID returns the PeerID associated with this libp2p Node
@@ -18,14 +9,14 @@ type Node struct {
 
     // ConnectPeerID establishes a connection to peer matching given PeerInfo.
     //
-    // PeerInfo.Addrs may be empty. If so:
+    // peer.AddrInfo may be empty. If so:
     // - Libp2pNode will try to use any Multiaddrs it knows (internal PeerStore)
     // - Libp2pNode may use any `PeerRouting` protocol mounted onto the libp2p node.
     //     TODO: how to define this.
     //     NOTE: probably implies using kad-dht or gossipsub for this.
     //
     // Idempotent. If a connection already exists, this method returns silently.
-    Connect(peerInfo PeerInfo)
+    Connect(peerInfo peer.AddrInfo)
 }
 
 type ProtocolPath string
@@ -61,12 +52,12 @@ type StreamProtocol struct {
     // AcceptStream accepts an incoming stream connection.
     AcceptStream() struct {
         stream    Stream
-        peerInfo  PeerInfo
+        peerInfo  peer.AddrInfo
         err       error
     }
 
     // OpenStream opens a stream to a particular PeerID.
-    OpenStream(peerInfo PeerInfo) struct {
+    OpenStream(peerInfo peer.AddrInfo) struct {
         stream  Stream
         err     error
     }
@@ -87,12 +78,12 @@ type DatagramProtocol struct {
     // AcceptDatagram accepts an incoming message.
     AcceptDatagram() struct {
         datagram  Datagram
-        peerInfo  PeerInfo
+        peerInfo  peer.AddrInfo
         err       error
     }
 
     // OpenStream opens a stream to a particular PeerID
-    SendDatagram(datagram Datagram, peerInfo PeerInfo) struct {err error}
+    SendDatagram(datagram Datagram, peerInfo peer.AddrInfo) struct {err error}
 }
 
 // type StorageDealLibp2pProtocol struct {

--- a/src/systems/filecoin_files/data_transfer/data_transfer_subsystem.id
+++ b/src/systems/filecoin_files/data_transfer/data_transfer_subsystem.id
@@ -1,7 +1,7 @@
 import ipld "github.com/filecoin-project/specs/libraries/ipld"
 import libp2p "github.com/filecoin-project/specs/libraries/libp2p"
-
 import piece "github.com/filecoin-project/specs/systems/filecoin_files/piece"
+import peer "github.com/libp2p/go-libp2p-core/peer"
 
 type StorageDeal struct {}
 type RetrievalDeal struct {}
@@ -39,7 +39,7 @@ type DataTransferStatus union {
 type TransferID UInt
 
 type ChannelID struct {
-    to libp2p.PeerID
+    to peer.ID
     id TransferID
 }
 
@@ -54,9 +54,9 @@ type DataTransferChannel struct {
     // used to verify this channel
     voucher     DataTransferVoucher
     // the party that is sending the data (not who initiated the request)
-    sender      libp2p.PeerID
+    sender      peer.ID
     // the party that is receiving the data (not who initiated the request)
-    recipient   libp2p.PeerID
+    recipient   peer.ID
     // expected amount of data to be transferred
     totalSize   UVarint
 }
@@ -71,7 +71,7 @@ type DataTransferState struct @(mutable) {
 }
 
 type Open struct {
-    Initiator libp2p.PeerID
+    Initiator peer.ID
 }
 
 type SendData struct {
@@ -83,7 +83,7 @@ type Progress struct {
 }
 
 type Pause struct {
-    Initiator libp2p.PeerID
+    Initiator peer.ID
 }
 
 type Error struct {
@@ -108,19 +108,19 @@ type DataTransferSubscriber struct {
 // RequestValidator is an interface implemented by the client of the data transfer module to validate requests
 type RequestValidator struct {
     ValidatePush(
-        sender    libp2p.PeerID
+        sender    peer.ID
         voucher   DataTransferVoucher
         PieceRef  ipld.CID
         Selector  ipld.Selector
     )
     ValidatePull(
-        receiver  libp2p.PeerID
+        receiver  peer.ID
         voucher   DataTransferVoucher
         PieceRef  ipld.CID
         Selector  ipld.Selector
     )
     ValidateIntermediate(
-        otherPeer  libp2p.PeerID
+        otherPeer  peer.ID
         voucher    DataTransferVoucher
         PieceRef   ipld.CID
         Selector   ipld.Selector
@@ -137,7 +137,7 @@ type DataTransferSubsystem struct @(mutable) {
     // open a data transfer that will send data to the recipient peer and
     // transfer parts of the piece that match the selector
     OpenPushDataChannel(
-        to        libp2p.PeerID
+        to        peer.ID
         voucher   DataTransferVoucher
         PieceRef  ipld.CID
         Selector  ipld.Selector
@@ -146,7 +146,7 @@ type DataTransferSubsystem struct @(mutable) {
     // open a data transfer that will request data from the sending peer and
     // transfer parts of the piece that match the selector
     OpenPullDataChannel(
-        to        libp2p.PeerID
+        to        peer.ID
         voucher   DataTransferVoucher
         PieceRef  ipld.CID
         Selector  ipld.Selector

--- a/src/systems/filecoin_markets/retrieval_market/retrieval_client.id
+++ b/src/systems/filecoin_markets/retrieval_market/retrieval_client.id
@@ -1,12 +1,12 @@
 import abi "github.com/filecoin-project/specs/actors/abi"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
-import libp2p "github.com/filecoin-project/specs/libraries/libp2p"
 import piece "github.com/filecoin-project/specs/systems/filecoin_files/piece"
+import peer "github.com/libp2p/go-libp2p-core/peer"
 
 type RetrievalClientDealState struct {
     RetrievalDealProposal
     Status                 DealStatus
-    Sender                 libp2p.PeerID
+    Sender                 peer.ID
     TotalReceived          UInt
     FundsSpent             abi.TokenAmount
 }
@@ -41,7 +41,7 @@ type RetrievalClient struct {
         pieceCID      piece.PieceCID
         params        RetrievalParams
         totalFunds    abi.TokenAmount
-        miner         libp2p.PeerID
+        miner         peer.ID
         clientWallet  addr.Address
         minerWallet   addr.Address
     ) RetrievalDealID

--- a/src/systems/filecoin_markets/retrieval_market/retrieval_provider.id
+++ b/src/systems/filecoin_markets/retrieval_market/retrieval_provider.id
@@ -1,10 +1,10 @@
 import abi "github.com/filecoin-project/specs/actors/abi"
-import libp2p "github.com/filecoin-project/specs/libraries/libp2p"
+import peer "github.com/libp2p/go-libp2p-core/peer"
 
 type RetrievalProviderDealState struct {
     RetrievalDealProposal
     Status                 DealStatus
-    Receiver               libp2p.PeerID
+    Receiver               peer.ID
     TotalSent              UInt
     FundsReceived          abi.TokenAmount
 }
@@ -17,7 +17,7 @@ type RetrievalProviderEvent struct {
 }
 
 type RetrievalProviderDealID struct {
-    From  libp2p.PeerID
+    From  peer.ID
     ID    RetrievalDealID
 }
 

--- a/src/systems/filecoin_markets/retrieval_market/types.id
+++ b/src/systems/filecoin_markets/retrieval_market/types.id
@@ -1,14 +1,14 @@
 import ipld "github.com/filecoin-project/specs/libraries/ipld"
-import libp2p "github.com/filecoin-project/specs/libraries/libp2p"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import abi "github.com/filecoin-project/specs/actors/abi"
 import piece "github.com/filecoin-project/specs/systems/filecoin_files/piece"
+import peer "github.com/libp2p/go-libp2p-core/peer"
 
 type PaymentVoucher struct {}
 
 type RetrievalPeer struct {
     Address  addr.Address
-    ID       libp2p.PeerID  // optional
+    ID       peer.ID  // optional
 }
 
 type Available struct {}

--- a/src/systems/filecoin_markets/storage_market/storage_client.id
+++ b/src/systems/filecoin_markets/storage_market/storage_client.id
@@ -1,9 +1,9 @@
 import ipld "github.com/filecoin-project/specs/libraries/ipld"
 import deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
 import abi "github.com/filecoin-project/specs/actors/abi"
-import libp2p "github.com/filecoin-project/specs/libraries/libp2p"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import message "github.com/filecoin-project/specs/systems/filecoin_vm/message"
+import peer "github.com/libp2p/go-libp2p-core/peer"
 
 // ClientLocalDealInfo is the information about a storage deal that storage client tracks
 // locally about a deal until it goes on chain. It is persisted to local storage
@@ -12,7 +12,7 @@ type ClientLocalDealInfo struct {
     ProposalCid     &deal.StorageDealProposal
     Proposal        deal.StorageDealProposal
     State           StorageDealStatus
-    MinerPeerID     libp2p.PeerID
+    MinerPeerID     peer.ID
     MinerWorker     addr.Address
     DealID          deal.DealID
     PublishMessage  &message.SignedMessage
@@ -27,7 +27,7 @@ type ProposeStorageDealResult struct {
 type StorageProviderInfo struct {
     Address     addr.Address  // actor address
     SectorSize  uint64
-    PeerID      libp2p.PeerID
+    PeerID      peer.ID
 }
 
 type StorageClient struct {

--- a/src/systems/filecoin_markets/storage_market/storage_provider.id
+++ b/src/systems/filecoin_markets/storage_market/storage_provider.id
@@ -1,10 +1,10 @@
 import ipld "github.com/filecoin-project/specs/libraries/ipld"
 import deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
 import abi "github.com/filecoin-project/specs/actors/abi"
-import libp2p "github.com/filecoin-project/specs/libraries/libp2p"
 import addr "github.com/filecoin-project/specs/systems/filecoin_vm/actor/address"
 import dt "github.com/filecoin-project/specs/systems/filecoin_files/data_transfer"
 import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
+import peer "github.com/libp2p/go-libp2p-core/peer"
 
 // ProviderLocalDealInfo is the information that a storage provider tracks locally about
 // a deal. It contains not only the storage proposal but the state of the deal
@@ -13,8 +13,8 @@ import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 type ProviderLocalDealInfo struct {
     ProposalCid   &deal.StorageDealProposal
     Proposal      deal.StorageDealProposal
-    MinerPeerID   libp2p.PeerID
-    ClientPeerID  libp2p.PeerID
+    MinerPeerID   peer.ID
+    ClientPeerID  peer.ID
     Status        StorageDealStatus
 
     PayloadID     ipld.CID
@@ -44,13 +44,13 @@ type StorageProvider struct {
 
     // DataTransferValidator methods
     ValidatePush(
-        sender    libp2p.PeerID
+        sender    peer.ID
         voucher   dt.DataTransferVoucher
         PieceRef  ipld.CID
         Selector  ipld.Selector
     )
     ValidatePull(
-        receiver  libp2p.PeerID
+        receiver  peer.ID
         voucher   dt.DataTransferVoucher
         PieceRef  ipld.CID
         Selector  ipld.Selector

--- a/src/systems/filecoin_mining/storage_mining/storage_mining_subsystem.go
+++ b/src/systems/filecoin_mining/storage_mining/storage_mining_subsystem.go
@@ -11,7 +11,6 @@ import (
 	filcrypto "github.com/filecoin-project/specs/algorithms/crypto"
 	filproofs "github.com/filecoin-project/specs/libraries/filcrypto/filproofs"
 	ipld "github.com/filecoin-project/specs/libraries/ipld"
-	libp2p "github.com/filecoin-project/specs/libraries/libp2p"
 	block "github.com/filecoin-project/specs/systems/filecoin_blockchain/struct/block"
 	deal "github.com/filecoin-project/specs/systems/filecoin_markets/storage_market/storage_deal"
 	sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
@@ -21,6 +20,7 @@ import (
 	msg "github.com/filecoin-project/specs/systems/filecoin_vm/message"
 	stateTree "github.com/filecoin-project/specs/systems/filecoin_vm/state_tree"
 	util "github.com/filecoin-project/specs/util"
+	peer "github.com/libp2p/go-libp2p-core/peer"
 )
 
 type Serialization = util.Serialization
@@ -37,7 +37,7 @@ func (sms *StorageMiningSubsystem_I) CreateMiner(
 	ownerAddr addr.Address,
 	workerAddr addr.Address,
 	sectorSize util.UInt,
-	peerId libp2p.PeerID,
+	peerId peer.ID,
 	pledgeAmt abi.TokenAmount,
 ) (addr.Address, error) {
 

--- a/src/systems/filecoin_mining/storage_mining/storage_mining_subsystem.id
+++ b/src/systems/filecoin_mining/storage_mining/storage_mining_subsystem.id
@@ -12,8 +12,8 @@ import storage_proving "github.com/filecoin-project/specs/systems/filecoin_minin
 import node_base "github.com/filecoin-project/specs/systems/filecoin_nodes/node_base"
 import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 import stateTree "github.com/filecoin-project/specs/systems/filecoin_vm/state_tree"
-import libp2p "github.com/filecoin-project/specs/libraries/libp2p"
 import msg "github.com/filecoin-project/specs/systems/filecoin_vm/message"
+import peer "github.com/libp2p/go-libp2p-core/peer"
 
 type StorageMiningSubsystem struct {
     Node               node_base.FilecoinNode
@@ -43,7 +43,7 @@ type StorageMiningSubsystem struct {
         ownerAddr   addr.Address
         workerAddr  addr.Address
         sectorSize  util.UInt
-        peerId      libp2p.PeerID
+        peerId      peer.ID
         pledgeAmt   abi.TokenAmount
     )
 


### PR DESCRIPTION
This requires that we update to go13 since go-libp2p-core/peer depends on crypto/ed25519 - its functionality was previously provided by the golang.org/x/crypto/ed25519 package, which becomes a wrapper for crypto/ed25519 when used with Go 1.13+. ([link](https://golang.org/doc/go1.13#crypto/ed25519))