### PR TITLE
Fix dead link to payment channel Go code

### DIFF
--- a/src/systems/filecoin_token/payment_channels/payment_channel_actor.md
+++ b/src/systems/filecoin_token/payment_channels/payment_channel_actor.md
@@ -3,4 +3,4 @@ title: Payment Channel Actor
 ---
 {{<label payment_channel_actor>}}
 
-{{< readfile file="payment_channel_actor.id" code="true" lang="go" >}}
+{{< readfile file="/docs/actors/actors/builtin/paych/paych_state.go" code="true" lang="go" >}} {{< readfile file="/docs/actors/actors/builtin/paych/paych_actor.go" code="true" lang="go" >}}


### PR DESCRIPTION
`payment_channel_actor.id` did not exist