### PR TITLE
Add Hello Protocol

### DIFF
--- a/src/systems/filecoin_nodes/network/_index.md
+++ b/src/systems/filecoin_nodes/network/_index.md
@@ -31,6 +31,24 @@ Here is the list of libp2p protocols used by Filecoin.
 - DNSDiscovery: Design and spec needed before implementing
 - HTTPDiscovery: Design and spec needed before implementing
 - Hello:
-	- Hello protocol handles new connections to filecoin nodes.  It is an important part of the discovery process for ambient protocols (like KademliaDHT)
-	- Spec TODO.
-	- No Filecoin specific modifications to the protocol id.
+	- Hello protocol handles new connections to filecoin nodes to facilitate discovery
+	- the protocol string is `fil/hello/1.0.0`. 
+
+# Hello Spec 
+
+## Protocol Flow
+
+`fil/hello` is a filecoin specific protocol built on the libp2p stack.  It consists of two conceptual
+procedures: `hello_connect` and `hello_listen`.   
+
+`hello_listen`: `on new stream` -> `read peer hello msg from stream` -> `write latency message to stream` -> `close stream`
+
+`hello_connect`: `on connected` -> `open stream` -> `write own hello msg to stream` -> `read peer latency msg from stream`  -> `close stream`
+
+where stream and connection operations are all standard libp2p operations.  Nodes running the Hello Protocol should consume the incoming Hello Message and use it to help manage peers and sync the chain.
+
+## Messages
+{{< readfile file="hello.id" code="true" lang="go" >}}
+
+
+When writing the `HelloMessage` to the stream the peer must inspect its current head to provide accurate information.  When writing the `LatencyMessage` to the stream the peer should set `TArrival` immediately upon receipt and `TSent` immediately before writing the message to the stream.

--- a/src/systems/filecoin_nodes/network/hello.id
+++ b/src/systems/filecoin_nodes/network/hello.id
@@ -10,6 +10,8 @@ type HelloMessage struct {
 
 // LatencyMessage shares information about a peer's network latency
 type LatencyMessage struct {
+    // Measured in unix nanoseconds 
     TArrival  Int
+    // Measured in unix nanoseconds
     TSent     Int
 }

--- a/src/systems/filecoin_nodes/network/hello.id
+++ b/src/systems/filecoin_nodes/network/hello.id
@@ -1,0 +1,16 @@
+import cid "github.com/ipfs/go-cid"
+
+
+// HelloMessage shares information about a peer's chain head
+type HelloMessage struct {
+	HeaviestTipSet       [cid.Cid]
+	HeaviestTipSetWeight BigInt
+	HeaviestTipSetHeight Int
+	GenesisHash          cid.Cid
+}
+
+// LatencyMessage shares information about a peer's network latency
+type LatencyMessage struct {
+	TArrival Int
+	TSent Int
+}

--- a/src/systems/filecoin_nodes/network/hello.id
+++ b/src/systems/filecoin_nodes/network/hello.id
@@ -1,16 +1,15 @@
 import cid "github.com/ipfs/go-cid"
 
-
 // HelloMessage shares information about a peer's chain head
 type HelloMessage struct {
-	HeaviestTipSet       [cid.Cid]
-	HeaviestTipSetWeight BigInt
-	HeaviestTipSetHeight Int
-	GenesisHash          cid.Cid
+    HeaviestTipSet        [cid.Cid]
+    HeaviestTipSetWeight  BigInt
+    HeaviestTipSetHeight  Int
+    GenesisHash           cid.Cid
 }
 
 // LatencyMessage shares information about a peer's network latency
 type LatencyMessage struct {
-	TArrival Int
-	TSent Int
+    TArrival  Int
+    TSent     Int
 }


### PR DESCRIPTION
This work is coming off of the effort to interop filecoin nodes.  Speccing the hello protocol is necessary for us to have an interoperable network.

Proposed diffs from current lotus hello Lotusers should be aware of:
1. added Height field to hello message (gfc wants to use this field).  
2. separated out Latency fields from the HelloMessage into their own message as they are only ever sent separately.