### PR TITLE
fix: correct libp2p audit date

### DIFF
--- a/content/libraries/libp2p/_index.md
+++ b/content/libraries/libp2p/_index.md
@@ -7,7 +7,7 @@ dashboardWeight: 1
 dashboardState: missing
 dashboardTests: 0
 dashboardAudit: done
-dashboardAuditDate: '2020-10-10'
+dashboardAuditDate: '2019-10-10'
 dashboardAuditURL: https://github.com/protocol/libp2p-vulnerabilities/blob/master/DRAFT_NCC_Group_ProtocolLabs_1903ProtocolLabsLibp2p_Report_2019-10-10_v1.1.pdf 
 ---
 


### PR DESCRIPTION
Specify the correct date for the libp2p audit

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>