### PR TITLE
feat: use cid-in-subdomain IPFS preview urls

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
 
       # Pin the built site to ipfs-cluster, output the cid as `steps.ipfs.outputs.cid`
       # see: https://github.com/ipfs-shipyard/ipfs-github-action
-      - uses: ipfs-shipyard/ipfs-github-action@use-cid-in-subdomain-preview-url
+      - uses: ipfs-shipyard/ipfs-github-action@v2.0.0
         id: ipfs
         with:
           path_to_add: public

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
 
       # Pin the built site to ipfs-cluster, output the cid as `steps.ipfs.outputs.cid`
       # see: https://github.com/ipfs-shipyard/ipfs-github-action
-      - uses: ipfs-shipyard/ipfs-github-action@v1.0.0
+      - uses: ipfs-shipyard/ipfs-github-action@use-cid-in-subdomain-preview-url
         id: ipfs
         with:
           path_to_add: public


### PR DESCRIPTION
Upgrade to ipfs-github-action@v2 to get cid-in-subdomain preview urls

Fixes #1007 

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>