### PR TITLE
Adding go-fil-markets repo to config.toml

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -106,3 +106,12 @@ enableGitInfo = true
     [[module.imports.mounts]]
     source = "actors"
     target = "content/modules/actors"
+    
+[module]
+  [[module.imports]]
+    path = "github.com/alex-shpak/hugo-book"
+  [[module.imports]]
+    path = "github.com/filecoin-project/"
+    [[module.imports.mounts]]
+    source = "go-fil-markets"
+    target = "content/modules/go-fil-markets"    


### PR DESCRIPTION
Adding `go-fil-markets` repo to config.toml, so that we link to markets code directly from the content of the spec and keep it up-to-date.