### PR TITLE
fix: remove pos pdf and add content

### DIFF
--- a/content/algorithms/post/_index.md
+++ b/content/algorithms/post/_index.md
@@ -10,4 +10,16 @@ dashboardTests: 0
 
 # Proof-of-Spacetime
 ---
-{{< pdf src="https://filecoin.io/filecoin.pdf" title="Filecoin Paper">}}
+_Proof-of-Storage_ schemes allow a user to check if a storage provider is storing the outsourced data at the time
+of the challenge. How can we use **PoS** schemes to prove that some data was being stored throughout a period
+of time? A natural answer to this question is to require the user to repeatedly (e.g. every minute) send
+challenges to the storage provider. However, the communication complexity required in each interaction can
+be the bottleneck in systems such as Filecoin, where storage providers are required to submit their proofs to
+the blockchain network.
+
+To address this question, we introduce a new proof, _Proof-of-Spacetime_, where a verifier can check if a prover
+is storing her/his outsourced data for a range of time. The intuition is to require the prover to (1) generate
+sequential Proofs-of-Storage (in our case Proof-of-Replication), as a way to determine time (2) recursively
+compose the executions to generate a short proof.
+
+Section 3.3 of the [Filecoin Paper](https://filecoin.io/filecoin.pdf) provides the original introduction to Proof-of-Spacetime.

--- a/layouts/shortcodes/pdf.html
+++ b/layouts/shortcodes/pdf.html
@@ -1,20 +1,13 @@
-{{ if not (.Page.Scratch.Get "panzoom") }}
-    <!-- Include mermaid only first time -->
-    <!-- <script src='https://unpkg.com/panzoom@9.2.4/dist/panzoom.min.js'></script> -->
-    <script src="https://unpkg.com/d3-zoomable@1.1.3/dist/d3-zoomable.min.js"></script>
-    {{ .Page.Scratch.Set "panzoom" true }}
-{{ end }}
-
-{{ if (.Get "src") }}
+{{- if (.Get "src") -}}
         <object data='{{- .Get "src" -}}#pagemode=thumbs&toolbar=1&statusbar=1&messages=1&navpanes=1' 
           type='application/pdf' 
           width='100%' 
           height='500px'>
           <p>This browser does not support inline PDFs. Please download the PDF to view it: <a href="{{- .Get "src" -}}">Download {{ .Get "title" }} PDF</a></p>
         </object>
-{{ else }}
+{{- else -}}
 <blockquote class="book-hint danger">
   {{- printf "File '%s' not found from Page '%s'" ($.Scratch.Get "filepath") .Page.File }}
 </blockquote>
 {{- warnf "File '%s' not found from Page '%s'" ($.Scratch.Get "filepath") .Page.File }}
-{{ end }}
+{{- end -}}


### PR DESCRIPTION
This PR removes the pdf shortcode from the PoS section and add a bit of content from the original paper.