### PR TITLE
chore: add bzr for lotus

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
           node-version: '12'
       
       # get lotus deps...
-      - run: apt install bzr
+      - run: sudo apt install bzr
 
       - run: npm install
       - run: npm run build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           node-version: '12'
       
+      # get lotus deps...
+      - run: apt install bzr
+
       - run: npm install
       - run: npm run build
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ yarn install
 ```
 
 ## Develop
-You need to have Go installed https://golang.org/doc/install
+You need to have [Go](https://golang.org/doc/install) and `bzr` installed (required to build lotus)
 
 ```bash
-brew install go
+brew install go bzr
 ```
 
 ### Serve with Live Reload


### PR DESCRIPTION
a lotus dep requires bzr be on the PATH, so we add it to the ci env.

fixes #1084

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>