### PR TITLE
feat: add modules and lang to impl dashboard

### DIFF
--- a/content/implementations/forest.md
+++ b/content/implementations/forest.md
@@ -4,8 +4,7 @@ weight: 3
 implAudit: 0
 implSpecCompliance: 0
 implRepos:
- - https://github.com/ChainSafe/forest
-implLang: rust  
+ - { lang: rust, repo: https://github.com/ChainSafe/forest }
 ---
 
 # Forest is an implementation of Filecoin written in Rust

--- a/content/implementations/forest.md
+++ b/content/implementations/forest.md
@@ -3,7 +3,9 @@ title: Forest
 weight: 3
 implAudit: 0
 implSpecCompliance: 0
-implRepo: https://github.com/ChainSafe/forest
+implRepos:
+ - https://github.com/ChainSafe/forest
+implLang: rust  
 ---
 
 # Forest is an implementation of Filecoin written in Rust

--- a/content/implementations/fuhon.md
+++ b/content/implementations/fuhon.md
@@ -1,9 +1,11 @@
 ---
-title: Fuhon (cpp-filecoin) 
+title: Fuhon
 weight: 4
 implAudit: 0
 implSpecCompliance: 0
-implRepo: https://github.com/filecoin-project/cpp-filecoin
+implRepos: 
+  - https://github.com/filecoin-project/cpp-filecoin
+implLang: c++
 ---
 
 # Fuhon (cpp-filecoin)

--- a/content/implementations/fuhon.md
+++ b/content/implementations/fuhon.md
@@ -4,8 +4,7 @@ weight: 4
 implAudit: 0
 implSpecCompliance: 0
 implRepos: 
-  - https://github.com/filecoin-project/cpp-filecoin
-implLang: c++
+  - { lang: c++, repo: https://github.com/filecoin-project/cpp-filecoin }
 ---
 
 # Fuhon (cpp-filecoin)

--- a/content/implementations/go-filecoin.md
+++ b/content/implementations/go-filecoin.md
@@ -4,8 +4,7 @@ weight: 2
 implAudit: 0
 implSpecCompliance: 0
 implRepos: 
-  - https://github.com/filecoin-project/go-filecoin
-implLang: go
+  - { lang: go, repo: https://github.com/filecoin-project/go-filecoin }
 ---
 
 # Filecoin (go-filecoin)

--- a/content/implementations/go-filecoin.md
+++ b/content/implementations/go-filecoin.md
@@ -1,9 +1,11 @@
 ---
-title: Filecoin (go-filecoin)
+title: go-filecoin
 weight: 2
 implAudit: 0
 implSpecCompliance: 0
-implRepo: https://github.com/filecoin-project/go-filecoin
+implRepos: 
+  - https://github.com/filecoin-project/go-filecoin
+implLang: go
 ---
 
 # Filecoin (go-filecoin)

--- a/content/implementations/lotus.md
+++ b/content/implementations/lotus.md
@@ -5,13 +5,13 @@ weight: 1
 implAudit: 0
 implSpecCompliance: 0
 implRepos: 
-  - https://github.com/filecoin-project/lotus
-  - https://github.com/filecoin-project/storage-fsm
-  - https://github.com/filecoin-project/sector-storage
-  - https://github.com/filecoin-project/specs-storage
-  - https://github.com/filecoin-project/go-fil-markets
-  - https://github.com/filecoin-project/specs-actors
-implLang: go
+  - { lang: go,   repo: https://github.com/filecoin-project/lotus }
+  - { lang: go,   repo: https://github.com/filecoin-project/storage-fsm }
+  - { lang: go,   repo: https://github.com/filecoin-project/sector-storage }
+  - { lang: go,   repo: https://github.com/filecoin-project/specs-storage }
+  - { lang: go,   repo: https://github.com/filecoin-project/go-fil-markets }
+  - { lang: go,   repo: https://github.com/filecoin-project/specs-actors }
+  - { lang: rust, repo: https://github.com/filecoin-project/rust-fil-proofs }
 ---
 
 # Lotus

--- a/content/implementations/lotus.md
+++ b/content/implementations/lotus.md
@@ -4,7 +4,14 @@ weight: 1
 
 implAudit: 0
 implSpecCompliance: 0
-implRepo: https://github.com/filecoin-project/lotus
+implRepos: 
+  - https://github.com/filecoin-project/lotus
+  - https://github.com/filecoin-project/storage-fsm
+  - https://github.com/filecoin-project/sector-storage
+  - https://github.com/filecoin-project/specs-storage
+  - https://github.com/filecoin-project/go-fil-markets
+  - https://github.com/filecoin-project/specs-actors
+implLang: go
 ---
 
 # Lotus

--- a/layouts/shortcodes/dashboard-impl.html
+++ b/layouts/shortcodes/dashboard-impl.html
@@ -18,7 +18,9 @@
 {{ define "dashboard-impls-children" }}
     {{- $pages := where .Section.Pages "Params.bookhidden" "ne" true -}}
     {{- range $impl := (sort $pages "Weight" "asc") -}}
-        {{- range $repoUrl := .Params.implRepos -}}
+        {{- range $repoUrlIndex, $repoItem := .Params.implRepos -}}
+            {{ $repoUrl := $repoItem.repo }}
+            {{ $repoLang := $repoItem.lang }}
             {{ $parts := split $repoUrl "/" }}
             {{ $size := len $parts }}
             {{ $repoName := (index $parts (sub $size 1)) }}
@@ -41,9 +43,13 @@
                 {{ $color = "bg-stable"}}
             {{ end }}
             <tr>
-                <td><a title="{{ $impl.Title }}" href="{{ $impl.Permalink }}">{{ $impl.Title }}</a></td>
+                {{ if eq $repoUrlIndex 0 }}
+                <td {{ if gt (len $impl.Params.implRepos) 1 }}rowspan="{{ len $impl.Params.implRepos }}"{{ end }}>
+                    <a title="{{ $impl.Title }}" href="{{ $impl.Permalink }}">{{ $impl.Title }}</a>
+                </td>
+                {{ end }}
                 <td style="text-align:left"><a title="{{ $repoName }}" href="{{ $repoUrl }}">{{ $repoName }}</a></td>
-                <td>{{ $impl.Params.implLang }}</td>
+                <td>{{ $repoLang }}</td>
                 <td class="text-black {{ if eq $data.commit.ci_passed  true }}bg-stable{{ else if eq $data.commit.ci_passed false }}bg-incorrect {{ else }}bg-na{{end}}">
                     {{ if eq $data.commit.ci_passed  true }}Passed{{ else if eq $data.commit.ci_passed false }}Failed{{ else }}Unknown{{ end }}
                 </td>

--- a/layouts/shortcodes/dashboard-impl.html
+++ b/layouts/shortcodes/dashboard-impl.html
@@ -1,7 +1,9 @@
 <table id="dashboard-impls" class="sort Dashboard">
     <thead>
         <tr>
-            <th>Implementation</th>
+            <th style="width:20%">Project</th>
+            <th>Module</th>
+            <th>Language</th>
             <th>CI</th>
             <th>Test Coverage</th>
             <th>Security Audit</th>
@@ -15,40 +17,45 @@
 <!-- Children Template -->
 {{ define "dashboard-impls-children" }}
     {{- $pages := where .Section.Pages "Params.bookhidden" "ne" true -}}
-    {{- range sort $pages "Weight" "asc" -}}
-        {{ $parts := split .Params.implRepo "/" }}
-        {{ $size := len $parts }}
-        {{ $path := delimit (slice (index $parts (sub $size 2)) (index $parts (sub $size 1))) "/" }}
-        {{ $url := printf "https://codecov.io/api/gh/%s" $path }}
-        {{ $data := getJSON $url }}
-        {{ $cov := $data.commit.totals.c }}
-        {{ $color := "bg-na"}}
-        {{ if gt $cov 0 }}
-            {{ $color = "bg-incorrect"}}
+    {{- range $impl := (sort $pages "Weight" "asc") -}}
+        {{- range $repoUrl := .Params.implRepos -}}
+            {{ $parts := split $repoUrl "/" }}
+            {{ $size := len $parts }}
+            {{ $repoName := (index $parts (sub $size 1)) }}
+            {{ $repoOrg := (index $parts (sub $size 2)) }}
+            {{ $path := delimit (slice $repoOrg $repoName) "/" }}
+            {{ $url := printf "https://codecov.io/api/gh/%s" $path }}
+            {{ $data := getJSON $url }}
+            {{ $cov := $data.commit.totals.c }}
+            {{ $color := "bg-na"}}
+            {{ if gt $cov 0 }}
+                {{ $color = "bg-incorrect"}}
+            {{ end }}
+            {{ if gt $cov 20 }}
+                {{ $color = "bg-wip"}}
+            {{ end }}
+            {{ if gt $cov 45 }}
+                {{ $color = "bg-incomplete"}}
+            {{ end }}
+            {{ if gt $cov 70 }}
+                {{ $color = "bg-stable"}}
+            {{ end }}
+            <tr>
+                <td><a title="{{ $impl.Title }}" href="{{ $impl.Permalink }}">{{ $impl.Title }}</a></td>
+                <td style="text-align:left"><a title="{{ $repoName }}" href="{{ $repoUrl }}">{{ $repoName }}</a></td>
+                <td>{{ $impl.Params.implLang }}</td>
+                <td class="text-black {{ if eq $data.commit.ci_passed  true }}bg-stable{{ else if eq $data.commit.ci_passed false }}bg-incorrect {{ else }}bg-na{{end}}">
+                    {{ if eq $data.commit.ci_passed  true }}Passed{{ else if eq $data.commit.ci_passed false }}Failed{{ else }}Unknown{{ end }}
+                </td>
+                <td class="text-black {{ $color }}">
+                    <a class="text-black" href="https://codecov.io/gh/{{ $path }}" title="Open on codecov.io">
+                        {{ if $data.commit.totals.c }}{{ math.Round $data.commit.totals.c }}%{{ else }}Unknown{{end}}
+                    </a>
+                </td>
+                <td class="text-transparent {{ if gt $impl.Params.implAudit 0 }}bg-stable{{ else }}bg-incorrect{{end}}">
+                    {{ $impl.Params.implAudit }}
+                </td>
+            </tr>
         {{ end }}
-        {{ if gt $cov 20 }}
-            {{ $color = "bg-wip"}}
-        {{ end }}
-        {{ if gt $cov 45 }}
-            {{ $color = "bg-incomplete"}}
-        {{ end }}
-        {{ if gt $cov 70 }}
-            {{ $color = "bg-stable"}}
-        {{ end }}
-        <tr>
-            <td><a title="{{.Title}}" href="{{.Permalink}}">{{.Title}}</a></td>
-            <td class="text-black {{ if eq $data.commit.ci_passed  true }}bg-stable{{ else if eq $data.commit.ci_passed false }}bg-incorrect {{ else }}bg-na{{end}}">
-                {{ if eq $data.commit.ci_passed  true }}Passed{{ else if eq $data.commit.ci_passed false }}Failed{{ else }}Unknown{{ end }}
-            </td>
-            <td class="text-black {{ $color }}">
-                <a class="text-black" href="https://codecov.io/gh/{{ $path }}" title="Open on codecov.io">
-                    {{ if $data.commit.totals.c }}{{ math.Round $data.commit.totals.c }}%{{ else }}N/A{{end}}
-                </a>
-            </td>
-            <td class="text-transparent {{ if gt .Page.Params.implAudit 0 }}bg-stable{{ else }}bg-incorrect{{end}}">
-                {{ .Page.Params.implAudit }}
-            </td>
-        </tr>
-        
     {{ end }}
 {{ end }}

--- a/layouts/shortcodes/dashboard-impl.html
+++ b/layouts/shortcodes/dashboard-impl.html
@@ -1,8 +1,7 @@
 <table id="dashboard-impls" class="sort Dashboard">
     <thead>
         <tr>
-            <th style="width:20%">Project</th>
-            <th>Module</th>
+            <th style="width:20%">Repo</th>
             <th>Language</th>
             <th>CI</th>
             <th>Test Coverage</th>
@@ -43,11 +42,6 @@
                 {{ $color = "bg-stable"}}
             {{ end }}
             <tr>
-                {{ if eq $repoUrlIndex 0 }}
-                <td {{ if gt (len $impl.Params.implRepos) 1 }}rowspan="{{ len $impl.Params.implRepos }}"{{ end }}>
-                    <a title="{{ $impl.Title }}" href="{{ $impl.Permalink }}">{{ $impl.Title }}</a>
-                </td>
-                {{ end }}
                 <td style="text-align:left"><a title="{{ $repoName }}" href="{{ $repoUrl }}">{{ $repoName }}</a></td>
                 <td>{{ $repoLang }}</td>
                 <td class="text-black {{ if eq $data.commit.ci_passed  true }}bg-stable{{ else if eq $data.commit.ci_passed false }}bg-incorrect {{ else }}bg-na{{end}}">


### PR DESCRIPTION
Add rows to the impl dashboard for submodules and columns for module and lang.

<img width="828" alt="Screenshot 2020-08-06 at 16 34 39" src="https://user-images.githubusercontent.com/58871/89551366-c7b0ac00-d802-11ea-84c5-56d07d05ff4b.png">


Fixes #1037
Fixes #1038

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>