### PR TITLE
fix(content): go-filecoin to venus

### DIFF
--- a/content/implementations/_index.md
+++ b/content/implementations/_index.md
@@ -15,7 +15,7 @@ Filecoin is targeting [multiple implementations](https://filecoin.io/blog/announ
 - [Lotus](https://lotu.sh): the Go-based implementation, supported by [Protocol Labs](https://protocol.ai),
 - [Forest](https://github.com/ChainSafe/forest): the Rust-based implementation, supported by [ChainSafe](https://chainsafe.io),
 - [Fuhon](https://github.com/filecoin-project/cpp-filecoin): the C++-based implementation, supported by [Soramitsu](https://soramitsu.co.jp),
-- [go-filecoin](https://github.com/filecoin-project/go-filecoin): a second Go-based implementation of Filecoin, which is a community-driven effort.
+- [Venus](https://github.com/filecoin-project/go-filecoin): a second Go-based implementation of Filecoin, previously called `go-filecoin`, which is maintained by the [IPFS-Force Community](https://github.com/ipfs-force-community).
 
 
 {{<dashboard-impl>}}

--- a/content/implementations/go-filecoin.md
+++ b/content/implementations/go-filecoin.md
@@ -1,5 +1,5 @@
 ---
-title: go-filecoin
+title: Venus
 weight: 2
 dashboardWeight: 1
 dashboardState: reliable
@@ -8,10 +8,10 @@ implRepos:
   - { lang: go, repo: https://github.com/filecoin-project/go-filecoin }
 ---
 
-# Filecoin (go-filecoin)
+# Venus
 
-`go-filecoin` is a [community-driven](https://filecoin.io/blog/roadmap-update-june-2020/#what-s-next) implementation of Filecoin in Go. The `go-filecoin` implementation is nearly feature-complete (as of June 2020) with `go-filecoin` nodes interoperating with Lotus nodes.
+Venus, previously called `go-filecoin`, is another implementation of Filecoin in Go and is maintained by the [IPFS Force Community](https://github.com/ipfs-force-community). The `go-filecoin` implementation, before it was renamed to Venus and taken over by IPFS Force, was already nearly feature-complete (as of June 2020) with `go-filecoin` nodes interoperating with Lotus nodes.
 
-Protocol Labs is offering [DevGrants](https://github.com/filecoin-project/devgrants/issues/140) to support the development of `go-filecoin`.
+Protocol Labs is offering [DevGrants](https://github.com/filecoin-project/devgrants/issues/140) to support the development of Venus.
 
-You can find the `go-filecoin` codebase [here](https://github.com/filecoin-project/go-filecoin) and its extensive documentation website [here](https://go.filecoin.io/).
+You can find the Venus codebase [here](https://github.com/filecoin-project/venus) and its extensive documentation website [here](https://go.filecoin.io/).


### PR DESCRIPTION
The go-filecoin implementation has recently been renamed to Venus and is now maintained by the [IPFS Force community](https://github.com/ipfs-force-community). This PR updates the description of the corresponding section of the spec and the links to the updated repository (although github.com/filecoin-project/go-filecoin redirects to github.com/filecoin-project/venus).