### PR TITLE
Update Retrieval Market spec to say voucher creation and redemption are off-chain

### DIFF
--- a/src/systems/filecoin_markets/retrieval_market/_index.md
+++ b/src/systems/filecoin_markets/retrieval_market/_index.md
@@ -25,11 +25,7 @@ The main components are as follows:
 
 # VO & V1
 
-V0 of the protocol has participants send data over the retrieval protocol itself in a
- series of
- Blocks encoded in Bitswap format and verify received blocks manually. It will only support
-  fetching the payload CID which is at the root of PieceCID's `.car` File, and will only support
-   fetching the whole DAG.
+V0 of the protocol has participants send data over the retrieval protocol itself in a series of Blocks encoded in Bitswap format and verify received blocks manually. It will only support fetching the payload CID which is at the root of PieceCID's `.car` File, and will only support fetching the whole DAG.
 
 In V1, the retrieval markets will evolve to support sending arbitrary payload CID's & selectors within a piece. Further, it will piggy back on the Data Transfer system and Graphsync to handle transfer and verification, to support arbitrary selectors, and to reduce round trips.
 The Data Transfer System will accordingly be augmented to support pausing/resuming and sending intermediate vouchers to facilitate this.
@@ -84,9 +80,7 @@ The evolved protocol for proposing and accepting a deal will work as follows:
 
 # Bootstrapping Trust
 
-Neither the client nor the provider have any specific reason to trust the other. Therefore
-, payment for a retrieval deal is done incrementally, sending vouchers as bytes are sent and
- verified.
+Neither the client nor the provider have any specific reason to trust the other. Therefore, payment for a retrieval deal is done incrementally, sending vouchers as bytes are sent and verified.
 
 The trust process is as follows:
 - When the deal is created, client & provider agree to a "payment interval" in bytes, which is the _minimum_ amount of data the provider will send before each required increment

--- a/src/systems/filecoin_markets/retrieval_market/_index.md
+++ b/src/systems/filecoin_markets/retrieval_market/_index.md
@@ -25,9 +25,13 @@ The main components are as follows:
 
 # VO & V1
 
-V0 of the protocol has participants send data over the retrieval protocol itself in a series of Blocks encoded in Bitswap format and verify received blocks manually. It will only support fetching the payload CID which is at the root of PieceCID's Car File, and will only support fetching the whole DAG.
+V0 of the protocol has participants send data over the retrieval protocol itself in a
+ series of
+ Blocks encoded in Bitswap format and verify received blocks manually. It will only support
+  fetching the payload CID which is at the root of PieceCID's `.car` File, and will only support
+   fetching the whole DAG.
 
-In V1, the retrieval markets will evolve to support sending arbitrary payload CID's & selectors within a piece (V1). Further, it will piggy back on the Data Transfer system and Graphsync to handle transfer and verification, to support arbitrary selectors, and to reduce round trips.
+In V1, the retrieval markets will evolve to support sending arbitrary payload CID's & selectors within a piece. Further, it will piggy back on the Data Transfer system and Graphsync to handle transfer and verification, to support arbitrary selectors, and to reduce round trips.
 The Data Transfer System will accordingly be augmented to support pausing/resuming and sending intermediate vouchers to facilitate this.
 V1 will also include additional mechanisms for timeouts and cancellations. (to be specified)
 
@@ -72,7 +76,7 @@ The evolved protocol for proposing and accepting a deal will work as follows:
 - The provider monitors data transfer as it sends blocks over the protocol, until it requires payment
 - When the provider requires payment, it pauses the data transfer and sends a request for payment as an intermediate voucher
 - The client receives the request for payment
-- The client creates and stores  payment voucher off-chain
+- The client creates and stores payment voucher off-chain
 - The client responds to provider with a reference to the payment voucher, sent as an intermediate voucher
 - The provider redeems the payment voucher off-chain
 - The provider resumes both the request and sending data
@@ -80,7 +84,9 @@ The evolved protocol for proposing and accepting a deal will work as follows:
 
 # Bootstrapping Trust
 
-Neither the client nor the provider have any specific reason to trust the other. Therefore, payment for a retrieval deal is done in pieces, sending vouchers as bytes are sent and verified.
+Neither the client nor the provider have any specific reason to trust the other. Therefore
+, payment for a retrieval deal is done incrementally, sending vouchers as bytes are sent and
+ verified.
 
 The trust process is as follows:
 - When the deal is created, client & provider agree to a "payment interval" in bytes, which is the _minimum_ amount of data the provider will send before each required increment

--- a/src/systems/filecoin_markets/retrieval_market/_index.md
+++ b/src/systems/filecoin_markets/retrieval_market/_index.md
@@ -27,7 +27,8 @@ The main components are as follows:
 
 V0 of the protocol has participants send data over the retrieval protocol itself in a series of Blocks encoded in Bitswap format and verify received blocks manually. It will only support fetching the payload CID which is at the root of PieceCID's Car File, and will only support fetching the whole DAG.
 
-In V1, the retrieval markets will evolve to support sending arbitrary payload CID's & selectors within a piece (V1). Further, it will piggy back on the Data Transfer system and Graphsync to handle transfer and verification, to support arbitrary selectors, and to reduce roundtrips.
+In V1, the retrieval markets will evolve to support sending arbitrary payload CID's & selectors
+ within a piece (V1). Further, it will piggy back on the Data Transfer system and Graphsync to handle transfer and verification, to support arbitrary selectors, and to reduce round trips.
 The Data Transfer System will accordingly be augmented to support pausing/resuming and sending intermediate vouchers to facilitate this.
 V1 will also include additional mechanisms for timeouts and cancellations. (to be specified)
 
@@ -49,9 +50,9 @@ The baseline version of proposing and accepting a deal will work as follows:
 - The provider sends blocks over the protocol until it requires payment
 - The client consumes blocks over the retrieval protocol and manually verifies them
 - When the provider requires payment to proceed, it sends payment request and does not send any more blocks
-- The client puts a payment voucher on chain
+- The client creates and stores a payment voucher off-chain
 - The client responds to the provider with a reference to the payment voucher
-- The provider redeems the payment voucher on the chain
+- The provider redeems the payment voucher off-chain
 - The provider resumes sending blocks
 - The client consumes blocks until payment is required again
 - The process continues until the end of the query
@@ -67,15 +68,16 @@ The evolved protocol for proposing and accepting a deal will work as follows:
 - The client schedules a `Data Transfer Pull Request` passing the `RetrievalDealProposal` as a voucher.
 - The provider validates the proposal and rejects it if it is invalid
 - If the proposal is valid, the provider responds with an accept message and begins monitoring the data transfer process
-- The client creates a payment channel as neccesary and a lane, ensures there are free funds in the channel
-- The provider unseals the sector as neccesary
+- The client creates a payment channel as necessary and a lane, ensures there are free funds in
+ the channel
+- The provider unseals the sector as necessary
 - The provider monitors data transfer as it sends blocks over the protocol, until it requires payment
 - When the provider requires payment, it pauses the data transfer and sends a request for payment as an intermediate voucher
 - The client receives the request for payment
-- The client puts a payment voucher on chain
+- The client creates and stores  payment voucher off-chain
 - The client responds to provider with a reference to the payment voucher, sent as an intermediate voucher
-- The provider redeems the payment voucher on the chain
-- The provider unpauses the request and data resumes sending 
+- The provider redeems the payment voucher off-chain
+- The provider resumes both the request and sending data
 - The process continues until the end of the query
 
 # Bootstrapping Trust

--- a/src/systems/filecoin_markets/retrieval_market/_index.md
+++ b/src/systems/filecoin_markets/retrieval_market/_index.md
@@ -27,8 +27,7 @@ The main components are as follows:
 
 V0 of the protocol has participants send data over the retrieval protocol itself in a series of Blocks encoded in Bitswap format and verify received blocks manually. It will only support fetching the payload CID which is at the root of PieceCID's Car File, and will only support fetching the whole DAG.
 
-In V1, the retrieval markets will evolve to support sending arbitrary payload CID's & selectors
- within a piece (V1). Further, it will piggy back on the Data Transfer system and Graphsync to handle transfer and verification, to support arbitrary selectors, and to reduce round trips.
+In V1, the retrieval markets will evolve to support sending arbitrary payload CID's & selectors within a piece (V1). Further, it will piggy back on the Data Transfer system and Graphsync to handle transfer and verification, to support arbitrary selectors, and to reduce round trips.
 The Data Transfer System will accordingly be augmented to support pausing/resuming and sending intermediate vouchers to facilitate this.
 V1 will also include additional mechanisms for timeouts and cancellations. (to be specified)
 
@@ -68,8 +67,7 @@ The evolved protocol for proposing and accepting a deal will work as follows:
 - The client schedules a `Data Transfer Pull Request` passing the `RetrievalDealProposal` as a voucher.
 - The provider validates the proposal and rejects it if it is invalid
 - If the proposal is valid, the provider responds with an accept message and begins monitoring the data transfer process
-- The client creates a payment channel as necessary and a lane, ensures there are free funds in
- the channel
+- The client creates a payment channel as necessary and a lane, ensures there are free funds in the channel
 - The provider unseals the sector as necessary
 - The provider monitors data transfer as it sends blocks over the protocol, until it requires payment
 - When the provider requires payment, it pauses the data transfer and sends a request for payment as an intermediate voucher


### PR DESCRIPTION
# Correction to the retrieval market spec

As noted in the payment channels section, the voucher system is done off chain with the final resolution/accounting posted on chain after the retrieval deal is terminated.  This was inconsistent with what the retrieval market spec said. This PR is to correct this, and a couple of typos.