### PR TITLE
fix: add missing premove dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "execa": "^4.0.3",
     "globby": "^11.0.1",
     "graphviz-cli": "^1.0.0",
-    "hugo-extended": "^0.74.3"
+    "hugo-extended": "^0.74.3",
+    "premove": "^3.0.1"
   }
 }


### PR DESCRIPTION
the clean npm run script depends on premove, so we add the dep.

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>