### PR TITLE
fix(content): minting model dashboard label

### DIFF
--- a/content/systems/filecoin_token/minting_model/_index.md
+++ b/content/systems/filecoin_token/minting_model/_index.md
@@ -4,7 +4,7 @@ bookCollapseSection: true
 weight: 1
 dashboardWeight: 1
 dashboardState: reliable
-dashboardAudit: missing
+dashboardAudit: n/a
 dashboardTests: 0
 ---
 


### PR DESCRIPTION
Tiny PR to update the dashboard label of the minting model section, which was incorrectly set to "Missing".