### PR TITLE
fix: ensure light mode even if dark mode OS pref

### DIFF
--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -77,8 +77,7 @@
     padding: 1px .5rem;
     border: 0;
     border-radius: .25rem;
-    background: rgba(255,255,255,.1);
-    color: #e9ecef;
+    background: $book-search-results-bg;
     margin-top: 3px;
 }
 
@@ -89,9 +88,7 @@
 #book-search-input {
     outline: none;
 }
-#book-search-input:focus {
-    background: rgba(255,255,255,.2);
-}
+
 // Tweaks
 summary {
     outline: none;

--- a/assets/_variables.scss
+++ b/assets/_variables.scss
@@ -1,1 +1,3 @@
 /* You can override SASS variables here. */
+
+$book-search-results-bg: #f8f9fa !default;

--- a/assets/dark-mode/dark-mode.js
+++ b/assets/dark-mode/dark-mode.js
@@ -32,6 +32,9 @@
   // Light is default, so enable dark if user previously chose it but their OS pref is light.
   if (theme === 'dark') {
     enableDarkMode()
+  } else {
+    // needed to catch those OS darkmoders who want their specs to be light mode.
+    enableLightMode()
   }
 
   // set up the toggle once the DOM is ready.

--- a/assets/dark-mode/dark-mode.js
+++ b/assets/dark-mode/dark-mode.js
@@ -5,8 +5,7 @@
   const lightMode = document.getElementById('light-mode-link')
   const darkMode = document.getElementById('dark-mode-link')
   const btn = document.querySelector('.dark-mode-toggle')
-  const prefersDarkScheme = window.matchMedia('(prefers-color-scheme: dark)').matches 
-  let theme = prefersDarkScheme ? 'dark' : 'light'
+  let theme = 'light'
 
   function enableLightMode () {
     lightMode.disabled = false
@@ -20,21 +19,13 @@
     btn.setAttribute('aria-pressed', theme === 'dark')
   }
   
-  // enable dark theme optimistically on OS with dark theme enabled to reduce flashing of white theme.
-  if (prefersDarkScheme) {
-    enableDarkMode()
-  }
-
   // wait for localstorage...
   const previousChoice = localStorage.getItem('theme')
   theme = previousChoice || theme
   
-  // Light is default, so enable dark if user previously chose it but their OS pref is light.
+  // Light is default, so enable dark if user previously chose it.
   if (theme === 'dark') {
     enableDarkMode()
-  } else {
-    // needed to catch those OS darkmoders who want their specs to be light mode.
-    enableLightMode()
   }
 
   // set up the toggle once the DOM is ready.

--- a/assets/plugins/_dark.scss
+++ b/assets/plugins/_dark.scss
@@ -9,3 +9,5 @@ $color-link: #0090ff;
 $color-visited-link: #0090ff;
 
 $icon-filter: brightness(0) invert(1);
+
+$book-search-results-bg: rgba(255,255,255,.1);


### PR DESCRIPTION
- Ignore users OS pref. Light mode is the default regardless. (this fixes light-mode choice not preserved for uses with dark-mode set as OS default.)
- Fix search results to respect color-scheme preference.

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>