### PR TITLE
fix: bring back label style

### DIFF
--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -96,6 +96,13 @@
     outline: none;
 }
 
+.label {
+    font-size: 10px;
+    font-weight: 700;
+    display: block;
+    color:$gray-600;
+}
+
 // Tweaks
 html {
     scroll-behavior: auto;

--- a/assets/_dashboard.scss
+++ b/assets/_dashboard.scss
@@ -16,6 +16,11 @@ table.Dashboard {
     th:first-child {
         width: 50%;
     }
+    .gg-external {
+        display: inline-block;
+        margin-left: 3px;
+        vertical-align: text-top;
+    }
 }
 
 .Dashboard tr th,

--- a/layouts/partials/docs/toc.html
+++ b/layouts/partials/docs/toc.html
@@ -1,4 +1,4 @@
 <div class="toc">
-    <p class="toc-label"><i class="gg-menu-motion"></i> CONTENTS</p>
+    <p class="label"><i class="gg-menu-motion"></i> CONTENTS</p>
     {{ .TableOfContents }}
 </div>

--- a/layouts/partials/single/menu-single.html
+++ b/layouts/partials/single/menu-single.html
@@ -1,6 +1,6 @@
 <div class="toc">
   <div class="toc-control">
-    <p class="toc-label">TABLE OF CONTENTS</p>
+    <p class="label">TABLE OF CONTENTS</p>
     <input title="Adjust the depth of the toc" id="toc-depth-slider" type="range" step="1" min="1" max="5" value="2" style="width:174px" />
   </div>
 </div>


### PR DESCRIPTION
fix the css for toc-label and make re-usable as a .label class

fixes #1135

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>