### PR TITLE
chore: refactor to a single watcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,9 @@
     "start": "concurrently npm:watch-*",
     "serve": "npm start",
     "watch-hugo": "npm run build-diagrams && hugo server --bind=0.0.0.0 --disableFastRender --renderToDisk",
-    "watch-diagrams": "tools/diagrams.js --watch",
-    "watch-toc": "tools/toc.js --watch",
+    "watch-assets": "tools/watch.js --watch",
     "build": "npm run build-diagrams && hugo --quiet && npm run build-toc && hugo --gc --minify",
-    "build-diagrams": "tools/diagrams.js --all",
+    "build-diagrams": "tools/diagrams.js",
     "build-toc": "tools/toc.js",
     "clean": "premove public resources static/_gen && hugo mod clean --all && hugo mod tidy",
     "release": "np --no-publish && conventional-github-releaser -p angular"

--- a/tools/watch.js
+++ b/tools/watch.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+const chokidar = require('chokidar')
+const diagrams = require('./diagrams')
+const toc = require('./toc')
+
+watch()
+
+function watch () {
+  const watcher = chokidar.watch([], {
+    awaitWriteFinish: {
+      stabilityThreshold: 1000,
+      pollInterval: 100
+    },
+    ignoreInitial: true
+  })
+
+  watcher
+    .on('error', err => console.error('error watching: ', err))
+    .on('all', (event, p) => console.log(event, p))
+
+  toc.configureWatcher(watcher)
+  diagrams.configureWatcher(watcher)
+
+  console.log('Watching', watcher.getWatched())
+}

--- a/tools/watch.js
+++ b/tools/watch.js
@@ -20,6 +20,4 @@ function watch () {
 
   toc.configureWatcher(watcher)
   diagrams.configureWatcher(watcher)
-
-  console.log('Watching', watcher.getWatched())
 }


### PR DESCRIPTION
- add watch.js to configure chokidar.
- pass watcher to each tool via an exported `configureWatcher` method.

If run directly, the tool assumes it should process all things it cares about. If required as module, it does nothing, and allows the calling code to use it to configure the watcher.

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>