### PR TITLE
Adding Lotus repo to config.toml

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -106,3 +106,12 @@ enableGitInfo = true
     [[module.imports.mounts]]
     source = "actors"
     target = "content/modules/actors"
+    
+[module]
+  [[module.imports]]
+    path = "github.com/alex-shpak/hugo-book"
+  [[module.imports]]
+    path = "github.com/filecoin-project/"
+    [[module.imports.mounts]]
+    source = "lotus"
+    target = "content/modules/lotus"

--- a/config.toml
+++ b/config.toml
@@ -106,12 +106,8 @@ enableGitInfo = true
     [[module.imports.mounts]]
     source = "actors"
     target = "content/modules/actors"
-    
-[module]
   [[module.imports]]
-    path = "github.com/alex-shpak/hugo-book"
-  [[module.imports]]
-    path = "github.com/filecoin-project/"
+    path = "github.com/filecoin-project/lostus"
     [[module.imports.mounts]]
-    source = "lotus"
+    source = "."
     target = "content/modules/lotus"


### PR DESCRIPTION
Adding Lotus repo to config.toml, so that we link to Lotus code directly from the content of the spec and have it up-to-date.