### PR TITLE
Replace build_go.mod specs-actors require directive with a replace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ jobs:
       - image: circleci/golang:1.13
     steps:
       - checkout
+      - update_submodules
       - run:
           name: "Test code (Generate, Build, Test)"
           command: make test
@@ -29,3 +30,10 @@ workflows:
     jobs:
       - code
       - website
+
+commands:
+  update_submodules:
+    steps:
+      - run:
+          name: Update submodules
+          command: git submodule update --init --recursive

--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ serve-and-watch: serve watch-hugo
 
 # code generation and building targets
 
-GO_INPUT_FILES=$(shell find src -iname '*.go')
+GO_INPUT_FILES=$(shell find src -iname '*.go' | grep -v ^src/actors)
 GO_OUTPUT_FILES=$(patsubst src/%.go, build/code/%.go, $(GO_INPUT_FILES))
 
 GO_UTIL_INPUT_FILE=tools/codeGen/util/util.go

--- a/src/build_go.mod
+++ b/src/build_go.mod
@@ -1,5 +1,5 @@
 module github.com/filecoin-project/specs
 
-require github.com/filecoin-project/specs-actors v0.0.0-20200117000027-ae3a170bc812
+replace github.com/filecoin-project/specs-actors => ../../src/actors
 
 go 1.13


### PR DESCRIPTION
Also exclude the actor code from being copied into the build dir.

After this, the build is performed directly with the code in the submodule, rather than fetching from GitHub. There's only one place to update when we want to pull in new code: the submodule ref.

