### PR TITLE
feat: update dnslink to deploy

### DIFF
--- a/.github/workflows/ipfs.yml
+++ b/.github/workflows/ipfs.yml
@@ -31,10 +31,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
+      - run: echo /ipfs/${{ steps.ipfs.outputs.cid }}
+
+      - run: echo ${{ github.ref }}
+
       # This branch updates a dnslink for a domain if the current branch should be deployed to prod.
       # see https://github.com/ipfs-shipyard/js-dnslink-dnsimple
       - run: npx dnslink-dnsimple --domain beta.spec.filecoin.io --link /ipfs/${{ steps.ipfs.outputs.cid }}
         env:
           DNSIMPLE_TOKEN: ${{ secrets.DNSIMPLE_TOKEN }}
         # TODO: change to master once merged.
-        if: github.ref == 'ref/head/feat/dnslink'
+        if: github.ref == 'refs/heads/feat/dnslink'

--- a/.github/workflows/ipfs.yml
+++ b/.github/workflows/ipfs.yml
@@ -41,4 +41,4 @@ jobs:
         env:
           DNSIMPLE_TOKEN: ${{ secrets.DNSIMPLE_TOKEN }}
         # TODO: change to master once merged.
-        if: github.ref == 'refs/heads/feat/dnslink'
+        if: github.ref == 'refs/heads/feat/new-setup'

--- a/.github/workflows/ipfs.yml
+++ b/.github/workflows/ipfs.yml
@@ -10,7 +10,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.14.4'
+          go-version: '1.14'
 
       - uses: actions/setup-node@v2-beta
         with:
@@ -19,7 +19,10 @@ jobs:
       - run: npm install
       - run: npm run build
 
+      # Pin the built site to ipfs-cluster, output the cid as `steps.ipfs.outputs.cid`
+      # see: https://github.com/ipfs-shipyard/ipfs-github-action
       - uses: ipfs-shipyard/ipfs-github-action@v1.0.0
+        id: ipfs
         with:
           path_to_add: public
           cluster_host: /dnsaddr/cluster.ipfs.io
@@ -27,3 +30,11 @@ jobs:
           cluster_password: ${{ secrets.CLUSTER_PASSWORD }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      # This branch updates a dnslink for a domain if the current branch should be deployed to prod.
+      # see https://github.com/ipfs-shipyard/js-dnslink-dnsimple
+      - run: npx dnslink-dnsimple --domain beta.spec.filecoin.io --link /ipfs/${{ steps.ipfs.outputs.cid }}
+        env:
+          DNSIMPLE_TOKEN: ${{ secrets.DNSIMPLE_TOKEN }}
+        # TODO: change to master once merged.
+        if: github.ref == 'ref/head/feat/dnslink'


### PR DESCRIPTION
Use dnslink-dnsimple to update the TXT record with the latest cid. This PR is intended to be merged in to the new-setup branch to automate deployment of the latest version under a dnslink for beta.spec.filecoin.io

TODO:
- [x] verify the action can deploy this PR branch to beta.spec.filecoin.io
- [x] update the details so that it will publish feat/new-setup

once the new-setup branch is merged to master, this mecahnism can be used to auto deploy changes to the prod domain spec.filecoin.io instead of gh-pages.

**BEHOLD THE DNSLINK IS UPDATED WHEN THE BLESSED BRANCH CHANGES**
<img width="1552" alt="Screenshot 2020-07-17 at 11 16 39" src="https://user-images.githubusercontent.com/58871/87777067-c0f4d180-c820-11ea-882a-39df2fb4fd51.png">


License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>