### PR TITLE
fix: import meter css

### DIFF
--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -7,6 +7,7 @@
 // @import "plugins/toggles";
 @import "plugins/lightbox";
 @import "plugins/bagdes";
+@import "plugins/meter";
 @import "plugins/toc";
 @import "table-sort";
 @import "colors";


### PR DESCRIPTION
fixes css for progress bar. the import was missed in the orginal pr #1137 

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>