### PR TITLE
update penalty deduction

### DIFF
--- a/src/systems/filecoin_vm/interpreter/vm_interpreter.go
+++ b/src/systems/filecoin_vm/interpreter/vm_interpreter.go
@@ -90,6 +90,9 @@ func (vmi *VMInterpreter_I) ApplyTipSetMessages(inTree st.StateTree, tipset chai
 			seenMsgs[_msgCID(m)] = struct{}{}
 		}
 
+		// transfer gas reward from BurntFundsActor to RewardActor
+		_withTransferFundsAssert(outTree, builtin.BurntFundsActorAddr, builtin.RewardActorAddr, minerGasRewardTotal)
+
 		// Pay block reward.
 		rewardMessage := _makeBlockRewardMessage(outTree, minerAddr, minerPenaltyTotal, minerGasRewardTotal)
 		outTree = _applyMessageBuiltinAssert(store, outTree, chainRand, rewardMessage, minerAddr)
@@ -324,9 +327,6 @@ func _makeBlockRewardMessage(state st.StateTree, minerAddr addr.Address, penalty
 
 	sysActor, ok := state.GetActor(builtin.SystemActorAddr)
 	Assert(ok)
-
-	// transfer gas reward from BurntFundsActor to RewardActor
-	_withTransferFundsAssert(state, builtin.BurntFundsActorAddr, builtin.RewardActorAddr, gasReward)
 
 	return &msg.UnsignedMessage_I{
 		From_:       builtin.SystemActorAddr,


### PR DESCRIPTION
per #781,

- Interpreter sends gasLimitCost and networkTxnFee to BurntFundsActor
- gasReward is returned from message execution and sent as a field to _makeBlockRewardMessage
- gasReward is transferred from BurntFundsActor to RewardActor
- RewardActor deducts gasPenalty from gasReward and BlockReward before dispensing/garnishing block reward
- If gasPenalty > gasReward + BlockReward, miners earn 0 reward from the block
- remove minerToOwner from interpreter as it is no longer needed

RewardActor is updated accordingly in specs-actors