### PR TITLE
move message field ordering back to what it was before

### DIFF
--- a/src/systems/filecoin_vm/message/message.id
+++ b/src/systems/filecoin_vm/message/message.id
@@ -26,14 +26,14 @@ type UnsignedMessage struct {
     // Amount of value to transfer from sender's to receiver's balance.
     Value       abi.TokenAmount
 
+    // GasPrice is a Gas-to-FIL cost
+    GasPrice    abi.TokenAmount
+    GasLimit    GasAmount
+
     // Optional method to invoke on receiver, zero for a plain value send.
     Method      abi.MethodNum
     /// Serialized parameters to the method (if method is non-zero).
     Params      abi.MethodParams
-
-    // GasPrice is a Gas-to-FIL cost
-    GasPrice    abi.TokenAmount
-    GasLimit    GasAmount
 }  // representation tuple
 
 type SignedMessage struct {


### PR DESCRIPTION
Not sure when these got reordered, but we've sunk a significant amount of external work into the ordering that this PR restores.