### PR TITLE
fix: page edit link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -70,7 +70,7 @@ enableGitInfo = true
   # Enable "Edit this page" links for 'doc' page type.
   # Disabled by default. Uncomment to enable. Requires 'BookRepo' param.
   # Edit path must point to root directory of repo.
-  BookEditPath = 'edit/master'
+  BookEditPath = 'edit/beta'
 
   # Configure the date format used on the pages
   # - In git information


### PR DESCRIPTION
Link in the footer to "edit this page" updated to point to beta branch. Current link points to non-existant path on master.

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>