### PR TITLE
fix(content): intro section tidy up

### DIFF
--- a/content/intro/arch.md
+++ b/content/intro/arch.md
@@ -10,23 +10,4 @@ dashboardAudit: n/a
 
 Actor State Diagram
 
-{{< mermaid >}}
-stateDiagram
-    Null --> Precommitted: PreCommitSectors
-    Precommitted --> Committed: CommitSectors
-    Precommitted --> Deleted: CronPreCommitExpiry (PCD)
-    Committed --> Active: SubmittedWindowPoSt
-    Committed --> Faulty: DeclareFault\nSubmitWindowPoSt (SP)\nProvingDeadline (SP)
-    Committed --> Terminated: TerminateSectors\n(TF)
-    Faulty --> Active: SubmittedWindowPoSt (FF)
-    Faulty --> Faulty: ProvingDeadline (FF)
-    Faulty --> Recovering: DeclareFaultRecovered
-    Faulty --> Terminated: EarlyExpiration (TF)\nTerminateSectors (TF)
-    Recovering --> Active: SubmittedWindowPoSt (FF)
-    Recovering --> Faulty: DeclareFault\nProvingDeadline (SP)
-    Recovering --> Terminated: TerminateSectors (TF)
-    Active --> Active: SubmittedWindowPoSt
-    Active --> Faulty: DeclareFault\nSubmitWindowPoSt (SP)\nProvingDeadline (SP)
-    Active --> Terminated: CronExpiration\nTerminateSectors (TF)
-    Terminated --> Deleted: CompactSectors
-{{</ mermaid >}}
+![Actor State Diagram](new-state-diagram.mmd)

--- a/content/intro/arch.md
+++ b/content/intro/arch.md
@@ -10,4 +10,4 @@ dashboardAudit: n/a
 
 Actor State Diagram
 
-![Actor State Diagram](new-state-diagram.mmd)
+![Actor State Diagram](intro/new-state-diagram.mmd)

--- a/content/intro/arch.md
+++ b/content/intro/arch.md
@@ -8,23 +8,25 @@ dashboardAudit: n/a
 
 # Architecture Diagrams
 
-## Overview Diagram
-{{< details title="TODO" >}}
-- cleanup / reorganize
-  - this diagram is accurate, and helps lots to navigate, but it's still a bit confusing
-  - the arrows and lines make it a bit hard to follow. We should have a much cleaner version (maybe based on [C4](https://c4model.com))
-- reflect addition of Token system
-  - move data_transfers into Token
-{{< /details >}}
+Actor State Diagram
 
-![Protocol Overview Diagram](diagrams/overview1/overview.dot)
-
-## Protocol Flow Diagram
-
-![Deals on Chain](diagrams/sequence/full-deals-on-chain.mmd)
-
-## Parameter Calculation Dependency Graph
-
-This is a diagram of the model for parameter calculation. This is made with [orient](https://github.com/filecoin-project/orient), our tool for modeling and solving for constraints.
-
-![Protocol Overview Diagram](diagrams/orient/filecoin.dot)
+{{< mermaid >}}
+stateDiagram
+    Null --> Precommitted: PreCommitSectors
+    Precommitted --> Committed: CommitSectors
+    Precommitted --> Deleted: CronPreCommitExpiry (PCD)
+    Committed --> Active: SubmittedWindowPoSt
+    Committed --> Faulty: DeclareFault\nSubmitWindowPoSt (SP)\nProvingDeadline (SP)
+    Committed --> Terminated: TerminateSectors\n(TF)
+    Faulty --> Active: SubmittedWindowPoSt (FF)
+    Faulty --> Faulty: ProvingDeadline (FF)
+    Faulty --> Recovering: DeclareFaultRecovered
+    Faulty --> Terminated: EarlyExpiration (TF)\nTerminateSectors (TF)
+    Recovering --> Active: SubmittedWindowPoSt (FF)
+    Recovering --> Faulty: DeclareFault\nProvingDeadline (SP)
+    Recovering --> Terminated: TerminateSectors (TF)
+    Active --> Active: SubmittedWindowPoSt
+    Active --> Faulty: DeclareFault\nSubmitWindowPoSt (SP)\nProvingDeadline (SP)
+    Active --> Terminated: CronExpiration\nTerminateSectors (TF)
+    Terminated --> Deleted: CompactSectors
+{{</ mermaid >}}

--- a/content/intro/arch.md
+++ b/content/intro/arch.md
@@ -10,4 +10,4 @@ dashboardAudit: n/a
 
 Actor State Diagram
 
-![Actor State Diagram](intro/new-state-diagram.mmd)
+![Actor State Diagram](/intro/new-state-diagram.mmd)

--- a/content/intro/new-state-diagram.mmd
+++ b/content/intro/new-state-diagram.mmd
@@ -1,4 +1,5 @@
 stateDiagram
+
     Null --> Precommitted: PreCommitSectors
     Precommitted --> Committed: CommitSectors
     Precommitted --> Deleted: CronPreCommitExpiry (PCD)

--- a/content/intro/new-state-diagram.mmd
+++ b/content/intro/new-state-diagram.mmd
@@ -1,0 +1,18 @@
+stateDiagram
+    Null --> Precommitted: PreCommitSectors
+    Precommitted --> Committed: CommitSectors
+    Precommitted --> Deleted: CronPreCommitExpiry (PCD)
+    Committed --> Active: SubmittedWindowPoSt
+    Committed --> Faulty: DeclareFault\nSubmitWindowPoSt (SP)\nProvingDeadline (SP)
+    Committed --> Terminated: TerminateSectors\n(TF)
+    Faulty --> Active: SubmittedWindowPoSt (FF)
+    Faulty --> Faulty: ProvingDeadline (FF)
+    Faulty --> Recovering: DeclareFaultRecovered
+    Faulty --> Terminated: EarlyExpiration (TF)\nTerminateSectors (TF)
+    Recovering --> Active: SubmittedWindowPoSt (FF)
+    Recovering --> Faulty: DeclareFault\nProvingDeadline (SP)
+    Recovering --> Terminated: TerminateSectors (TF)
+    Active --> Active: SubmittedWindowPoSt
+    Active --> Faulty: DeclareFault\nSubmitWindowPoSt (SP)\nProvingDeadline (SP)
+    Active --> Terminated: CronExpiration\nTerminateSectors (TF)
+    Terminated --> Deleted: CompactSectors

--- a/layouts/shortcodes/mermaid.html
+++ b/layouts/shortcodes/mermaid.html
@@ -4,7 +4,7 @@
     <script>
     mermaid.initialize({
       startOnLoad:false,
-      theme: 'dark',
+      theme: 'forest',
       flowchart: { useMaxWidth:true }
     });
     </script>


### PR DESCRIPTION
This PR deletes outdated TODOs and diagrams and includes an updated state diagram. This small updates comes while we work on a more substantial revision to the Intro section, which comes with https://github.com/filecoin-project/specs/pull/1168