### PR TITLE
feat: spec state badges

### DIFF
--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -403,4 +403,22 @@ i[class^="gg-"] {
     box-shadow: 4px -6px 0,8px -12px 0;
     border-radius: 4px;
     background: currentColor
-} 
+}
+
+.state-badge {
+    font-size: 10px;
+    font-weight: 500;   
+}
+.state-badge-link {
+    text-decoration: none !important;
+    color: white !important;
+    &:hover {
+        text-decoration: none;
+    }
+}
+.state-badge-key, .state-badge-value {
+    padding: 2px 5px;
+}
+.state-badge-key {
+    background-color: #555;
+}

--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -23,4 +23,7 @@
 <h{{ $level }} id="{{ $anchor | safeURL }}">
   {{ .Text | safeHTML }}
   <a class="anchor" href="#{{ $anchor | safeURL }}">#</a>
+  <span style="float:right">
+  {{ partial "state-badge.html" .Page.Params }}
+  </span>
 </h{{ $level }}>

--- a/layouts/partials/state-badge.html
+++ b/layouts/partials/state-badge.html
@@ -1,0 +1,7 @@
+{{ if .dashboardState }}
+<label class="state-badge">
+  <a class="state-badge-link" href="#">
+    <span class="state-badge-key">state</span><span class="state-badge-value text-black bg-{{ .dashboardState }}">{{ .dashboardState }}</span>
+  </a>
+</label>
+{{ end }}


### PR DESCRIPTION
add badges to section headers to show the current state. CSS only, no dep on shields.io being up.

<img width="1552" alt="Screenshot 2020-07-31 at 10 45 21" src="https://user-images.githubusercontent.com/58871/89023413-72b0f980-d31b-11ea-8267-e0a9c45ae114.png">
