### PR TITLE
fix: link fixes in specs actors

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,19 @@ You can find examples in the `config.toml`
     source = "actors"
     target = "content/modules/actors"
 ```
-This makes files from external repos available for Hugo rendering.  
+This makes files from external repos available for Hugo rendering and allows for linking to up-to-date sites that are directly pulled from other repositories.
+
+The configuration above gives the following information:
+
+- `path`: gives the repository you want to mount content from.
+- `source`: the folder in the mounted repository on which you mount the the local Hugo site. This is the "root" seen from your Hugo site where you pull content from. In the above case, this means that the source on the mounted repository is `https://github.com/filecoin-project/specs-actors/actors/`.
+- `target`: the folder in your local Hugo site where the mounted content appears. In our case folder `content` is where we include all Hugo content.
+
+Putting everything together in an example: if you want to link to the file `xyz.go` from `https://github.com/filecoin-project/specs-actors/actors/xyz-folder/xyz.go`, from any file within the local folder `content` (or any of its subfolders), then with the above configuration you have to include:
+
+```
+{{<embed src="/modules/actors/xyz-folder/xyz.go"  lang="go">}}
+```
 
 These modules can be updated with 
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This makes files from external repos available for Hugo rendering and allows for
 The configuration above gives the following information:
 
 - `path`: gives the repository you want to mount content from.
-- `source`: the folder in the mounted repository on which you mount the the local Hugo site. This is the "root" seen from your Hugo site where you pull content from. In the above case, this means that the source on the mounted repository is `https://github.com/filecoin-project/specs-actors/actors/`.
+- `source`: the folder from the repository referenced in the `path` that we want to mount into  our local Hugo filesystem. This is the "root" seen from your Hugo site where you pull content from. In the above case, this means that the source that will be mounted is `https://github.com/filecoin-project/specs-actors/actors/`.
 - `target`: the folder in your local Hugo site where the mounted content appears. In our case folder `content` is where we include all Hugo content.
 
 Putting everything together in an example: if you want to link to the file `xyz.go` from `https://github.com/filecoin-project/specs-actors/actors/xyz-folder/xyz.go`, from any file within the local folder `content` (or any of its subfolders), then with the above configuration you have to include:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You can find examples in the `config.toml`
     source = "actors"
     target = "content/modules/actors"
 ```
-This makes files from external repos available for Hugo rendering and allows for linking to up-to-date sites that are directly pulled from other repositories.
+This makes files from external repos available for Hugo rendering and allows for linking to up-to-date files that are directly pulled from other repositories.
 
 The configuration above gives the following information:
 

--- a/content/algorithms/crypto/randomness.md
+++ b/content/algorithms/crypto/randomness.md
@@ -89,7 +89,7 @@ GetRandomness(dst, l, s):
 Issue with readfile
 {{< /hint >}}
 
-{{<embed src="/docs/actors/actors/crypto/randomness.go"  lang="go">}}
+{{<embed src="/specs-actors/actors/crypto/randomness.go"  lang="go">}}
 {{<embed src="/systems/filecoin_blockchain/struct/chain/chain.go" lang="go">}}
 
 ## Entropy to be used with randomness

--- a/content/algorithms/crypto/randomness.md
+++ b/content/algorithms/crypto/randomness.md
@@ -85,10 +85,6 @@ GetRandomness(dst, l, s):
     return H(buffer)
 ```
 
-{{< hint danger >}}
-Issue with readfile
-{{< /hint >}}
-
 {{<embed src="/modules/actors/crypto/randomness.go"  lang="go">}}
 {{<embed src="/systems/filecoin_blockchain/struct/chain/chain.go" lang="go">}}
 

--- a/content/algorithms/crypto/randomness.md
+++ b/content/algorithms/crypto/randomness.md
@@ -89,7 +89,7 @@ GetRandomness(dst, l, s):
 Issue with readfile
 {{< /hint >}}
 
-{{<embed src="/specs-actors/actors/crypto/randomness.go"  lang="go">}}
+{{<embed src="/modules/actors/crypto/randomness.go"  lang="go">}}
 {{<embed src="/systems/filecoin_blockchain/struct/chain/chain.go" lang="go">}}
 
 ## Entropy to be used with randomness

--- a/content/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor.md
+++ b/content/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor.md
@@ -7,11 +7,11 @@ title: Storage Power Actor
 
 ## `StoragePowerActorState` implementation
 
-{{<embed src="/docs/actors/actors/builtin/storage_power/storage_power_actor_state.go" lang="go" >}}
+{{<embed src="/specs-actors/actors/builtin/power/power_state.go" lang="go" >}}
 
 ## `StoragePowerActor` implementation
 
-{{<embed src="/docs/actors/actors/builtin/storage_power/storage_power_actor.go" lang="go" >}}
+{{<embed src="/specs-actors/actors/builtin/power/power_actor.go" lang="go" >}}
 
 ## The Power Table
 

--- a/content/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor.md
+++ b/content/systems/filecoin_blockchain/storage_power_consensus/storage_power_actor.md
@@ -7,11 +7,11 @@ title: Storage Power Actor
 
 ## `StoragePowerActorState` implementation
 
-{{<embed src="/specs-actors/actors/builtin/power/power_state.go" lang="go" >}}
+{{<embed src="/modules/actors/builtin/power/power_state.go" lang="go" >}}
 
 ## `StoragePowerActor` implementation
 
-{{<embed src="/specs-actors/actors/builtin/power/power_actor.go" lang="go" >}}
+{{<embed src="/modules/actors/builtin/power/power_actor.go" lang="go" >}}
 
 ## The Power Table
 

--- a/content/systems/filecoin_markets/storage_market/storage_deal/_index.md
+++ b/content/systems/filecoin_markets/storage_market/storage_deal/_index.md
@@ -15,5 +15,5 @@ This section describes the storage deal data type and a technical outline for de
 
 ## Data Types
 
-{{< embed src="/docs/actors/actors/builtin/storage_market/storage_deal.go" lang="go" >}}
+{{< embed src="/specs-actors/actors/builtin/market/deal.go" lang="go" >}}
 

--- a/content/systems/filecoin_markets/storage_market/storage_deal/_index.md
+++ b/content/systems/filecoin_markets/storage_market/storage_deal/_index.md
@@ -15,5 +15,5 @@ This section describes the storage deal data type and a technical outline for de
 
 ## Data Types
 
-{{< embed src="/specs-actors/actors/builtin/market/deal.go" lang="go" >}}
+{{< embed src="/modules/actors/builtin/market/deal.go" lang="go" >}}
 

--- a/content/systems/filecoin_markets/storage_market/storage_market_actor.md
+++ b/content/systems/filecoin_markets/storage_market/storage_market_actor.md
@@ -10,11 +10,11 @@ weight: 2
 
 ## `StorageMarketActorState` implementation
 
-{{<embed src="/specs-actors/actors/builtin/market/market_state.go" lang="go" >}}
+{{<embed src="/modules/actors/builtin/market/market_state.go" lang="go" >}}
 
 ## `StorageMarketActor` implementation
 
-{{<embed src="/specs-actors/actors/builtin/market/market_actor.go" lang="go" >}}
+{{<embed src="/modules/actors/builtin/market/market_actor.go" lang="go" >}}
 
 
 ## Storage Deal Collateral

--- a/content/systems/filecoin_markets/storage_market/storage_market_actor.md
+++ b/content/systems/filecoin_markets/storage_market/storage_market_actor.md
@@ -10,15 +10,12 @@ weight: 2
 
 ## `StorageMarketActorState` implementation
 
-{{<embed src="/docs/actors/actors/builtin/storage_market/storage_market_actor_state.go" lang="go" >}}
+{{<embed src="/specs-actors/actors/builtin/market/market_state.go" lang="go" >}}
 
 ## `StorageMarketActor` implementation
 
-{{<embed src="/docs/actors/actors/builtin/storage_market/storage_market_actor.go" lang="go" >}}
+{{<embed src="/specs-actors/actors/builtin/market/market_actor.go" lang="go" >}}
 
-## `StorageMarketActor` implementation
-
-{{<embed src="/docs/actors/actors/builtin/storage_market/storage_market_actor.go" lang="go" >}}
 
 ## Storage Deal Collateral
 

--- a/content/systems/filecoin_mining/storage_mining/storage_miner_actor.md
+++ b/content/systems/filecoin_mining/storage_mining/storage_miner_actor.md
@@ -7,8 +7,8 @@ title: Storage Miner Actor
 
 ## `StorageMinerActorState` implementation
 
-{{<embed src="/specs-actors/actors/builtin/miner/miner_state.go"  lang="go" >}}
+{{<embed src="/modules/actors/builtin/miner/miner_state.go"  lang="go" >}}
 
 ## `StorageMinerActorCode` implementation
 
-{{<embed src="/specs-actors/actors/builtin/miner/miner_actor.go"  lang="go" >}}
+{{<embed src="/modules/actors/builtin/miner/miner_actor.go"  lang="go" >}}

--- a/content/systems/filecoin_mining/storage_mining/storage_miner_actor.md
+++ b/content/systems/filecoin_mining/storage_mining/storage_miner_actor.md
@@ -7,8 +7,8 @@ title: Storage Miner Actor
 
 ## `StorageMinerActorState` implementation
 
-{{<embed src="/docs/actors/actors/builtin/storage_miner/storage_miner_actor_state.go"  lang="go" >}}
+{{<embed src="/specs-actors/actors/builtin/miner/miner_state.go"  lang="go" >}}
 
 ## `StorageMinerActorCode` implementation
 
-{{<embed src="/docs/actors/actors/builtin/storage_miner/storage_miner_actor.go"  lang="go" >}}
+{{<embed src="/specs-actors/actors/builtin/miner/miner_actor.go"  lang="go" >}}

--- a/content/systems/filecoin_token/multisig/multisig_actor.md
+++ b/content/systems/filecoin_token/multisig/multisig_actor.md
@@ -5,5 +5,5 @@ title: Multisig Actor
 # Multisig Actor
 ---
 
-{{<embed src="/docs/actors/actors/builtin/multisig/multisig_actor.go" lang="go" >}}
-{{<embed src="/docs/actors/actors/builtin/multisig/multisig_actor_state.go" lang="go" >}}
+{{<embed src="/specs-actors/actors/builtin/multisig/multisig_actor.go" lang="go" >}}
+{{<embed src="/specs-actors/actors/builtin/multisig/multisig_state.go" lang="go" >}}

--- a/content/systems/filecoin_token/multisig/multisig_actor.md
+++ b/content/systems/filecoin_token/multisig/multisig_actor.md
@@ -5,5 +5,5 @@ title: Multisig Actor
 # Multisig Actor
 ---
 
-{{<embed src="/specs-actors/actors/builtin/multisig/multisig_actor.go" lang="go" >}}
-{{<embed src="/specs-actors/actors/builtin/multisig/multisig_state.go" lang="go" >}}
+{{<embed src="/modules/actors/builtin/multisig/multisig_actor.go" lang="go" >}}
+{{<embed src="/modules/actors/builtin/multisig/multisig_state.go" lang="go" >}}

--- a/content/systems/filecoin_vm/indices/_index.md
+++ b/content/systems/filecoin_vm/indices/_index.md
@@ -10,5 +10,3 @@ dashboardInterface: incomplete
 ---
 
 Indices are a set of global economic indicators computed from State Tree and a collection of pure functions to compute policy output based on user state/action. Indices are used to compute and implement economic mechanisms and policies for the system. There are no persistent states in Indicies. Neither can Indices introduce any state mutation. Note that where indices should live is a design decision. It is possible to break Indices into multiple files or place indices in different actors once all economic mechanisms have been decided on. Temporarily, Indices is a holding file for all potential macroeconomic indicators that the system needs to be aware of.
-
-{{<embed src="/docs/actors/actors/runtime/indices/indices.go" lang="go" >}}

--- a/content/systems/filecoin_vm/runtime/_index.md
+++ b/content/systems/filecoin_vm/runtime/_index.md
@@ -22,7 +22,7 @@ A syntactically valid receipt has:
 
 ## `vm/runtime` interface
 
-{{<embed src="/specs-actors/actors/runtime/runtime.go" lang="go" >}}
+{{<embed src="/modules/actors/runtime/runtime.go" lang="go" >}}
 
 ## `vm/runtime` implementation
 
@@ -34,4 +34,4 @@ A syntactically valid receipt has:
 
 ## Exit codes
 
-{{<embed src="/specs-actors/actors/runtime/exitcode/common.go" lang="go" >}}
+{{<embed src="/modules/actors/runtime/exitcode/common.go" lang="go" >}}

--- a/content/systems/filecoin_vm/runtime/_index.md
+++ b/content/systems/filecoin_vm/runtime/_index.md
@@ -22,7 +22,7 @@ A syntactically valid receipt has:
 
 ## `vm/runtime` interface
 
-{{<embed src="/docs/actors/actors/runtime/runtime.go" lang="go" >}}
+{{<embed src="/specs-actors/actors/runtime/runtime.go" lang="go" >}}
 
 ## `vm/runtime` implementation
 
@@ -34,4 +34,4 @@ A syntactically valid receipt has:
 
 ## Exit codes
 
-{{<embed src="/docs/actors/actors/runtime/exitcode/vm_exitcodes.go" lang="go" >}}
+{{<embed src="/specs-actors/actors/runtime/exitcode/common.go" lang="go" >}}

--- a/content/systems/filecoin_vm/sysactors/account_actor.md
+++ b/content/systems/filecoin_vm/sysactors/account_actor.md
@@ -6,4 +6,4 @@ weight: 3
 # AccountActor
 ---
 
-{{<embed src="/specs-actors/actors/builtin/account/account_actor.go" lang="go" >}}
+{{<embed src="/modules/actors/builtin/account/account_actor.go" lang="go" >}}

--- a/content/systems/filecoin_vm/sysactors/account_actor.md
+++ b/content/systems/filecoin_vm/sysactors/account_actor.md
@@ -6,4 +6,4 @@ weight: 3
 # AccountActor
 ---
 
-{{<embed src="/docs/actors/actors/builtin/account/account_actor.go" lang="go" >}}
+{{<embed src="/specs-actors/actors/builtin/account/account_actor.go" lang="go" >}}

--- a/content/systems/filecoin_vm/sysactors/cron_actor.md
+++ b/content/systems/filecoin_vm/sysactors/cron_actor.md
@@ -6,4 +6,4 @@ weight: 2
 # CronActor
 ---
 
-{{<embed src="/docs/actors/actors/builtin/cron/cron_actor.go"  lang="go">}}
+{{<embed src="/specs-actors/actors/builtin/cron/cron_actor.go"  lang="go">}}

--- a/content/systems/filecoin_vm/sysactors/cron_actor.md
+++ b/content/systems/filecoin_vm/sysactors/cron_actor.md
@@ -6,4 +6,4 @@ weight: 2
 # CronActor
 ---
 
-{{<embed src="/specs-actors/actors/builtin/cron/cron_actor.go"  lang="go">}}
+{{<embed src="/modules/actors/builtin/cron/cron_actor.go"  lang="go">}}

--- a/content/systems/filecoin_vm/sysactors/init_actor.md
+++ b/content/systems/filecoin_vm/sysactors/init_actor.md
@@ -6,4 +6,4 @@ weight: 1
 # InitActor
 ---
 
-{{<embed src="/docs/actors/actors/builtin/init/init_actor.go" lang="go">}}
+{{<embed src="/specs-actors/actors/builtin/init/init_actor.go" lang="go">}}

--- a/content/systems/filecoin_vm/sysactors/init_actor.md
+++ b/content/systems/filecoin_vm/sysactors/init_actor.md
@@ -6,4 +6,4 @@ weight: 1
 # InitActor
 ---
 
-{{<embed src="/specs-actors/actors/builtin/init/init_actor.go" lang="go">}}
+{{<embed src="/modules/actors/builtin/init/init_actor.go" lang="go">}}

--- a/content/systems/filecoin_vm/sysactors/reward_actor.md
+++ b/content/systems/filecoin_vm/sysactors/reward_actor.md
@@ -11,4 +11,4 @@ RewardActor is where unminted Filecoin tokens are kept. RewardActor contains a `
 
 A `Reward` struct contains a `StartEpoch` that keeps track of when this `Reward` is created, `Value` that represents the total number of tokens rewarded, and `EndEpoch` which is when the reward will be fully vested. `VestingFunction` is currently an enum to represent the flexibility of different vesting functions. `AmountWithdrawn` records how many tokens have been withdrawn from a `Reward` struct so far. Owner addresses can call `WithdrawReward` which will withdraw all vested tokens that the investor address has from the RewardMap so far. When `AmountWithdrawn` equals `Value` in a `Reward` struct, the `Reward` struct will be removed from the `RewardMap`.
 
-{{<embed src="/docs/actors/actors/builtin/reward/reward_actor.go"  lang="go">}}
+{{<embed src="/specs-actors/actors/builtin/reward/reward_actor.go"  lang="go">}}

--- a/content/systems/filecoin_vm/sysactors/reward_actor.md
+++ b/content/systems/filecoin_vm/sysactors/reward_actor.md
@@ -11,4 +11,4 @@ RewardActor is where unminted Filecoin tokens are kept. RewardActor contains a `
 
 A `Reward` struct contains a `StartEpoch` that keeps track of when this `Reward` is created, `Value` that represents the total number of tokens rewarded, and `EndEpoch` which is when the reward will be fully vested. `VestingFunction` is currently an enum to represent the flexibility of different vesting functions. `AmountWithdrawn` records how many tokens have been withdrawn from a `Reward` struct so far. Owner addresses can call `WithdrawReward` which will withdraw all vested tokens that the investor address has from the RewardMap so far. When `AmountWithdrawn` equals `Value` in a `Reward` struct, the `Reward` struct will be removed from the `RewardMap`.
 
-{{<embed src="/specs-actors/actors/builtin/reward/reward_actor.go"  lang="go">}}
+{{<embed src="/modules/actors/builtin/reward/reward_actor.go"  lang="go">}}


### PR DESCRIPTION
This PR fixes some broken links to old specs-actors documentation in several files.