### PR TITLE
chore: dashboard ui improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,10 +159,12 @@ bookhidden: true
 dashboardWeight: 2
 <!-- This is used in the dashboard to describe the state of the page content options are "missing", "incorrect", "wip", "reliable", "stable" or "n/a" -->
 dashboardState: stable
-<!-- This is used in the dashboard to describe if the theory of the page has been audited, options are "missing", "wip", "stable" or "n/a" -->
+<!-- This is used in the dashboard to describe if the theory of the page has been audited, options are "missing", "wip", "done" or "n/a" -->
 dashboardAudit: wip
 <!-- When dashboardAudit is stable we should have a report url -->
 dashboardAuditURL: https://url.to.the.report
+<!-- The date that the report at dashboardAuditURL was completed -->
+dashboardAuditDate: "2020-08-01"
 <!-- This is used in the dashboard to describe if the page content has compliance tests, options are 0 or numbers of tests -->
 dashboardTests: 0
 ```

--- a/assets/_colors.scss
+++ b/assets/_colors.scss
@@ -1,17 +1,19 @@
 // Colors
-.text-missing {color: #ff0010;}
-.text-incorrect {color: #ff6f00;}
-.text-wip {color: #ffef00;}
-.text-reliable {color: #0090ff;}
-.text-stable {color: #90ff00;}
+
+
+.text-missing {color: $red;}
+.text-incorrect {color: $orange;}
+.text-wip {color: $yellow;}
+.text-reliable {color: $blue;}
+.text-stable {color: $green;}
 .text-transparent { color: transparent;}
 .text-black { color: black !important;}
 
 .bg-na { background-color: #6c8293;}
-.bg-missing { background-color: #ff0010; }
-.bg-incorrect {background-color: #ff6f00;}
-.bg-wip {background-color: #ffef00;}
-.bg-reliable {background-color: #0090ff; }
-.bg-stable {background-color: #90ff00;}
+.bg-missing { background-color: $red; }
+.bg-incorrect {background-color: $orange;}
+.bg-wip {background-color: $yellow;}
+.bg-reliable {background-color: $blue; }
+.bg-stable {background-color: $green;}
 .bg-transparent { background-color: transparent;}
 .bg-black { background-color: black;}

--- a/assets/_colors.scss
+++ b/assets/_colors.scss
@@ -4,8 +4,8 @@
 .text-missing {color: $red;}
 .text-incorrect {color: $orange;}
 .text-wip {color: $yellow;}
-.text-reliable {color: $blue;}
-.text-stable {color: $green;}
+.text-reliable {color: $green;}
+.text-stable {color: $blue;}
 .text-transparent { color: transparent;}
 .text-black { color: black !important;}
 
@@ -13,7 +13,12 @@
 .bg-missing { background-color: $red; }
 .bg-incorrect {background-color: $orange;}
 .bg-wip {background-color: $yellow;}
-.bg-reliable {background-color: $blue; }
-.bg-stable {background-color: $green;}
+.bg-done {background-color: $green; }
+.bg-reliable {background-color: $green; }
+.bg-stable { background-color: $blue;
+  a {
+    color: black;
+  }
+}
 .bg-transparent { background-color: transparent;}
 .bg-black { background-color: black;}

--- a/assets/_variables.scss
+++ b/assets/_variables.scss
@@ -1,6 +1,10 @@
 /* You can override SASS variables here. */
 
-$book-search-results-bg: #f8f9fa !default;
+$red: #ff0010;
+$orange: #ff6f00;
+$yellow: #ffef00;
+$green: #90ff00;
+$blue: #0090ff;
 
-$blue: rgb(14,120,254);
+$book-search-results-bg: #f8f9fa !default;
 $color-link: $blue;

--- a/assets/js/content-model.js
+++ b/assets/js/content-model.js
@@ -22,6 +22,7 @@ function buildTocModel (contentSelector) {
         dashboardWeight: el.dataset.dashboardWeight,
         dashboardAudit: el.dataset.dashboardAudit,
         dashboardAuditURL: el.dataset.dashboardAuditUrl,
+        dashboardAuditDate: el.dataset.dashboardAuditDate,
         dashboardState: el.dataset.dashboardState,
         children: []
       }

--- a/assets/js/dashboard-spec.js
+++ b/assets/js/dashboard-spec.js
@@ -26,6 +26,7 @@ const humanize = (input) => {
 
 const stateToNumber = (s) => {
   switch (s) {
+    case 'done':
     case 'stable':
       return 1
     case 'reliable':
@@ -59,7 +60,11 @@ function buildDashboard(selector, model) {
       <td class="Dashboard-section">${i.number} <a href="#${i.id}">${i.text}</a></td>
       <td>${i.dashboardWeight}</td>
       <td data-sort="${stateToNumber(i.dashboardState)}" class="text-black bg-na bg-${i.dashboardState}">${humanize(i.dashboardState)}</td>
-      <td data-sort="${stateToNumber(i.dashboardAudit)}" class="text- bg-na bg-${i.dashboardAudit}">${humanize(i.dashboardAudit)} ${i.dashboardAuditURL ? html`<a href="${i.dashboardAuditURL}" title="Audit Report" target="_blank" rel="noopener noreferrer"><i class="gg-external gg-s-half"></i></a>`: ''} </td>
+      <td data-sort="${stateToNumber(i.dashboardAudit)}" class="text-black bg-na bg-${i.dashboardAudit}">
+        ${i.dashboardAuditURL
+          ? html`<a href="${i.dashboardAuditURL}" title="Read the audit report" target="_blank" rel="noopener noreferrer" class="text-black">${i.dashboardAuditDate}<i class="gg-external gg-s-half"></i></a>`
+          : humanize(i.dashboardAudit) } 
+      </td>
     </tr>
     `: '')}
   </tbody>

--- a/content-pt/intro/_index.md
+++ b/content-pt/intro/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Introduction
 weight: 1
-dashboardState: incomplete
+dashboardState: wip
 bookCollapseSection: true
 ---
 

--- a/content/algorithms/crypto/signatures.md
+++ b/content/algorithms/crypto/signatures.md
@@ -3,7 +3,7 @@ title: "Signatures"
 weight: 1
 dashboardWeight: 2
 dashboardState: wip
-dashboardAudit: stable
+dashboardAudit: done
 dashboardTests: 0
 ---
 

--- a/content/algorithms/gossip_sub.md
+++ b/content/algorithms/gossip_sub.md
@@ -3,8 +3,9 @@ title: "GossipSub"
 weight: 6
 dashboardWeight: 1.5
 dashboardState: wip
-dashboardAudit: stable
 dashboardTests: 0
+dashboardAudit: done
+dashboardAuditDate: '2020-06-03'
 dashboardAuditURL: https://gateway.ipfs.io/ipfs/QmWR376YyuyLewZDzaTHXGZr7quL5LB13HRFnNdSJ3CyXu/Least%20Authority%20-%20Gossipsub%20v1.1%20Final%20Audit%20Report%20%28v2%29.pdf
 ---
 

--- a/content/algorithms/post/proof_of_spacetime_parameters.org
+++ b/content/algorithms/post/proof_of_spacetime_parameters.org
@@ -3,7 +3,7 @@
 #+HUGO_BASE_DIR: ../../
 #+dashboardWeight: 2
 #+dashboardState: incorrect
-#+dashboardAudit: 0
+#+dashboardAudit: n/a
 #+dashboardTests: 0
 
 * Proof of Spacetime Paramerters

--- a/content/algorithms/sdr/_index.md
+++ b/content/algorithms/sdr/_index.md
@@ -8,7 +8,7 @@ math-mode: true
 
 dashboardWeight: 2
 dashboardState: stable
-dashboardAudit: stable
+dashboardAudit: done
 dashboardTests: 0
 ---
 

--- a/content/algorithms/sdr/notation.md
+++ b/content/algorithms/sdr/notation.md
@@ -6,7 +6,7 @@ description: "Notation, Constants, and Types for Stacked DRG PoRep"
 
 dashboardWeight: 2
 dashboardState: stable
-dashboardAudit: stable
+dashboardAudit: done
 dashboardTests: 0
 ---
 

--- a/content/appendix/_index.md
+++ b/content/appendix/_index.md
@@ -2,8 +2,8 @@
 title: Appendix
 weight: 7
 dashboardWeight: 0.2
-dashboardState: incomplete
-dashboardAudit: 0
+dashboardState: wip
+dashboardAudit: n/a
 ---
 
 # Appendix

--- a/content/appendix/address.md
+++ b/content/appendix/address.md
@@ -2,8 +2,8 @@
 title: "Address"
 weight: 2
 dashboardWeight: 0.2
-dashboardState: incomplete
-dashboardAudit: 0
+dashboardState: wip
+dashboardAudit: n/a
 ---
 
 # Filecoin Address

--- a/content/appendix/network_params.md
+++ b/content/appendix/network_params.md
@@ -2,8 +2,8 @@
 title: Filecoin Parameters
 weight: 3
 dashboardWeight: 0.2
-dashboardState: incomplete
-dashboardAudit: 0
+dashboardState: wip
+dashboardAudit: n/a
 ---
 
 # Filecoin Parameters

--- a/content/appendix/sharray.md
+++ b/content/appendix/sharray.md
@@ -2,8 +2,8 @@
 title: "Sharded IPLD Array"
 weight: 1
 dashboardWeight: 0.2
-dashboardState: incomplete
-dashboardAudit: 0
+dashboardState: wip
+dashboardAudit: n/a
 ---
 
 # Sharded IPLD Array

--- a/content/glossary/_index.md
+++ b/content/glossary/_index.md
@@ -2,8 +2,8 @@
 title: "Glossary"
 weight: 6
 dashboardWeight: 0.2
-dashboardState: incomplete
-dashboardAudit: 0
+dashboardState: wip
+dashboardAudit: n/a
 ---
 
 # Glossary

--- a/content/implementations/forest.md
+++ b/content/implementations/forest.md
@@ -1,8 +1,6 @@
 ---
 title: Forest 
 weight: 3
-implAudit: 0
-implSpecCompliance: 0
 implRepos:
  - { lang: rust, repo: https://github.com/ChainSafe/forest }
 ---

--- a/content/implementations/fuhon.md
+++ b/content/implementations/fuhon.md
@@ -1,8 +1,6 @@
 ---
 title: Fuhon
 weight: 4
-implAudit: 0
-implSpecCompliance: 0
 implRepos: 
   - { lang: c++, repo: https://github.com/filecoin-project/cpp-filecoin }
 ---

--- a/content/implementations/go-filecoin.md
+++ b/content/implementations/go-filecoin.md
@@ -1,8 +1,6 @@
 ---
 title: go-filecoin
 weight: 2
-implAudit: 0
-implSpecCompliance: 0
 implRepos: 
   - { lang: go, repo: https://github.com/filecoin-project/go-filecoin }
 ---

--- a/content/implementations/lotus.md
+++ b/content/implementations/lotus.md
@@ -6,9 +6,6 @@ implAudit: 0
 implSpecCompliance: 0
 implRepos: 
   - { lang: go,   repo: https://github.com/filecoin-project/lotus }
-  - { lang: go,   repo: https://github.com/filecoin-project/storage-fsm }
-  - { lang: go,   repo: https://github.com/filecoin-project/sector-storage }
-  - { lang: go,   repo: https://github.com/filecoin-project/specs-storage }
   - { lang: go,   repo: https://github.com/filecoin-project/go-fil-markets }
   - { lang: go,   repo: https://github.com/filecoin-project/specs-actors }
   - { lang: rust, repo: https://github.com/filecoin-project/rust-fil-proofs }

--- a/content/implementations/lotus.md
+++ b/content/implementations/lotus.md
@@ -1,13 +1,10 @@
 ---
 title: Lotus
 weight: 1
-
-implAudit: 0
-implSpecCompliance: 0
 implRepos: 
-  - { lang: go,   repo: https://github.com/filecoin-project/lotus }
-  - { lang: go,   repo: https://github.com/filecoin-project/go-fil-markets }
-  - { lang: go,   repo: https://github.com/filecoin-project/specs-actors }
+  - { lang: go,   repo: https://github.com/filecoin-project/lotus, auditState: done, auditDate: '2020-07-31' }
+  - { lang: go,   repo: https://github.com/filecoin-project/go-fil-markets, auditState: done, auditDate: '2020-07-31' }
+  - { lang: go,   repo: https://github.com/filecoin-project/specs-actors, auditState: done, auditDate: '2020-07-31' }
   - { lang: rust, repo: https://github.com/filecoin-project/rust-fil-proofs }
 ---
 

--- a/content/libraries/drand/_index.md
+++ b/content/libraries/drand/_index.md
@@ -3,9 +3,10 @@ title: drand - Distributed Randomness
 weight: 1
 dashboardWeight: 2
 dashboardState: stable
-dashboardAudit: stable
 dashboardTests: 0
+dashboardAudit: done
 dashboardAuditURL: https://drive.google.com/file/d/1fCy1ynO78gJLCNbqBruzHx7bh72Tu-q2/view
+dashboardAuditDate: '2020-08-09'
 ---
 
 # DRAND

--- a/content/libraries/filcrypto/_index.md
+++ b/content/libraries/filcrypto/_index.md
@@ -5,7 +5,7 @@ weight: 1
 bookCollapseSection: true
 dashboardWeight: 1.5
 dashboardState: wip
-dashboardAudit: 0
+dashboardAudit: n/a
 dashboardTests: 0
 ---
 

--- a/content/libraries/filcrypto/filproofs/_index.md
+++ b/content/libraries/filcrypto/filproofs/_index.md
@@ -3,8 +3,9 @@ title: FIL Proofs
 description: Filecoin Storage Proofs
 dashboardWeight: 1.5
 dashboardState: incorrect
-dashboardAudit: stable
 dashboardTests: 0
+dashboardAudit: done
+dashboardAuditDate: '2020-07-28'
 dashboardAuditURL: https://github.com/filecoin-project/rust-fil-proofs/blob/master/audits/Sigma-Prime-Protocol-Labs-Filecoin-Proofs-Security-Review-v2.1.pdf
 
 ---

--- a/content/libraries/ipfs/_index.md
+++ b/content/libraries/ipfs/_index.md
@@ -4,6 +4,6 @@ description: IPFS - InterPlanetary File System
 weight: 5
 dashboardWeight: 1
 dashboardState: wip
-dashboardAudit: stable
+dashboardAudit: done
 dashboardTests: 0
 ---

--- a/content/libraries/libp2p/_index.md
+++ b/content/libraries/libp2p/_index.md
@@ -5,8 +5,9 @@ weight: 4
 bookCollapseSection: true
 dashboardWeight: 1
 dashboardState: missing
-dashboardAudit: stable
 dashboardTests: 0
+dashboardAudit: done
+dashboardAuditDate: '2020-10-10'
 dashboardAuditURL: https://github.com/protocol/libp2p-vulnerabilities/blob/master/DRAFT_NCC_Group_ProtocolLabs_1903ProtocolLabsLibp2p_Report_2019-10-10_v1.1.pdf 
 ---
 

--- a/content/libraries/libp2p/gossipsub.md
+++ b/content/libraries/libp2p/gossipsub.md
@@ -3,8 +3,9 @@ title: Gossipsub
 description: Gossipsub for broadcasts
 dashboardWeight: 1
 dashboardState: missing
-dashboardAudit: stable
 dashboardTests: 0
+dashboardAudit: done
+dashboardAuditDate: '2020-06-03'
 dashboardAuditURL: https://gateway.ipfs.io/ipfs/QmWR376YyuyLewZDzaTHXGZr7quL5LB13HRFnNdSJ3CyXu/Least%20Authority%20-%20Gossipsub%20v1.1%20Final%20Audit%20Report%20%28v2%29.pdf
 ---
 

--- a/content/listings/_index.md
+++ b/content/listings/_index.md
@@ -2,8 +2,8 @@
 title: Listings
 weight: 5
 dashboardWeight: 0.2
-dashboardState: incomplete
-dashboardAudit: 0
+dashboardState: wip
+dashboardAudit: n/a
 ---
 
 # Listings

--- a/content/listings/actors.md
+++ b/content/listings/actors.md
@@ -2,8 +2,8 @@
 title: "Filecoin VM Actors"
 weight: 1
 dashboardWeight: 0.2
-dashboardState: incomplete
-dashboardAudit: 0
+dashboardState: wip
+dashboardAudit: n/a
 ---
 
 # Filecoin VM Actors

--- a/content/listings/data_structures.md
+++ b/content/listings/data_structures.md
@@ -2,8 +2,8 @@
 title: "Data Structures"
 weight: 3
 dashboardWeight: 0.2
-dashboardState: incomplete
-dashboardAudit: 0
+dashboardState: wip
+dashboardAudit: n/a
 ---
 
 # Data Structures

--- a/content/listings/libp2p_protocols/_index.md
+++ b/content/listings/libp2p_protocols/_index.md
@@ -3,6 +3,6 @@ title: "Libp2p Protocols"
 bookCollapseSection: true
 weight: 5
 dashboardWeight: 0.2
-dashboardState: incomplete
-dashboardAudit: 0
+dashboardState: wip
+dashboardAudit: n/a
 ---

--- a/content/listings/libp2p_protocols/data_transfer_protocol.md
+++ b/content/listings/libp2p_protocols/data_transfer_protocol.md
@@ -1,8 +1,8 @@
 ---
 title: Data Transfer Protocol
 dashboardWeight: 0.2
-dashboardState: incomplete
-dashboardAudit: 0
+dashboardState: wip
+dashboardAudit: n/a
 ---
 
 # Data Transfer Protocol

--- a/content/listings/reserved_ranges.md
+++ b/content/listings/reserved_ranges.md
@@ -2,8 +2,8 @@
 title: "Reserved Ranges"
 weight: 2
 dashboardWeight: 0.2
-dashboardState: incomplete
-dashboardAudit: 0
+dashboardState: wip
+dashboardAudit: n/a
 ---
 
 # Reserved Ranges

--- a/content/listings/system_map.md
+++ b/content/listings/system_map.md
@@ -2,8 +2,8 @@
 title: "Components"
 weight: 4
 dashboardWeight: 0.2
-dashboardState: incomplete
-dashboardAudit: 0
+dashboardState: wip
+dashboardAudit: n/a
 ---
 
 # Components

--- a/content/systems/filecoin_markets/storage_market/_index.md
+++ b/content/systems/filecoin_markets/storage_market/_index.md
@@ -3,7 +3,7 @@ title: Storage Market
 weight: 1
 bookCollapseSection: true
 dashboardWeight: 2
-dashboardState: incomplete
+dashboardState: wip
 dashboardAudit: missing
 dashboardTests: 0
 ---

--- a/content/systems/filecoin_markets/storage_market/storage_client.md
+++ b/content/systems/filecoin_markets/storage_market/storage_client.md
@@ -2,7 +2,7 @@
 title: Storage Client
 weight: 4
 dashboardWeight: 2
-dashboardState: incomplete
+dashboardState: wip
 dashboardAudit: n/a
 dashboardTests: 0
 ---

--- a/content/systems/filecoin_markets/storage_market/storage_market_actor.md
+++ b/content/systems/filecoin_markets/storage_market/storage_market_actor.md
@@ -2,7 +2,7 @@
 title: Storage Market Actor
 weight: 2
 dashboardWeight: 2
-dashboardState: incomplete
+dashboardState: wip
 dashboardAudit: missing
 dashboardTests: 0
 ---

--- a/content/systems/filecoin_mining/storage_proving/_index.md
+++ b/content/systems/filecoin_mining/storage_proving/_index.md
@@ -3,7 +3,7 @@ title: Storage Proving
 weight: 4
 bookCollapseSection: true
 dashboardWeight: 1
-dashboardState: incomplete
+dashboardState: wip
 dashboardAudit: wip
 dashboardTests: 0
 ---

--- a/content/systems/filecoin_mining/storage_proving/poster/_index.md
+++ b/content/systems/filecoin_mining/storage_proving/poster/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Sector Poster
 dashboardWeight: 1
-dashboardState: incomplete
+dashboardState: wip
 dashboardAudit: wip
 dashboardTests: 0
 ---

--- a/content/systems/filecoin_mining/storage_proving/sealer/_index.md
+++ b/content/systems/filecoin_mining/storage_proving/sealer/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Sector Sealer
 dashboardWeight: 1
-dashboardState: incomplete
+dashboardState: wip
 dashboardAudit: wip
 dashboardTests: 0
 ---

--- a/content/systems/filecoin_vm/runtime/gascost/_index.md
+++ b/content/systems/filecoin_vm/runtime/gascost/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Gas Costs
 dashboardWeight: 1
-dashboardState: incomplete
+dashboardState: wip
 dashboardAudit: missing
 dashboardTests: 0
 ---

--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -35,7 +35,7 @@
   - headings get numbered by css; changing the nesting requires updating numbered.scss.
   - heading text is grabbed by toc.js as the ToC link text
 */}}
-<h{{ $level }} id="{{ $anchor | safeURL }}" class="level-{{ $level }}" data-page="{{if eq $originalLevel 1 }}true{{end}}" data-dashboard-weight="{{.Page.Params.dashboardWeight}}" data-dashboard-state="{{.Page.Params.dashboardState}}" data-dashboard-audit="{{.Page.Params.dashboardAudit}}" data-dashboard-audit-url="{{.Page.Params.dashboardAuditURL}}">
+<h{{ $level }} id="{{ $anchor | safeURL }}" class="level-{{ $level }}" data-page="{{if eq $originalLevel 1 }}true{{end}}" data-dashboard-weight="{{.Page.Params.dashboardWeight}}" data-dashboard-state="{{.Page.Params.dashboardState}}" data-dashboard-audit="{{.Page.Params.dashboardAudit}}" data-dashboard-audit-url="{{.Page.Params.dashboardAuditURL}}" data-dashboard-audit-date="{{.Page.Params.dashboardAuditDate}}">
   <a href="#{{ $anchor | safeURL }}">{{ .Text | safeHTML }}</a>
 </h{{ $level }}>
 <div class="section-badges">

--- a/layouts/shortcodes/dashboard-impl.html
+++ b/layouts/shortcodes/dashboard-impl.html
@@ -52,8 +52,16 @@
                         {{ if $data.commit.totals.c }}{{ math.Round $data.commit.totals.c }}%{{ else }}Unknown{{end}}
                     </a>
                 </td>
-                <td class="text-transparent {{ if gt $impl.Params.implAudit 0 }}bg-stable{{ else }}bg-incorrect{{end}}">
-                    {{ $impl.Params.implAudit }}
+                <td class="text-black bg-{{ $repoItem.auditState | default "na" }}">
+                    {{if eq $repoItem.auditState "wip"}}
+                        WIP
+                    {{else if $repoItem.auditURL}} 
+                        <a href="{{ $repoItem.auditURL }}" title="Read the audit report" target="_blank" rel="noopener noreferrer" class="text-black">
+                            {{ $repoItem.auditDate }}<i class="gg-external gg-s-half"></i>
+                        </a>
+                    {{else}}
+                        {{ humanize $repoItem.auditState | default "None" }}
+                    {{end}}
                 </td>
             </tr>
         {{ end }}

--- a/layouts/shortcodes/dashboard-impl.html
+++ b/layouts/shortcodes/dashboard-impl.html
@@ -35,9 +35,6 @@
             {{ if gt $cov 20 }}
                 {{ $color = "bg-wip"}}
             {{ end }}
-            {{ if gt $cov 45 }}
-                {{ $color = "bg-incomplete"}}
-            {{ end }}
             {{ if gt $cov 70 }}
                 {{ $color = "bg-reliable"}}
             {{ end }}

--- a/layouts/shortcodes/dashboard-impl.html
+++ b/layouts/shortcodes/dashboard-impl.html
@@ -39,12 +39,12 @@
                 {{ $color = "bg-incomplete"}}
             {{ end }}
             {{ if gt $cov 70 }}
-                {{ $color = "bg-stable"}}
+                {{ $color = "bg-reliable"}}
             {{ end }}
             <tr>
                 <td style="text-align:left"><a title="{{ $repoName }}" href="{{ $repoUrl }}">{{ $repoName }}</a></td>
                 <td>{{ $repoLang }}</td>
-                <td class="text-black {{ if eq $data.commit.ci_passed  true }}bg-stable{{ else if eq $data.commit.ci_passed false }}bg-incorrect {{ else }}bg-na{{end}}">
+                <td class="text-black {{ if eq $data.commit.ci_passed  true }}bg-reliable{{ else if eq $data.commit.ci_passed false }}bg-incorrect {{ else }}bg-na{{end}}">
                     {{ if eq $data.commit.ci_passed  true }}Passed{{ else if eq $data.commit.ci_passed false }}Failed{{ else }}Unknown{{ end }}
                 </td>
                 <td class="text-black {{ $color }}">


### PR DESCRIPTION
- [x] show audit date where we can link to an audit report (fixes #1020)
- [x] otherwise show audit label as `done` rather than stable where the audit has been done but we dont yet have a link to a report. (#1082)
- [x] make `reliable` be green, and `stable` be blue (fixes #1082)
- [x] remove repos from impls section (fixes #1080)
- [x] fix some sections should be marked as audited (fixes #1079)
- [ ] ~~remove scroll from table without breaking the anchor links... (#1082)~~
- [x] ensure latest dashboardState and dashboardAudit enum values are used (fixes #1078)

<img width="832" alt="Screenshot 2020-08-24 at 22 27 16" src="https://user-images.githubusercontent.com/58871/91098221-034bd280-e659-11ea-8d19-bb30e20515ed.png">


<img width="851" alt="Screenshot 2020-08-24 at 19 55 22" src="https://user-images.githubusercontent.com/58871/91084948-a1816d80-e644-11ea-9d0b-d26f18fe1d33.png">

