### PR TITLE
feat: change DHT protocol format

### DIFF
--- a/src/systems/filecoin_nodes/network/_index.md
+++ b/src/systems/filecoin_nodes/network/_index.md
@@ -21,7 +21,7 @@ Here is the list of libp2p protocols used by Filecoin.
 - KademliaDHT: 
 	- Kademlia DHT is a distributed hash table with a logarithmic bound on the maximum number of lookups for a particular node. Kad DHT is used primarily for peer routing as well as peer discovery in the Filecoin protocol.
 	- Spec TODO [reference implementation](https://github.com/libp2p/go-libp2p-kad-dht)
-	- The protocol id must be of the form `fil/kad/<network-name>`
+	- The protocol id must be of the form `fil/<network-name>/kad/1.0.0`
 - Bootstrap List: 
 	- Bootstrap is a list of nodes that a new node attempts to connect upon joining the network. The list of bootstrap nodes and their addresses are defined by the users.
 - Peer Exchange: 


### PR DESCRIPTION
Change the DHT protocol format from

    /fil/kad/<network-name>

to

    /fil/<network-name>/kad/1.0.0

The underlying format is `/CUSTOM_PREFIX/CANONICAL_DHT_PROTOCOL`.

This makes it possible for DHT implementations to add additional protocol versions without needing `{custom protocol -> canonical protocol}` map.

Context: The content routing team is currently adding a new DHT protocol and plans to add more in the future. Supporting a custom protocol map where the user specifies individual protocols for every DHT protocol variant is _possible_ but messy. We'd like to avoid that situation if at all possible.

Note: The current lotus testnet uses /lotus/kad/1.0.0 so upgrading the current live network should be seamless.