### PR TITLE
feat: publish to IPFS on PR

### DIFF
--- a/.github/workflows/add-to-ipfs.yml
+++ b/.github/workflows/add-to-ipfs.yml
@@ -1,21 +1,14 @@
-name: github pages deploy
+name: Add to IPFS 
 
-on:
-  push:
-    branches:
-      - master
+on: [push]
 
 jobs:
-  build-deploy:
+  add-to-ipfs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: true
-
-      - uses: webfactory/ssh-agent@v0.2.0
-        with:
-          ssh-private-key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
 
       - name: Install Go
         run: |
@@ -37,13 +30,6 @@ jobs:
           sudo echo 'PATH=$GOROOT/bin:$GOPATH/bin' >>~/.profile
           source ~/.profile
 
-      - name: Debug
-        run: |
-          pwd
-          go env
-          which go
-          go version
-
       - name: Install deps-ga
         run: |
           sudo make deps-ga
@@ -61,19 +47,3 @@ jobs:
           cluster_password: ${{ secrets.CLUSTER_PASSWORD }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Deploy using SSH
-        env:
-          DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          sudo chown -R runner $GITHUB_WORKSPACE
-          sudo chown -R runner .git/
-          eval "$(ssh-agent -s)"
-          ssh-add - <<< "${DEPLOY_KEY}"
-
-          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-          git config --local user.email "no-reply-spec-deploy@protocol.ai"
-          git config --local user.name "no-reply-spec-deploy"
-
-          bin/publish-to-gh-pages.sh

--- a/.github/workflows/add-to-ipfs.yml
+++ b/.github/workflows/add-to-ipfs.yml
@@ -39,7 +39,7 @@ jobs:
           sudo chown -R root:root $GITHUB_WORKSPACE
           sudo make build
 
-      - uses: ipfs-shipyard/ipfs-github-action@v1
+      - uses: ipfs-shipyard/ipfs-github-action@v1.0.0
         with:
           path_to_add: $GITHUB_WORKSPACE/build/website
           cluster_host: /dnsaddr/cluster.ipfs.io

--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -1,0 +1,70 @@
+name: github pages deploy
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: true
+
+      - uses: webfactory/ssh-agent@v0.2.0
+        with:
+          ssh-private-key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+
+      - name: Install Go
+        run: |
+          sudo apt-get remove golang-go
+          sudo apt-get remove --auto-remove golang-go
+          sudo rm -rf /usr/local/go
+          sudo rm -rf /usr/local/go1.12
+          sudo rm -rf /usr/local/go1.27
+          sudo apt-get update
+          wget https://dl.google.com/go/go1.14.4.linux-amd64.tar.gz
+          sudo tar -xvf go1.14.4.linux-amd64.tar.gz
+          sudo chown -R root:root ./go
+          sudo cp -r go /usr/local
+          sudo cp -r go /usr/local/go1.12
+          sudo cp -r go /usr/local/go1.27
+          sudo ln -sf /usr/local/go/bin/go /usr/bin/go
+          sudo echo 'GOROOT=/usr/local/go' >> ~/.profile
+          sudo echo 'GOPATH=$HOME/work' >>~/.profile
+          sudo echo 'PATH=$GOROOT/bin:$GOPATH/bin' >>~/.profile
+          source ~/.profile
+
+      - name: Debug
+        run: |
+          pwd
+          go env
+          which go
+          go version
+
+      - name: Install deps-ga
+        run: |
+          sudo make deps-ga
+
+      - name: Build
+        run: |
+          sudo chown -R root:root $GITHUB_WORKSPACE
+          sudo make build
+
+      - name: Deploy using SSH
+        env:
+          DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          sudo chown -R runner $GITHUB_WORKSPACE
+          sudo chown -R runner .git/
+          eval "$(ssh-agent -s)"
+          ssh-add - <<< "${DEPLOY_KEY}"
+
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+          git config --local user.email "no-reply-spec-deploy@protocol.ai"
+          git config --local user.name "no-reply-spec-deploy"
+
+          bin/publish-to-gh-pages.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,15 +50,24 @@ jobs:
 
       - name: Build
         run: |
-          sudo chown -R root:root /home/runner/work/specs
+          sudo chown -R root:root $GITHUB_WORKSPACE
           sudo make build
+
+      - uses: ipfs-shipyard/ipfs-github-action@v1
+        with:
+          path_to_add: $GITHUB_WORKSPACE/build/website
+          cluster_host: /dnsaddr/cluster.ipfs.io
+          cluster_user: ${{ secrets.CLUSTER_USER }}
+          cluster_password: ${{ secrets.CLUSTER_PASSWORD }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy using SSH
         env:
           DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          sudo chown -R runner /home/runner/work/specs/specs
+          sudo chown -R runner $GITHUB_WORKSPACE
           sudo chown -R runner .git/
           eval "$(ssh-agent -s)"
           ssh-add - <<< "${DEPLOY_KEY}"


### PR DESCRIPTION
- Adds step to pin the rendered website to IPFS, whenever a commit is pushed.
- Replaces hardcoded paths with the `$GITHUB_WORKSPACE` var. This makes the build work on forked repos, where the repo has to be renamed, and shields us from future issues if actions change their workspace dir.
- Updated the github action to pin to IPFS to work with the new style github actions and published as 1.0 https://github.com/ipfs-shipyard/ipfs-github-action

**IPFS ACTION IN ACTION**
<img width="1437" alt="Screenshot 2020-07-13 at 15 51 15" src="https://user-images.githubusercontent.com/58871/87318878-d6b47f00-c520-11ea-8965-6e0024b9ecb3.png">

This will give us a github status entry on each commit that links to a rendered build, published to IPFS and pinned on cluster.ipfs.io

I've added the required `CLUSTER_USER` & `CLUSTER_PASSWORD` secrets to the repo.

Fixes: #581 

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>