### PR TITLE
docs: add description to SDR pages

### DIFF
--- a/content/algorithms/sdr/notation.md
+++ b/content/algorithms/sdr/notation.md
@@ -2,6 +2,7 @@
 title: "Notation, Constants, and Types"
 weight: 2
 math-mode: true
+description: "Notation, Constants, and Types for Stacked DRG PoRep"
 ---
 
 {{< plain hidden >}}

--- a/content/algorithms/sdr/spec.md
+++ b/content/algorithms/sdr/spec.md
@@ -2,6 +2,7 @@
 title: "Specification"
 weight: 1
 math-mode: true
+description: "Stacked DRG Proof of Replication Specification"
 ---
 
 {{< plain hidden >}}


### PR DESCRIPTION
This way previews (like e.g. on Slack) don't show TeX code, but a nicer
description.