### PR TITLE
docs: katex link syntax typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ $SectorInitialConsensusPledge = \\[0.2cm] 30\% \times FILCirculatingSupply \time
 
 ## Math mode
 
-For short snippets of math text (e.g., inline reference to parameters, or single formulas) it is easier to use the `{{<katex>}}`/`{{/katex}}` shortcode (as described just [above](specs#katex)). Check how KaTeX parses math typesetting [here]((https://katex.org/docs/api.html)).
+For short snippets of math text (e.g., inline reference to parameters, or single formulas) it is easier to use the `{{<katex>}}`/`{{/katex}}` shortcode (as described just [above](specs#katex)). Check how KaTeX parses math typesetting [here](https://katex.org/docs/api.html).
 
 For extensive blocks of math content it is more convenient to use `math-mode` to avoid having to repeat the katex shortcode for every math formula.
 


### PR DESCRIPTION
Fixes a small syntax typo.