### PR TITLE
fix(content): outdated todos

### DIFF
--- a/content/libraries/drand/_index.md
+++ b/content/libraries/drand/_index.md
@@ -44,9 +44,8 @@ Specifically, the message signed is the concatenation of the round number treate
 
 ## Polling the drand network
 
-Filecoin nodes fetches the drand entry from the distribution network of the
-selected drand network. TODO: define network's name/entrypoints when drand
-network's live.
+Filecoin nodes fetch the drand entry from the distribution network of the
+selected drand network.
 
 drand distributes randomness via multiple distribution channels (HTTP servers,
 S3 buckets, gossiping...).  Simply put, the drand nodes themselves will not be
@@ -154,10 +153,3 @@ of these blocks.
 
 In any event, a heavier chain will emerge after the catch up period and mining
 can resume as normal.
-
-## drand network specification
-
-TODO once ready: @nikkolasg
-- Filecoin node access to randomness (how to connect, poll, etc)
-- Drand Node composition and governance
-- Network characteristics (DDoS resistance, layer description etc)

--- a/content/systems/filecoin_blockchain/message_pool/message_syncer.md
+++ b/content/systems/filecoin_blockchain/message_pool/message_syncer.md
@@ -24,8 +24,3 @@ The updated, hardened version of the GossipSub protocol includes a number of att
 NOTES:
 - _Fund Checking:_ It is important to note that the `mpool` logic is not checking whether there are enough funds in the account of the transaction message issuer. This is checked by the miner before including a transaction message in a block.
 - _Message Sorting:_ Transaction messages are sorted in the `mpool` of miners as they arrive according to cryptoeconomic rules followed by the miner and in order for the miner to compose the next block.
-
-
-{{<hint warning>}}
-**TODO:** discuss checking signatures and account balances, some tricky bits that need consideration. Does the fund check cause improper dropping? E.g. I have a message sending funds then use the newly constructed account to send funds, as long as the previous wasn't executed the second will be considered "invalid" ... though it won't be at the time of execution.
-{{</hint>}}


### PR DESCRIPTION
Small PR to remove outdated TODOs that either do not apply anymore, or have already been included in the description.