### PR TITLE
Major update in EC and Secret Leader Election Specification

### DIFF
--- a/content/algorithms/expected_consensus/_index.md
+++ b/content/algorithms/expected_consensus/_index.md
@@ -2,7 +2,7 @@
 title: "Expected Consensus"
 weight: 1
 dashboardWeight: 2
-dashboardState: incomplete
+dashboardState: stable
 dashboardAudit: 1
 dashboardTests: 0
 ---
@@ -12,11 +12,11 @@ dashboardTests: 0
 
 ## Algorithm
 
-Expected Consensus (EC) is a probabilistic Byzantine fault-tolerant consensus protocol. At a high level, it operates by running a leader election every round in which, on expectation, one participant may be eligible to submit a block. EC guarantees that this winner will be anonymous until they reveal themselves by submitting a proof of their election. The miner can submit a number of such proofs per round and will be rewarded proportionally. Each proof can be derived from a `Challenge Ticket` produced by the [Election PoSt](election_post). All valid blocks submitted in a given round form a `Tipset`. Every block in a Tipset adds weight to its chain. The 'best' chain is the one with the highest weight, which is to say that the fork choice rule is to choose the heaviest known chain. For more details on how to select the heaviest chain, see [Chain Selection](expected_consensus#chain-selection).
+Expected Consensus (EC) is a probabilistic Byzantine fault-tolerant consensus protocol. At a high level, it operates by running a leader election on every round during which, on expectation, one participant may be eligible to submit a block. EC guarantees that this winner will be anonymous until they reveal themselves by submitting a proof of their election. The miner can submit a proof per round and will be rewarded proportionally to its power. **Each miner will submit a proof for election (Leader Election step 1) and a proof of storage (winning PoSt step 2).** All valid blocks submitted in a given round form a `Tipset`. Every block in a Tipset adds weight to its chain. The 'best' chain is the one with the highest weight, which is to say that the fork choice rule is to choose the heaviest known chain. For more details on how to select the heaviest chain, see [Chain Selection](expected_consensus#chain-selection).
 
-At a very high level, with every new block generated, a miner will craft a new ticket from the prior one in the chain appended with the current epoch number (i.e. parentTipset.epoch + 1 to start). While on expectation at least one block will be generated at every round, in cases where no one finds a block in a given round, a miner will increment the round number and attempt a new leader election (using the new input) thereby ensuring liveness in the protocol.
+Every block is associated with a randomness value. This randomness value is generated from [DRAND](https://drand.love), an unbiasable randomness generator, through a beacon. When the miner wants to publish a new block, they invoke the `getRandomness` function providing the chain height (i.e., epoch) as input. The randomness value is returned through the DRAND beacon and included in the block. For the details of DRAND and its implementation, please consult the project's [documentation](https://drand.love/docs/overview/) and [specification](https://drand.love/docs/specification/).
 
-The [Storage Power Consensus](storage_power_consensus) subsystem uses access to EC to use the following facilities:
+The [Storage Power Consensus](storage_power_consensus) subsystem uses access to EC to make use of the following facilities:
 
 - Access to verifiable randomness for the protocol, derived from [Tickets](storage_power_consensus#tickets).
 - Running and verifying [Secret Leader Election](expected_consensus#secret-leader-election) for block generation.
@@ -28,115 +28,290 @@ The [Storage Power Consensus](storage_power_consensus) subsystem uses access to 
 
 ## Tickets in EC
 
-Within SPC, a miner generates a new ticket in their block for every ticket they use running leader election, thereby ensuring the ticket chain is always as long as the block chain.
+There are two kinds of tickets:
+1. election proof/ticket: which is the VRF that runs based on DRAND input. In particular, the miner gets the DRAND randomness beacon and gives it as input to the VRF together with the miner's worker's key.
+2. VRF Chain: the ticket is the same as above, but includes the concatenation of the previous ticket. This means that the new ticket becomes the old ticket concatenated with the new DRAND value.
 
-Tickets are used to achieve the following:
+```text
+## Get Randomness value from  DRAND beacon, by giving the current epoch as input.
+Drand_value = GetRandmness(current epoch)
 
-- Ensure leader secrecy -- meaning a block producer will not be known until they release their block to the network.
-- Prove leader election -- meaning a block producer can be verified by any participant in the network.
+## Create election proof (also called election ticket) by calling VRF and  giving the secret key of the miner's worker and the DRAND value obtained in the previous step
+Election_Proof = VRF(sk, drand_value)
 
-In practice, EC defines two different fields within a block:
+## Extend the VRF ticket chain by concatenating the previous proof/ticket with the current one by following the same process as above (i.e., call VRF function with the secret key of the miner's worker and the DRAND value of the current epoch).
+VRF chain: new_ticket = VRF(sk, drand_value || previous ticket)
+```
 
-- A `Ticket` field — this stores the new ticket generated during this block generation attempt. It is from this ticket that miners will sample randomness to run leader election in `K` rounds (see [Tickets](storage_power_consensus#tickets)).
-- A set of winning `ChallengeTickets` — this stores a proof that a given miner has won a leader election using the appropriate ticket generated by the election PoSt process with randomness `K` rounds back. It proves that the leader was validly elected in this epoch.
+Within Storage Power Consensus (SPC), a miner generates a new ticket for every block on which they run a leader election. This means that the ticket chain is always as long as the blockchain.
 
-{{<embed src="../../systems/filecoin_blockchain/struct/block/election.id"  lang="go" >}}
-{{<embed src="../../systems/filecoin_blockchain/struct/block/election.go"  lang="go" >}}
+Through the use of VRFs and thanks to the unbiasable design of DRAND, we achieve the following two properties.
 
-**But why the randomness lookback?**
+- _Ensure leader secrecy:_ meaning a block producer will not be known until they release their block to the network.
+- _Prove leader election:_ meaning a block producer can be verified by any participant in the network.
 
-The randomness lookback helps turn independent ticket generation from a block one round back
-into a global ticket generation game instead. Rather than having a distinct chance of winning or losing
-for each potential fork in a given round, a miner will either win on all or lose on all
-forks descended from the block in which the ticket is sampled.
 
-This is useful as it reduces opportunities for grinding, across forks or sybil identities.
 
-However this introduces a tradeoff:
+## Leader Election
 
-- The randomness lookback means that a miner can know K rounds in advance that they will win,
-decreasing the cost of running a targeted attack (given they have local predictability).
+Expected Consensus (EC) is a consensus protocol that works by electing a miner from a weighted set in proportion to their mining power. In the case of Filecoin, participants and powers are drawn from the [The Power Table](storage_power_actor#the-power-table), where power is equivalent to storage provided over time.
 
-How is K selected?
-
-- On the one end, there is no advantage to picking K larger than finality.
-- On the other, making K smaller reduces adversarial power to grind.
-
-## Secret Leader Election
-
-Expected Consensus is a consensus protocol that works by electing a miner from a weighted set in proportion to their power. In the case of Filecoin, participants and powers are drawn from the [The Power Table](storage_power_actor#the-power-table), where power is equivalent to storage provided through time.
-
-Leader Election in Expected Consensus must be Secret, Fair and Verifiable. This is achieved through the use of randomness used to run the election. In the case of Filecoin's EC, the blockchain tracks an independent ticket chain. These tickets are used as randomness inputs for Leader Election. Every block generated references winning `ChallengeTickets` generated using a past ticket. The ticket chain is extended by the miner who generates a new block for each successful leader election.
+Leader Election in Filecoin Expected Consensus must be _Secret, Fair and Verifiable_. This is achieved through the use of randomness used to run the election. As noted earlier, there are two ways through which randomness can be used in the Filecoin EC: i) through the election proof (or ticket), and ii) through the VRF ticket chain.
 
 ### Running a leader election
 
-Now, a miner must also check whether they are eligible to mine a block in this round.
+The miner whose block has been submitted must be checked to verify that they are eligible to mine a block in this round, i.e., they have not been slashed in the previous round.
 
 Design goals here include:
 
-- Miners should be rewarded proportional to their power in the system
+- Miners should be rewarded proportionally to their power in the system.
 - The system should be able to tune how many blocks are put out per epoch on expectation (hence "expected consensus").
 
-As discussed in [Election PoSt](election_post), a miner will use the challenge ticket of an ElectionPoSt to uniformly draw a value from 0 to 1 when crafting a block.
+A miner will use the election proof/ticket to uniformly draw a value from 0 to 1 when crafting a block.
 
-The miner gets to draw one such challenge ticket per sector they have committed and must then compare the value derived from the challenge ticket against a target to determine whether they are eligible to mine. This is called finding a winning ticket.
+#### Winning a block
 
-The target is set as follows, for each sector sampled for a ticket from the miner's `ProvingSet` and the number of sectors in the set:
+**Step 1:* Check for leader election
 
-```text
-target = activePowerInSector/networkPower * EC.ExpectedLeadersPerEpoch * numSectorsMiner / numSectorsSampled
+A miner checks if they are elected for the current epoch by running `GenerateElectionProof`. 
+
+Recall that a miner is elected proportionally to their quality adjusted power at `ElectionPowerTableLookback`.
+
+A requirement for setting `ElectionPowerTableLookback` is that it must be larger than finality. This is because if `ElectionPowerTableLookback` is shorter, a malicious miner could create sybils with different VRF keys to increase the chances of election and then fork the chain to assign power to those keys.
+
+The steps of this well-known attack in Proof of Stake systems would be:
+
+1. The miner generates keys used in the VRF part of the election until they find a key that would allow them to win.
+2. The miner forks the chain and creates a miner with the winning key.
+
+This is generally a problem in Proof of Stake systems where the stake table is read from the past to make sure that no staker can do a transfer of stake to a new key that they found to be winning.
+
+**Step 2:** Generate a storage proof (WinningPoSt)
+
+An elected miner gets the randomness value through the DRAND randomness generator based on the current epoch and uses it to generate WinningPoSt.
+
+WinningPoSt uses the randomness to select a sector for which the miner must generate a proof. If the miner is not able to generate this proof within some predefined amount of time, then they will not be able to create a block. The sector is chosen from the power table `WinningPoStSectorSetLookback` epochs in the past.
+
+Similarly to `ElectionPowerTableLookback`, a requirement for setting `WinningPoStSectorSetLookback` is that it must be larger than finality. This is to enforce that a miner cannot play with the power table and change which sector is challenged for  WinningPoSt (i.e., set the challenged sector to one of their preference).
+
+If `WinningPoStSectorSetLookback` is not longer than finality, a miner could try to create forks to change their sectors allocation to get a more favourable sector to be challenged for example. A simple attack could unfold as follows:
+
+- The power table at epoch `X` shows that the attacker has sectors 1, 2, 3, 4, 5.
+- The miner decides to not store sector 5.
+- The miner wins the election at epoch `X`.
+  - Main fork: Miner is asked a WinningPoSt for sector 5 for which they won't be able to provide a proof.
+  - The miner creates a fork, terminates sector 5 in epochs before `X`.
+  - At `X`, the miner is now challenged a different sector (not 5).
+
+Note that there are variants of this attack in which the miner introduces a new sector to change which sector will be challenged.
+
+> What happens if a sector expired after `WinningPoStSectorSetLookback`?
+
+An expired sector will not be challenged during WindowPoSt (hence not penalized after its expiration). However, an edge case around the fact that `WinningPoStSectorSetLookback` is longer than finality is that due to the lookback, a miner can be challenged for an expired sector between `expirationEpoch` and `expirationEpoch + WinningPoStSectorSetLookback - 1`. Therefore, it is important that miners keep an expired sector for `WinningPoStSectorSetLookback` more epochs after expiration, or they will not be able to generate a WinningPoSt (and get the corresponding reward).
+
+Example:
+- At epoch `X`:
+  - Sector expires and miner deletes the sector.
+- At epoch `X+WinningPoStSectorSetLookback-1`:
+  - The expired sector gets selected for WinningPoSt
+  - The miner will not be able to generate the WinningPoSt and they will not win the sector.
+
+**Step 3:** Block creation and propagation
+
+If the above is successful, miners build a block and propagate it.
+
+### GenerateElectionProof
+
+`GenerateElectionProof` outputs the result of whether a miner won the block or not as well as the quality of the block mined.
+
+The "Block Quality" is an integer that is used for weight and block reward calculations. For example a block with quality "2" is equivalent as two blocks of quality "1".
+
+#### High level algorithm
+
+- Get the percentage of power at block `ElectionPowerTableLookback`
+  - Get the power of the miner at block `ElectionPowerTableLookback`
+  - Get the total network power at block `ElectionPowerTableLookback`
+- Get randomness for the current epoch using `GetRandomness`.
+- Generate a VRF and compute its hash
+  - The storage miner's `workerKey` is given as input in the VRF process
+- Compute block quality: The smaller the hash is, the higher the block quality will be
+  - Compute the probability distribution of winning `k` blocks (i.e. Poisson distribution see below for details)
+  - Let `h_n` be the normalised VRF, i.e. `h_n = vrfout/2^256`
+  - The probability of winning one block is `1-P[X=0]`, thus if `h_n` is less than `1-P[X=0]`, the miner wins at least one block.
+  - Similarly if `h_n` is less than `1-P[X=0]-P[X=1]` we have at least two blocks and so on.
+
+#### Explanations - Poisson Sortition
+
+Filecoin is building on the principle that a miner possessing X% of network power should win as many times as X miners with 1% of network power in the election algorithm.
+
+This is modelled via a Binomial distribution with parameter`p=ExpectedLeaderPerRound/TotalPower` and `n= MinerPower`.
+
+For ease of implementation, we use the the Poisson distribution with parameter `lambda = MinerPower*ExepectedLeader` to approximate this Binomial distribution.
+
+The table below shows results of the comparison of the probability mass functions for the Binomial and Poisson distributions. For these computations the following have been assumed: `TotalPower =10000`, `minerPower = 3300` and `ExpectedLeaderPerEpoch = 5`.
+
+k | Binomial | Poisson
+|---|---|---|
+0 | 0.19197 | 0.19205
+1 | 0.31691 | 0.31688
+2 | 0.26150 | 0.26143
+3 | 0.14381 | 0.14379
+4 | 0.05930 | 0.05931
+5 | 0.01955 | 0.01957
+6 | 0.00537 | 0.00538
+7 | 0.00126 | 0.00127
+8 | 0.00026 | 0.00026
+9 | 0.00005 | 0.00005
+
+
+**Justification for the need of _Block Quality_**
+
+It should not be possible for a miner to split their power into multiple identities and have more chances of winning more blocks than keeping their power under one identity. In particular, Strategy 2 below should not be possible to achieve.
+
+- Strategy 1: A miner with X% can run a single election and win a single block.
+- Strategy 2: The miner splits its power in multiple sybil miners (with the sum still equal to X%), running multiple elections to win more blocks.
+
+Block quality guarantees that a lucky single block will earn the same reward as the reward that the miner would earn had they split their power into multiple sybils.
+
+**Alternative Options for the Distribution/Sortition**
+
+Bernouli, Binomial and Poisson distributions have been considered for the _WinCount_ of a miner with power `p` out of a total network power of `N`. There are the following options:
+
+- Option 1: WinCount(p,N) ~ Bernouli(pE/N)
+- Option 2: WinCount(p,N) ~ Binomial(E, p/N)
+- Option 3: WinCount(p,N) ~ Binomial(p, E/N)
+- Option 4: WinCount(p,N) ~ Binomial(p/M, ME/N)
+- Option 5: WinCount(p,N) ~ Poisson(pE/N)
+
+Note that in Options 2-5 the expectation of the win-count grows linearly with the miner's power `p`. That is,  𝔼[WinCount(p,N)] = pE/N. For Option 1 this property does not hold when p/N > 1/E.
+
+Furthermore, in Options 1, 3 and 5 the _WinCount distribution is invariant to the number of Sybils in the system. In particular WinCount(p,N)=2WinCount(p/2,N), which is a desirable property.
+
+In Option 5 (the one used in Filecoin Leader Election), the ticket targets for each _WinCount k that range from 1 to mE (with m=2 or 3) shall approximate the upside-down CDF of a Poisson distribution with rate λ=pE/N, or explicitly, 2²⁵⁶(1-exp(-pE/N)∑ᵏ⁻¹ᵢ₌₀(pE/N)ⁱ/(i!)).
+
+**Rationale for the Poisson Sortition choice**
+
+- Option 1 - Bernouli(pE/N): this option is easy to implement, but comes with a drawback: if the miner's power exceeds 1/E, the miner's WinCount is always 1, but never higher than 1.
+- Option 2 - Binomial(E, p/N): the expectation of WinCount stays the same irrespectively of whether the miner splits their power into more than one Sybil nodes, but the variance increases if they choose to Sybil. Risk-seeking miners will prefer to Sybil, while risk-averse miners will prefer to pool, none of which is a behaviour the protocol should encourage. This option is not computationally-expensive as it would involve calculation of factorials and fixed-point multiplications (or small integer exponents) only.
+- Option 3 - Binomial(p, E/N): this option is computationally inefficient. It involves very large integer exponents.
+- Option 4 - Binomial(p/M, ME/N): the complexity of this option depends on the value of M. A small M results in high computational cost, similarly to Option 3. A large M, on the other hand, leads to a situation similar to that of Option 2, where a risk-seeking miner is incentivized to Sybil. Clearly none of these are desirable properties.
+- Option 5 - Poisson(pE/N): the chosen option presents the implementation difficulty of having to hard-code the co-efficients (see below), but overcomes all of the problems of the previous options. Furthermore, the expensive part, that is calculating exp(λ), or exp(-pE/N) has to be calculated only once.
+
+**Coefficient Approximation**
+
+We have used the Horner rule with 128-bit fixed-point coefficients in decimal, in order to approximate the co-efficients of `exp(-x)`. The coefficients are given below:
+
+```
+(x * (x * (x * (x * (x * (x * (x * (
+-648770010757830093818553637600
+*2^(-128)) +
+67469480939593786226847644286976
+*2^(-128)) +
+-3197587544499098424029388939001856
+*2^(-128)) +
+89244641121992890118377641805348864
+*2^(-128)) +
+-1579656163641440567800982336819953664
+*2^(-128)) +
+17685496037279256458459817590917169152
+*2^(-128)) +
+-115682590513835356866803355398940131328
+*2^(-128))
++ 1) /
+(x * (x * (x * (x * (x * (x * (x * (x * (x * (x * (x * (x * (x * (
+1225524182432722209606361
+*2^(-128)) +
+114095592300906098243859450
+*2^(-128)) +
+5665570424063336070530214243
+*2^(-128)) +
+194450132448609991765137938448
+*2^(-128)) +
+5068267641632683791026134915072
+*2^(-128)) +
+104716890604972796896895427629056
+*2^(-128)) +
+1748338658439454459487681798864896
+*2^(-128)) +
+23704654329841312470660182937960448
+*2^(-128)) +
+259380097567996910282699886670381056
+*2^(-128)) +
+2250336698853390384720606936038375424
+*2^(-128)) +
+14978272436876548034486263159246028800
+*2^(-128)) +
+72144088983913131323343765784380833792
+*2^(-128)) +
+224599776407103106596571252037123047424
+*2^(-128))
++ 1)
 ```
 
-The target ensures that the miner can express the power across all of their sectors through the tickets they have sampled. Specifically, on expectation, checking `numSectorsSampled` (with `numSectorsSampled = ceil(len(provingSet) * EPoStSampleRate)`) challenge tickets in every epoch, a miner will find `minerPower/networkPower * EC.ExpectedLeadersPerEpoch` winning tickets per epoch on expectation. Note that while the sectorPower may differ based on the challenged sector, i.e. in any given epoch a miner may have an advantage (if picking sectors with more than the average across all their sectors) or a disadvantage (conversely) in their election; but over multiple epochs, on expectation the election will be fair.
+#### Implementation Guidelines
 
-```text
-We elaborate on the above claim:
+- The `ElectionProof` struct in block header has two fields:
+  - `vrf.Proof` the output of the VRF
+  - `WinCount` that corresponds to the result of the Poisson Sortition.
+- `WinCount` needs to be `> 0` for winning blocks.
+- `WinCount` is included in the tipset weight function. The sum of `WinCount`s of a tipset replaces the size of tipset factor in the weight function.
+- `WinCount` is passed to Reward actor to increase the reward for blocks winning multiple times.
 
-We want the miner's expected wins over time to be equal to w = minerPower/networkPower * EC.ExpectedLeadersPerEpoch
+```go
+GenerateElectionProof(epoch) {
+  electionProofInput := GetRandomness(DomainSeparationTag_ElectionProofProduction, epoch, CBOR_Serialize(miner.address))
+  vrfResult := miner.VRFSecretKey.Generate(electioinProofInput)
 
-Take P to be the average miner power over the N sectors in their ProvingSet.
-We have P = SUM_{i=0}^N P_i / N
+  if GetWinCount(vrfResult.Digest,minerID,epoch)>0 {
+    return vrfResult.Proof, GetWinCount(vrfResult.Digest,minerID,epoch)
+  }
+  return nil
+}
 
-The miner's likelihood of winning an election in any epoch is, for C tickets randomly drawn
-W = C * target = C * P_i/networkPower * EC.ExpectedLeadersPerEpoch * N/C = N * P_i/networkPower * EC.ExpectedLeadersPerEpoch
+GetWinCount(proofDigest, minerID,epoch) {
+  // for SHA256, more generally it is 2^len(H)
+    const maxDigestSize = 2^256
+    minerPower = GetminerPower(minerID, epoch-PowerTableLookback)
+    TotalPower = GetTotalPower(epoch-PowerTableLookback)
+    if minerPower = 0 {
+        return 0
+    }
+    lambda = minerPower/totalPower*ExpectedLeaderPerEpoch
+    h = hash(proofDigest)/maxDigestSize
+    rhs = 1 - PoissPmf(lambda, 0)
 
-with N * P_i ~= minerPower on expectation over enough epochs. That is to say: W = minerPower/networkPower * EC.ExpectedLeadersPerEpoch as wanted.
+    WinCount = 0
+    for h < rhs {
+      WinCount++
+      rhs -= PoissPmf(lambda, WinCount)
+    }
+    return WinCount
+}
 ```
 
-We show this below, removing division for ease of implementation:
+### VerifyLeaderElection
 
-```text
-const maxChallengeTicketSize = 2^len(H)
+In order to verify that the leader election proof in a block is correct, miners perform the following checks:
 
-def TicketIsWinner(challengeTicket):
-    // Check that `ChallengeTicket < Target`
-    return challengeTicket * networkPower * numSectorsSampled < activePowerInSector * EC.ExpectedLeadersPerEpoch * maxChallengeTicketSize * numSectorsMiner
-```
+- Verify that the randomness is correct by checking `GetRandomness(epoch)`
+- Use this randomness to verify the VRF correctness `Verify_VRF(vrfout,beacon,public_key)`
+- Verify ElectionProof.WinCount > 0 by checking `GetWinCount(vrfout, miner,epoch)`
 
-If the miner finds any winning ticket in this round, it can use it, along with a new randomness ticket to generate and publish a new block. Otherwise, it waits to hear of another block generated in this round.
-
-We also use the [Verifiable Random Function](vrf) to draw randomness as part of crafting the Challenge Tickets in order to ensure leader election is secret (a miner cannot be known to win until they publish their ticket on the chain).
-
-It is important to note that every block contains three artifacts: one, a ticket derived from last block's ticket to extend the ticket-chain, two, a challenge ticket array PoSt process run in this epoch, and three a PoStProof to prove each ChallengeTicket was derived correctly.
-
-### Election Validation
-
-In order to determine that the mined block was generated by an eligible miner, one must check its `ChallengeTickets`' validity and that they were generated appropriately by the PoSt generator. Thereafter, for each ticket the miner must check that it is a winning challenge ticket, per the above definition.
 
 ## Chain Selection
 
-Just as there can be 0 miners win in a round, multiple miners can be elected in a given round. This in turn means multiple blocks can be created in a round, as seen above. In order to avoid wasting valid work done by miners, EC makes use of all valid blocks generated in a round.
+Just as there can be zero winning miners in a round, there can equally be multiple miners elected in a given round. This in turn means multiple blocks can be created in a round, as seen above. In order to avoid wasting valid work done by miners, EC makes use of all valid blocks generated in a round.
 
 ### Chain Weighting
 
-It is possible for forks to emerge naturally in Expected Consensus. EC relies on weighted chains in order to quickly converge on 'one true chain', with every block adding to the chain's weight. This means the heaviest chain should reflect the most amount of work performed, or in Filecoin's case, the most storage provided.
+It is possible for forks to emerge naturally in Expected Consensus. EC relies on weighted chains in order to quickly converge on 'one true chain', with every block adding to the chain's weight. This means the heaviest chain should reflect the most amount of work performed, or in Filecoin's case, the biggest amount of committed storage.
 
 In short, the weight at each block is equal to its `ParentWeight` plus that block's delta weight. Details of Filecoin's chain weighting function [are included here](https://observablehq.com/d/3812cd65c054082d).
 
 Delta weight is a term composed of a few elements:
 
 - wPowerFactor: which adds weight to the chain proportional to the total power backing the chain, i.e. accounted for in the chain's power table.
-- wBlocksFactor: which adds weight to the chain proportional to the number of tickets mined in a given epoch. It rewards miner cooperation (which will yield more blocks per round on expectation).
+- wBlocksFactor: which adds weight to the chain proportional to the number of tickets mined in a given epoch. It rewards miner cooperation (which, on expectation, will yield more blocks per round).
 
 The weight should be calculated using big integer arithmetic with order of operations defined above. We use brackets instead of parentheses below for legibility. We have:
 
@@ -146,9 +321,9 @@ w[r+1] = w[r] + (wPowerFactor[r+1] + wBlocksFactor[r+1]) * 2^8
 
 For a given tipset `ts` in round `r+1`, we define:
 
-- `wPowerFactor[r+1]  = wFunction(totalPowerAtTipset(ts))`
-- wBlocksFactor[r+1] =  `wPowerFactor[r+1] * wRatio * t / e`
-  - with `t = |ticketsInTipset(ts)|`
+- `wPowerFactor[r+1] = wFunction(totalPowerAtTipset(ts))`
+- `wBlocksFactor[r+1] = wPowerFactor[r+1] * wRatio * t / e`
+  - with `t = sum_{b In Tipset}(b.WinCount)`
   - `e = expected number of tickets per round in the protocol`
   - and `wRatio in ]0, 1[`
 Thus, for stability of weight across implementations, we take:
@@ -160,7 +335,7 @@ We get:
 w[r+1] = w[r] + wFunction(totalPowerAtTipset(ts)) * 2^8 + (wFunction(totalPowerAtTipset(ts)) * len(ts.tickets) * wRatio_num * 2^8) / (e * wRatio_den)
 ```
 
-Using the 2^8 here to prevent precision loss ahead of the division in the wBlocksFactor.
+Using the 2^8 here to prevent precision loss ahead of the division in the `wBlocksFactor`.
 
 The exact value for these parameters remain to be determined, but for testing purposes, you may use:
 
@@ -181,15 +356,15 @@ potentially long chain scans would be required to compute a given block's weight
 
 ### Selecting between Tipsets with equal weight
 
-When selecting between Tipsets of equal weight, a miner chooses the one with the smallest final ticket.
+When selecting between Tipsets of equal weight, a miner chooses the one with the smallest final VRF output.
 
-In the case where two Tipsets of equal weight have the same min ticket, the miner will compare the next smallest ticket (and select the Tipset with the next smaller ticket). This continues until one Tipset is selected.
+In the case where two Tipsets of equal weight have the same minimum VRF output, the miner will compare the next smallest output (and select the Tipset with the next smaller output). This continues until one Tipset is selected.
 
-The above case may happen in situations under certain block propagation conditions. Assume three blocks B, C, and D have been mined (by miners 1, 2, and 3 respectively) off of block A, with minTicket(B) < minTicket(C) < minTicket(D).
+The above case may happen in situations under certain block propagation conditions. Assume three blocks B, C, and D have been mined (by miners 1, 2, and 3 respectively) off of block A, with minVRF(B) < minVRF(C) < minVRF(D).
 
-Miner 1 outputs their block B and shuts down. Miners 2 and 3 both receive B but not each others' blocks. We have miner 2 mining a Tipset made of B and C and miner 3 mining a Tipset made of B and D. If both succesfully mine blocks now, other miners in the network will receive new blocks built off of Tipsets with equal weight and the same smallest ticket (that of block B). They should select the block mined atop [B, C] since minTicket(C) < minTicket(D).
+Miner 1 outputs their block B and shuts down. Miners 2 and 3 both receive B but not each others' blocks. We have miner 2 mining a Tipset made of B and C and miner 3 mining a Tipset made of B and D. If both succesfully mine blocks now, other miners in the network will receive new blocks built off of Tipsets with equal weight and the same smallest VRF output (that of block B). In this case, miners 2 and 3 should select the block mined atop [B, C] since minVRF(C) < minVRF(D).
 
-The probability that two Tipsets with different blocks would have all the same tickets can be considered negligible: this would amount to finding a collision between two 256-bit (or more) collision-resistant hashes.
+The probability that two Tipsets with different blocks would have all the same VRF output can be considered negligible: this would amount to finding a collision between two 256-bit (or more) collision-resistant hashes.
 
 ## Finality in EC
 
@@ -227,6 +402,6 @@ A single consensus fault results into:
 
 ### Detection and Reporting
 
-A node that detects and report a consensus fault is called "slasher", any user in Filecoin can be a slasher. They can report consensus faults by calling the `ReportConsensusFault` on the `StorageMinerActor` of the faulty miner. The slasher is rewarded with a portion of the offending miner's [Pledge Collateral](storage_power_actor#pledge-collateral) for notifying the network of the consensu fault.
+A node that detects and report a consensus fault is called "slasher", any user in Filecoin can be a slasher. They can report consensus faults by calling the `ReportConsensusFault` on the `StorageMinerActor` of the faulty miner. The slasher is rewarded with a portion of the offending miner's [Pledge Collateral](storage_power_actor#pledge-collateral) for notifying the network of the consensus fault.
 
-The reward give to the slasher is a function of some initial share (`SLASHER_INITIAL_SHARE`) and growth rate (`SLASHER_SHARE_GROWTH_RATE`) and it has a maximum `maxReporterShare`. Slasher's share increases exponentially as epoch elapses since the block when the fault is committed (see `RewardForConsensusSlashReport`). Only the first slasher gets their share of the pledge collateral and the remaining pledge collateral is burned. The longer a slasher waits, the higher the likelihood that the slashed collateral will be claimed by another slasher.
+The reward given to the slasher is a function of some initial share (`SLASHER_INITIAL_SHARE`) and growth rate (`SLASHER_SHARE_GROWTH_RATE`) and it has a maximum `maxReporterShare`. Slasher's share increases exponentially as epoch elapses since the block when the fault is committed (see `RewardForConsensusSlashReport`). Only the first slasher gets their share of the pledge collateral and the remaining pledge collateral is burned. The longer a slasher waits, the higher the likelihood that the slashed collateral will be claimed by another slasher.

--- a/content/algorithms/expected_consensus/_index.md
+++ b/content/algorithms/expected_consensus/_index.md
@@ -12,7 +12,7 @@ dashboardTests: 0
 
 ## Algorithm
 
-Expected Consensus (EC) is a probabilistic Byzantine fault-tolerant consensus protocol. At a high level, it operates by running a leader election on every round during which, on expectation, one participant may be eligible to submit a block. EC guarantees that this winner will be anonymous until they reveal themselves by submitting a proof of their election. The miner can submit a proof per round and will be rewarded proportionally to its power. **Each miner will submit a proof for election (Leader Election step 1) and a proof of storage (winning PoSt step 2).** All valid blocks submitted in a given round form a `Tipset`. Every block in a Tipset adds weight to its chain. The 'best' chain is the one with the highest weight, which is to say that the fork choice rule is to choose the heaviest known chain. For more details on how to select the heaviest chain, see [Chain Selection](expected_consensus#chain-selection).
+Expected Consensus (EC) is a probabilistic Byzantine fault-tolerant consensus protocol. At a high level, it operates by running a leader election on every round during which, on expectation, one participant may be eligible to submit a block. EC guarantees that this winner will be anonymous until they reveal themselves by submitting a proof of their election. The miner can submit a proof per round and will be rewarded proportionally to its power. **Each miner will submit a proof for election (Leader Election - Step 1) and a proof of storage (Winning PoSt - Step 2).** All valid blocks submitted in a given round form a `Tipset`. Every block in a Tipset adds weight to its chain. The 'best' chain is the one with the highest weight, which is to say that the fork choice rule is to choose the heaviest known chain. For more details on how to select the heaviest chain, see [Chain Selection](expected_consensus#chain-selection).
 
 Every block is associated with a randomness value. This randomness value is generated from [DRAND](https://drand.love), an unbiasable randomness generator, through a beacon. When the miner wants to publish a new block, they invoke the `getRandomness` function providing the chain height (i.e., epoch) as input. The randomness value is returned through the DRAND beacon and included in the block. For the details of DRAND and its implementation, please consult the project's [documentation](https://drand.love/docs/overview/) and [specification](https://drand.love/docs/specification/).
 
@@ -71,7 +71,7 @@ A miner will use the election proof/ticket to uniformly draw a value from 0 to 1
 
 #### Winning a block
 
-**Step 1:* Check for leader election
+**Step 1:** Check for leader election
 
 A miner checks if they are elected for the current epoch by running `GenerateElectionProof`. 
 


### PR DESCRIPTION
This PR is applying all the latest changes in the Expected Consensus, Leader Election and the rationale behind Poisson Sortition of `WinCount`. It removes all mention of Election PoSt which was very out-of-date.