### PR TITLE
wip: dashboard updates

### DIFF
--- a/assets/_colors.scss
+++ b/assets/_colors.scss
@@ -4,7 +4,7 @@
 .text-incomplete {color: #ffef00;}
 .text-stable {color: #90ff00;}
 .text-transparent { color: transparent;}
-.text-black { color: black;}
+.text-black { color: black !important;}
 
 .bg-na { background-color: #6c8293;}
 .bg-incorrect {background-color: #ff0010;}

--- a/assets/_dashboard.scss
+++ b/assets/_dashboard.scss
@@ -1,7 +1,19 @@
+table.Dashboard {
+    display: table;
+    table-layout: fixed;
+    width: 100%;
+    font-size: 12px;
+}
+
+table.Dashboard {
+    th:first-child {
+        width: 50%;
+    }
+}
+
 .Dashboard tr th,
 .Dashboard tr td {
     padding: 0 1rem !important;
-    font-size: 12px;
     text-align: center;
 }
 .Dashboard tr td:first-child {

--- a/content/intro/_index.md
+++ b/content/intro/_index.md
@@ -32,10 +32,53 @@ over time, without requiring further interaction from the original parties
 (such as the clients who requested the data storage).
 
 ## Spec Status Overview
-{{<dashboard-progress>}}
+
+Each section of the spec must be stable and audited before it is considered done. The state of each section is tracked below. 
+
+- The **State** column indicates the stability as defined in the legend. 
+- The **Theory Audit** column shows the date of the last theory audit with a link to the report.
+
+### Legend
+
+<table class="Dashboard"">
+  <thead>
+    <tr>
+      <th>Spec state</th>
+      <th>Label</th>
+    <tr>
+  <thead>
+  <tbody>
+    <tr>
+      <td>Final, will not change before mainnet launch</td>
+      <td class="text-black bg-stable">Stable</td>
+    </tr>
+    <tr>
+      <td>Correct, but some details are missing</td>
+      <td class="text-black bg-incomplete">Incomplete</td>
+    </tr>
+    <tr>
+      <td>Likely to change. Details still being finalised</td>
+      <td class="text-black bg-wip">WIP</td>
+    </tr>
+    <tr>
+      <td>Do not follow. Important things have changed</td>
+      <td class="text-black bg-incorrect">Incorrect</td>
+    </tr>
+  </tbody>
+</table>
+
+### Spec Status
 
 {{<dashboard-spec>}}
 
+### Spec Stabilization Progess
+
+This progress bar shows what percentage of the spec sections are considered stable.
+
+{{<dashboard-progress>}}
+
 ## Implementations Status
+
+Known implementations of the filecoin spec are tracked below, with their current CI build status, their test coverage as reported by coveralls.io, and a link to their last security audit report where one exists.
 
 {{<dashboard-impl>}}

--- a/content/intro/_index.md
+++ b/content/intro/_index.md
@@ -37,6 +37,7 @@ Each section of the spec must be stable and audited before it is considered done
 
 - The **State** column indicates the stability as defined in the legend. 
 - The **Theory Audit** column shows the date of the last theory audit with a link to the report.
+- The **Weight** column is used to highlight the relative criticality of a section against the others.
 
 ### Legend
 
@@ -77,8 +78,10 @@ This progress bar shows what percentage of the spec sections are considered stab
 
 {{<dashboard-progress>}}
 
+
+
 ## Implementations Status
 
-Known implementations of the filecoin spec are tracked below, with their current CI build status, their test coverage as reported by coveralls.io, and a link to their last security audit report where one exists.
+Known implementations of the filecoin spec are tracked below, with their current CI build status, their test coverage as reported by [codecov.io](https://codecov.io), and a link to their last security audit report where one exists.
 
 {{<dashboard-impl>}}

--- a/layouts/shortcodes/dashboard-impl.html
+++ b/layouts/shortcodes/dashboard-impl.html
@@ -1,11 +1,10 @@
-<table id="dashboard-impls" class="sort">
+<table id="dashboard-impls" class="sort Dashboard">
     <thead>
         <tr>
             <th>Implementation</th>
-            <th>Test Coverage</th>
-            <th>Compliance Tests</th>
-            <th>Security Audit</th>
             <th>CI</th>
+            <th>Test Coverage</th>
+            <th>Security Audit</th>
         </tr>
     </thead>
     <tbody>
@@ -35,17 +34,13 @@
         {{ end }}
         <tr>
             <td><a title="{{.Title}}" href="{{.Permalink}}">{{.Title}}</a></td>
+            <td class="text-transparent {{ if eq $data.commit.ci_passed  true }}bg-stable{{ else if eq $data.commit.ci_passed false }}bg-incorrect {{ else }}bg-na{{end}}">
+            </td>
             <td class="text-black {{ $color }}">
                 {{ if $data.commit.totals.c }}{{ math.Round $data.commit.totals.c }}%{{ else }}N/A{{end}}
             </td>
-            <td class="text-transparent {{ if gt .Page.Params.implSpecCompliance 0 }}bg-stable{{ else }}bg-incorrect{{end}}">
-                {{ .Page.Params.implSpecCompliance }}
-            </td>
             <td class="text-transparent {{ if gt .Page.Params.implAudit 0 }}bg-stable{{ else }}bg-incorrect{{end}}">
                 {{ .Page.Params.implAudit }}
-            </td>
-            <td class="text-transparent {{ if eq $data.commit.ci_passed  true }}bg-stable{{ else if eq $data.commit.ci_passed false }}bg-incorrect {{ else }}bg-na{{end}}">
-                
             </td>
         </tr>
         

--- a/layouts/shortcodes/dashboard-impl.html
+++ b/layouts/shortcodes/dashboard-impl.html
@@ -4,7 +4,7 @@
             <th>Implementation</th>
             <th>Test Coverage</th>
             <th>Compliance Tests</th>
-            <th>Audit</th>
+            <th>Security Audit</th>
             <th>CI</th>
         </tr>
     </thead>

--- a/layouts/shortcodes/dashboard-impl.html
+++ b/layouts/shortcodes/dashboard-impl.html
@@ -25,19 +25,25 @@
         {{ $color := "bg-na"}}
         {{ if gt $cov 0 }}
             {{ $color = "bg-incorrect"}}
-        {{ else if gt $cov 25 }}
+        {{ end }}
+        {{ if gt $cov 20 }}
             {{ $color = "bg-wip"}}
-        {{ else if gt $cov 50 }}
+        {{ end }}
+        {{ if gt $cov 45 }}
             {{ $color = "bg-incomplete"}}
-        {{ else if gt $cov 75 }}
+        {{ end }}
+        {{ if gt $cov 70 }}
             {{ $color = "bg-stable"}}
         {{ end }}
         <tr>
             <td><a title="{{.Title}}" href="{{.Permalink}}">{{.Title}}</a></td>
-            <td class="text-transparent {{ if eq $data.commit.ci_passed  true }}bg-stable{{ else if eq $data.commit.ci_passed false }}bg-incorrect {{ else }}bg-na{{end}}">
+            <td class="text-black {{ if eq $data.commit.ci_passed  true }}bg-stable{{ else if eq $data.commit.ci_passed false }}bg-incorrect {{ else }}bg-na{{end}}">
+                {{ if eq $data.commit.ci_passed  true }}Passed{{ else if eq $data.commit.ci_passed false }}Failed{{ else }}Unknown{{ end }}
             </td>
             <td class="text-black {{ $color }}">
-                {{ if $data.commit.totals.c }}{{ math.Round $data.commit.totals.c }}%{{ else }}N/A{{end}}
+                <a class="text-black" href="https://codecov.io/gh/{{ $path }}" title="Open on codecov.io">
+                    {{ if $data.commit.totals.c }}{{ math.Round $data.commit.totals.c }}%{{ else }}N/A{{end}}
+                </a>
             </td>
             <td class="text-transparent {{ if gt .Page.Params.implAudit 0 }}bg-stable{{ else }}bg-incorrect{{end}}">
                 {{ .Page.Params.implAudit }}

--- a/layouts/shortcodes/dashboard-progress.html
+++ b/layouts/shortcodes/dashboard-progress.html
@@ -25,14 +25,9 @@
     {{- end -}}
     {{- $perc := lang.NumFmt 2 (div (float (mul $stable 100))  (float $count)) -}}
     {{- $perc2 := lang.NumFmt 2 (div (mul $stableWeight 100) $countWeight) -}}
-
-    <h3>Progress</h3>
+    
     <div class="meter">
         <span style="width: {{$perc}}%">{{$perc}}%</span>
-    </div>
-    <h3>Consequence</h3>
-    <div class="meter">
-        <span style="width: {{$perc2}}%">{{$perc2}}%</span>
     </div>
     <style>
         .meter { 

--- a/layouts/shortcodes/dashboard-progress.html
+++ b/layouts/shortcodes/dashboard-progress.html
@@ -23,9 +23,9 @@
             {{- end -}}
         {{- end -}}
     {{- end -}}
-    {{- $perc := lang.NumFmt 2 (div (float (mul $stable 100))  (float $count)) -}}
-    {{- $perc2 := lang.NumFmt 2 (div (mul $stableWeight 100) $countWeight) -}}
-    
+    {{- $perc := lang.NumFmt 0 (div (float (mul $stable 100))  (float $count)) -}}
+    {{- $perc2 := lang.NumFmt 0 (div (mul $stableWeight 100) $countWeight) -}}
+
     <div class="meter">
         <span style="width: {{$perc}}%">{{$perc}}%</span>
     </div>

--- a/layouts/shortcodes/dashboard-spec.html
+++ b/layouts/shortcodes/dashboard-spec.html
@@ -28,7 +28,9 @@
     {{- $pages2 := where $pages "Params.dashboardhidden" "ne" true -}}
     {{- range sort $pages2 "Weight" "asc" -}}
         {{- $level = add $level 1 -}}
-        {{- if .IsSection -}}
+        {{- if (or (lt $level 200) (gt $level 10000)) -}}
+            {{ template "dashboard-section-children" (dict "Section" . "level" $level) }}
+        {{- else if .IsSection -}}
             {{ template "dashboard-tr" (dict "Page" . "Level" $level) }}
             {{ template "dashboard-section-children" (dict "Section" . "level" $level) }}
         {{ else if and .IsPage .Content }}

--- a/layouts/shortcodes/dashboard-spec.html
+++ b/layouts/shortcodes/dashboard-spec.html
@@ -8,7 +8,6 @@
             <th>Weight</th>
             <th>State</th>
             <th>Theory Audit</th>
-            <th>Compliance Tests</th>
         </tr>
     </thead>
     <tbody>
@@ -61,16 +60,5 @@
     
     <!-- Audit -->
     <td class="text-transparent {{ if gt .Page.Params.dashboardaudit 0 }}bg-stable{{ else }}bg-incorrect{{end}}">{{ .Page.Params.dashboardaudit }}</td>
-    
-    <!-- Tests -->
-    <td class="text-black {{- if gt .Page.Params.dashboardTests 0 -}}bg-stable{{ else if eq .Page.Params.dashboardTests 0 }} bg-incorrect {{ else }} bg-na {{ end }}">
-        {{- if eq .Page.Params.dashboardTests 0 -}}
-            {{ .Page.Params.dashboardTests }}
-        {{- else if gt .Page.Params.dashboardTests 0 -}}
-            {{ .Page.Params.dashboardTests }}
-        {{- else -}}
-            N/A
-        {{- end -}}
-    </td>
 </tr>
 {{- end -}}


### PR DESCRIPTION
Updates to the dashboard from feedback, trying to find the right granularity of information.

- [x] show levels 3 and 4 in dashboard
- [x] skip the intro section
- [x] remove consequence bar
- [x] add intro text and legend


<img width="1416" alt="Screenshot 2020-07-30 at 14 00 22" src="https://user-images.githubusercontent.com/58871/88925895-1abbb980-d26d-11ea-8402-1916145231b7.png">

<img width="1416" alt="Screenshot 2020-07-30 at 14 00 29" src="https://user-images.githubusercontent.com/58871/88925902-1d1e1380-d26d-11ea-8cd6-1919e6f12346.png">

Fixes #1019 

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>