### PR TITLE
Link hamt spec

### DIFF
--- a/src/listings/data_structures.md
+++ b/src/listings/data_structures.md
@@ -57,6 +57,9 @@ a long block.
 
 For Filecoin, byte arrays representing RLE+ bitstreams are encoded using [LSB 0](https://en.wikipedia.org/wiki/Bit_numbering#LSB_0_bit_numbering) bit numbering.
 
+# HAMT
+
+See the draft [IPLD hash map spec](https://github.com/ipld/specs/blob/master/data-structures/hashmap.md) for details on implementing the HAMT used for the global state tree map and throughout the actor code.
 
 # Other Considerations
 


### PR DESCRIPTION
Figured we should link this as I couldn't find the link in the spec yet.  It's a draft but it appears to match go-hamt-ipld at a glance.  If they don't match either go-hamt-ipld or this spec should change so that they do.