### PR TITLE
Updating Data Transfer Protocol section status to "Stable"

### DIFF
--- a/content/systems/filecoin_files/data_transfer/_index.md
+++ b/content/systems/filecoin_files/data_transfer/_index.md
@@ -2,7 +2,7 @@
 title: Data Transfer
 weight: 3
 dashboardWeight: 1
-dashboardState: wip
+dashboardState: stable
 dashboardAudit: missing
 dashboardTests: 0
 ---


### PR DESCRIPTION
Due to parallel commits and PR merges the status of this section was accidentally downgraded to "wip" from "stable". This PR is setting the status back to the correct one.