### PR TITLE
chore: document fix for hugo module fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ yarn serve
 # open http://localhost:1313/ in the browser
 ```
 
+### Solving Common problems
+
+**Problem** - Site fails to build with an error that states it faled to download modules on macos
+
+```
+Error: failed to download modules: go command failed ...
+```
+
+**Solution** - run `npm run clean-modules` - the cache dir hugo uses can get corrupted, and this resets it. See [#1048](https://github.com/filecoin-project/specs/issues/1048)
+
+
 ### External modules
 External modules should be added as [Hugo Modules](https://gohugo.io/hugo-modules/)
 You can find examples in the `config.toml`

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "serve": "hugo server --bind=0.0.0.0 --disableFastRender",
     "build": "hugo --gc --minify",
-    "clean-modules": "hugo mod clean && hugo mod tidy"
+    "clean-modules": "hugo mod clean --all && hugo mod tidy"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
add a note to the readme and update the npm run script to ensure it can recover from the error.

fixes #1048

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>