### PR TITLE
Add runtime syscalls for interface to proofs. Remove filproofs direct access from storage miner actor.

### DIFF
--- a/src/actors/builtin/storage_miner/storage_miner_actor.id
+++ b/src/actors/builtin/storage_miner/storage_miner_actor.id
@@ -99,7 +99,6 @@ type MinerInfo struct {
 
     // Amount of space in each sector committed to the network by this miner.
     SectorSize              sector.SectorSize
-    RegisteredProof         sector.RegisteredProof
     SealPartitions          UVarint
     ElectionPoStPartitions  UVarint
     SurprisePoStPartitions  UVarint

--- a/src/actors/builtin/storage_miner/storage_miner_actor_code.go
+++ b/src/actors/builtin/storage_miner/storage_miner_actor_code.go
@@ -199,6 +199,7 @@ func (a *StorageMinerActorCode_I) ProveCommitSector(rt Runtime, info sector.Sect
 		SealedCID_:        preCommitSector.Info().SealedCID(),
 		SealEpoch_:        preCommitSector.Info().SealEpoch(),
 		InteractiveEpoch_: info.InteractiveEpoch(),
+		RegisteredProof_:  info.RegisteredProof(),
 		Proof_:            info.Proof(),
 		DealIDs_:          preCommitSector.Info().DealIDs(),
 		SectorNumber_:     preCommitSector.Info().SectorNumber(),

--- a/src/actors/runtime/runtime.id
+++ b/src/actors/runtime/runtime.id
@@ -4,6 +4,7 @@ import exitcode "github.com/filecoin-project/specs/actors/runtime/exitcode"
 import addr "github.com/filecoin-project/go-address"
 import indices "github.com/filecoin-project/specs/actors/runtime/indices"
 import ipld "github.com/filecoin-project/specs/libraries/ipld"
+import sector "github.com/filecoin-project/specs/systems/filecoin_mining/sector"
 import cid "github.com/ipfs/go-cid"
 
 // Runtime is the VM's internal runtime object.
@@ -116,6 +117,20 @@ type Runtime interface {
     IpldGet(c cid.Cid, o ipld.Object) bool
     // Serializes and stores an object, returning its CID.
     IpldPut(x ipld.Object) cid.Cid
+
+    // Provides the system call interface.
+    Syscalls() Syscalls
+}
+
+type Syscalls interface {
+    // Verifies that a signature is valid for an address and plaintext.
+    VerifySignature(signature [byte], signer addr.Address, plaintext [byte]) bool
+    // Computes an unsealed sector CID (CommD) from its constituent piece CIDs (CommPs) and sizes.
+    ComputeUnsealedSectorCID(sectorSize sector.SectorSize, pieces [sector.PieceInfo]) (sector.UnsealedSectorCID, error)
+    // Verifies a sector seal proof.
+    VerifySeal(sectorSize sector.SectorSize, vi sector.SealVerifyInfo) bool
+    // Verifies a proof of spacetime.
+    VerifyPoSt(sectorSize sector.SectorSize, vi sector.PoStVerifyInfo) bool
 }
 
 type InvocInput struct {

--- a/src/systems/filecoin_mining/sector/sealing.id
+++ b/src/systems/filecoin_mining/sector/sealing.id
@@ -72,6 +72,7 @@ type SectorPreCommitInfo struct {
 
 type SectorProveCommitInfo struct {
     SectorNumber
+    RegisteredProof
     Proof             SealProof
     InteractiveEpoch  abi.ChainEpoch
     Expiration        abi.ChainEpoch


### PR DESCRIPTION
The actor code can't depend on filproofs (i.e. rust-fil-proofs) directly, but must go via runtime.

FYI @jzimmerman 