### PR TITLE
ChainEpoch and CallSeqNum are int64

### DIFF
--- a/src/systems/filecoin_nodes/clock/clock_subsystem.id
+++ b/src/systems/filecoin_nodes/clock/clock_subsystem.id
@@ -7,7 +7,7 @@ type UTCClock struct {
 }
 
 // ChainEpoch represents a round of a blockchain protocol.
-type ChainEpoch UVarint
+type ChainEpoch int64
 
 // ChainEpochClock is a clock that represents epochs of the protocol.
 type ChainEpochClock struct {

--- a/src/systems/filecoin_vm/actor/actor.id
+++ b/src/systems/filecoin_vm/actor/actor.id
@@ -19,7 +19,7 @@ import cid "github.com/ipfs/go-cid"
 //   Yes, a user may submit N separate messages with increasing
 //   sequence number, causing them to execute in order.
 //
-type CallSeqNum UVarint
+type CallSeqNum int64
 
 // Actor is a base computation object in the Filecoin VM. Similar
 // to Actors in the Actor Model (programming), or Objects in Object-


### PR DESCRIPTION
After a quick sync with lotus team I'm bringing up this change.  It is already what lotus has and is already way more bits than we need to represent block height without going full varint.

Because lotus and spec disagree here and it is an inescapable part of genesis block byte format this is a current interop blocker.  I'm moving forward with serializing block heights as cbor major type 0 as lotus does (instead of 2 with big int semantics on the byte string as spec wants) and submitting this change to the spec to align everyone.  This is time sensitive so please bring all dissenting opinions up ASAP.  

--edit-- 
we are in the same situation with CallSeqNum so I've added it here too