### PR TITLE
feat(tooling): fix all report links and defers all audit content to the new audit section

### DIFF
--- a/assets/_icons.scss
+++ b/assets/_icons.scss
@@ -6,5 +6,5 @@
     stroke: currentColor;
     fill: currentColor;
     vertical-align: text-bottom;
-    margin: 2px 2px;
+    margin: 1px;
 }

--- a/content/algorithms/gossip_sub.md
+++ b/content/algorithms/gossip_sub.md
@@ -5,7 +5,7 @@ dashboardWeight: 2.0
 dashboardState: stable
 dashboardTests: 0
 dashboardAudit: done
-dashboardAuditURL: /#section-appendix.audit_reports.2020-06-03-gossipsub-design-and-implementation
+dashboardAuditURL: /#section-appendix.audit_reports.gossipsub
 dashboardAuditDate: '2020-06-03'
 ---
 

--- a/content/implementations/_index.md
+++ b/content/implementations/_index.md
@@ -17,8 +17,4 @@ Filecoin is targeting [multiple implementations](https://filecoin.io/blog/announ
 - [Fuhon](https://github.com/filecoin-project/cpp-filecoin): the C++-based implementation, supported by [Soramitsu](https://soramitsu.co.jp),
 - [Venus](https://github.com/filecoin-project/go-filecoin): a second Go-based implementation of Filecoin, previously called `go-filecoin`, which is maintained by the [IPFS-Force Community](https://github.com/ipfs-force-community).
 
-
 {{<dashboard-impl>}}
-
-
-

--- a/content/implementations/forest.md
+++ b/content/implementations/forest.md
@@ -1,11 +1,11 @@
 ---
-title: Forest 
+title: Forest
 weight: 3
 dashboardWeight: 1
 dashboardState: reliable
 dashboardAudit: n/a
 implRepos:
- - { lang: rust, repo: https://github.com/ChainSafe/forest }
+  - { lang: rust, repo: https://github.com/ChainSafe/forest }
 ---
 
 # Forest

--- a/content/implementations/fuhon.md
+++ b/content/implementations/fuhon.md
@@ -4,7 +4,7 @@ weight: 4
 dashboardWeight: 1
 dashboardState: reliable
 dashboardAudit: n/a
-implRepos: 
+implRepos:
   - { lang: c++, repo: https://github.com/filecoin-project/cpp-filecoin }
 ---
 

--- a/content/implementations/lotus.md
+++ b/content/implementations/lotus.md
@@ -4,33 +4,23 @@ weight: 1
 dashboardWeight: 1
 dashboardState: reliable
 dashboardAudit: n/a
-implRepos: 
+implRepos:
   - repo: https://github.com/filecoin-project/lotus
     lang: go
     auditState: done
-    audits:
-      - auditDate: '2020-10-20'
-        auditURL: '/#section-appendix.audit_reports.2020-10-20-lotus-mainnet-ready-security-audit'        
+    auditURL: /#section-appendix.audit_reports.lotus
   - repo: https://github.com/filecoin-project/go-fil-markets
     lang: go
     auditState: done
-    audits:
-      - auditDate: '2020-10-20'
-        auditURL: '/#section-appendix.audit_reports.2020-10-20-lotus-mainnet-ready-security-audit'    
+    auditURL: /#section-appendix.audit_reports.lotus
   - repo: https://github.com/filecoin-project/specs-actors
     lang: go
     auditState: done
-    audits:
-      - auditDate: '2020-10-19'
-        auditURL: '/#section-appendix.audit_reports.2020-10-19-actors-audit'
+    auditURL: /#section-appendix.audit_reports.actors
   - repo: https://github.com/filecoin-project/rust-fil-proofs
     lang: rust
     auditState: done
-    audits:
-    - auditDate: '2020-07-28'
-      auditURL: /#section-appendix.audit_reports.2020-07-28-filecoin-proving-subsystem
-    - auditDate: '2020-07-28'
-      auditURL: /#section-appendix.audit_reports.2020-07-28-zk-snark-proofs
+    auditURL: /#section-appendix.audit_reports.proofs
 ---
 
 # Lotus
@@ -40,6 +30,7 @@ Lotus is an implementation of the Filecoin Distributed Storage Network. Lotus is
 You can run the Lotus software client to join the Filecoin Testnet. Lotus can run on MacOS and Linux. Windows is not supported yet.
 
 The two main components of Lotus are:
+
 1. **The Lotus Node** can sync the blockchain, validating all blocks, transfers, and deals along the way. It can also facilitate the creation of new storage deals. Running this type of node is ideal for users that do not wish to contribute storage to the network, produce new blocks and extend the blockchain.
 2. **The Lotus Storage Miner** can register as a miner in the network, register storage, accept deals and store data. The Lotus Storage Miner can produce blocks, extend the blockchain and receive rewards for new blocks added to the network.
 

--- a/content/implementations/venus.md
+++ b/content/implementations/venus.md
@@ -4,7 +4,7 @@ weight: 2
 dashboardWeight: 1
 dashboardState: reliable
 dashboardAudit: n/a
-implRepos: 
+implRepos:
   - { lang: go, repo: https://github.com/filecoin-project/venus }
 ---
 

--- a/content/libraries/drand/_index.md
+++ b/content/libraries/drand/_index.md
@@ -5,7 +5,7 @@ dashboardWeight: 2
 dashboardState: stable
 dashboardTests: 0
 dashboardAudit: done
-dashboardAuditURL: /#section-appendix.audit_reports.2020-08-09-drand
+dashboardAuditURL: /#section-appendix.audit_reports.drand
 dashboardAuditDate: '2020-08-09'
 ---
 

--- a/content/systems/filecoin_markets/onchain_storage_market/storage_market_actor.md
+++ b/content/systems/filecoin_markets/onchain_storage_market/storage_market_actor.md
@@ -4,7 +4,7 @@ weight: 1
 dashboardWeight: 2
 dashboardState: reliable
 dashboardAudit: done
-dashboardAuditURL: /#section-appendix.audit_reports.specs-actors
+dashboardAuditURL: /#section-appendix.audit_reports.actors
 dashboardAuditDate: '2020-10-19'
 dashboardTests: 0
 math-mode: true

--- a/content/systems/filecoin_mining/storage_mining/storage_miner_actor.md
+++ b/content/systems/filecoin_mining/storage_mining/storage_miner_actor.md
@@ -4,7 +4,7 @@ weight: 5
 dashboardWeight: 2
 dashboardState: wip
 dashboardAudit: done
-dashboardAuditURL: /#section-appendix.audit_reports.specs-actors
+dashboardAuditURL: /#section-appendix.audit_reports.actors
 dashboardAuditDate: '2020-10-19'
 dashboardTests: 0
 ---

--- a/content/systems/filecoin_token/multisig.md
+++ b/content/systems/filecoin_token/multisig.md
@@ -5,7 +5,7 @@ bookCollapseSection: true
 dashboardWeight: 1
 dashboardState: reliable
 dashboardAudit: done
-dashboardAuditURL: /#section-appendix.audit_reports.specs-actors
+dashboardAuditURL: /#section-appendix.audit_reports.actors
 dashboardAuditDate: '2020-10-19'
 dashboardTests: 0
 ---

--- a/content/systems/filecoin_vm/sysactors/_index.md
+++ b/content/systems/filecoin_vm/sysactors/_index.md
@@ -5,7 +5,7 @@ bookCollapseSection: true
 dashboardWeight: 2
 dashboardState: reliable
 dashboardAudit: done
-dashboardAuditURL: /#section-appendix.audit_reports.specs-actors
+dashboardAuditURL: /#section-appendix.audit_reports.actors
 dashboardAuditDate: '2020-10-19'
 dashboardTests: 0
 ---

--- a/layouts/shortcodes/dashboard-impl.html
+++ b/layouts/shortcodes/dashboard-impl.html
@@ -49,25 +49,20 @@
                 <td class="text-black bg-{{ $repoItem.auditState | default "missing" }}">
                     {{ if eq $repoItem.auditState "wip" }}
                         WIP
-                    {{ else if and (eq $repoItem.auditState "done") (isset $repoItem "audits") }}
-                    {{ else }}
-                        {{ humanize $repoItem.auditState | default "Missing" }}
-                    {{ end }}
-                    {{ if isset $repoItem "audits" }}
-                        {{ range $auditIndex, $audit := $repoItem.audits }}
-                            {{ if hasPrefix $audit.auditURL "http" }}
-                                <a href="{{ $audit.auditURL }}" title="Read the audit report - {{ $audit.auditDate }}" target="_blank" rel="noopener noreferrer" class="text-black">
-                                    [{{ add $auditIndex 1 }}<svg class="icon">
+                    {{ else if isset $repoItem "auditURL" }}
+                            {{ if hasPrefix $repoItem.auditURL "http" }}
+                                <a href="{{ $repoItem.auditURL }}" title="Read the audit reports" target="_blank" rel="noopener noreferrer" class="text-black">
+                                    Reports<svg class="icon">
                                         <use xlink:href="/symbol-defs.svg#icon-external-link"></use>
-                                    </svg>]
+                                    </svg>
                                 </a>
                             {{ else }}
-                                <a href="{{ $audit.auditURL }}" title="Read the audit report - {{ $audit.auditDate }}" class="text-black">
-                                    [{{ add $auditIndex 1 }}]
+                                <a href="{{ $repoItem.auditURL }}" title="Read the audit reports" class="text-black">
+                                    Reports
                                 </a>
                             {{ end }}
-
-                        {{ end }}
+                    {{ else }}
+                        {{ humanize $repoItem.auditState | default "Missing" }}
                     {{ end }}
                 </td>
             </tr>

--- a/layouts/shortcodes/dashboard-impl.html
+++ b/layouts/shortcodes/dashboard-impl.html
@@ -51,14 +51,16 @@
                         WIP
                     {{ else if isset $repoItem "auditURL" }}
                             {{ if hasPrefix $repoItem.auditURL "http" }}
-                                <a href="{{ $repoItem.auditURL }}" title="Read the audit reports" target="_blank" rel="noopener noreferrer" class="text-black">
+                                <a href="{{ $repoItem.auditURL }}" title="Read the audit reports" target="_blank" rel="noopener noreferrer">
                                     Reports<svg class="icon">
                                         <use xlink:href="/symbol-defs.svg#icon-external-link"></use>
                                     </svg>
                                 </a>
                             {{ else }}
-                                <a href="{{ $repoItem.auditURL }}" title="Read the audit reports" class="text-black">
-                                    Reports
+                                <a href="{{ $repoItem.auditURL }}" title="Read the audit reports">
+                                    <svg class="icon">
+                                        <use xlink:href="/symbol-defs.svg#icon-shield"></use>
+                                    </svg>Reports
                                 </a>
                             {{ end }}
                     {{ else }}

--- a/layouts/shortcodes/dashboard-spec.html
+++ b/layouts/shortcodes/dashboard-spec.html
@@ -61,11 +61,13 @@
             {{ template "humanizeState" .dashboardAudit }}
         {{- else -}}
             {{- if hasPrefix .dashboardAuditURL "http" -}}
-                <a href="{{ .dashboardAuditURL }}" title="Read the audit report" target="_blank" rel="noopener noreferrer" class="text-black">{{.dashboardAuditDate}}<svg class="icon">
+                <a href="{{ .dashboardAuditURL }}" title="Read the audit report" target="_blank" rel="noopener noreferrer">{{.dashboardAuditDate}}<svg class="icon">
                     <use xlink:href="/symbol-defs.svg#icon-external-link"></use>
                 </svg></a>
             {{- else -}}
-                <a href="{{ .dashboardAuditURL }}" title="Read the audit reports" class="text-black">Reports</a>
+                <a href="{{ .dashboardAuditURL }}" title="Read the audit reports"><svg class="icon">
+                    <use xlink:href="/symbol-defs.svg#icon-shield"></use>
+                </svg>Reports</a>
             {{- end -}}
         {{- end -}}
     </td>

--- a/layouts/shortcodes/dashboard-spec.html
+++ b/layouts/shortcodes/dashboard-spec.html
@@ -65,7 +65,7 @@
                     <use xlink:href="/symbol-defs.svg#icon-external-link"></use>
                 </svg></a>
             {{- else -}}
-                <a href="{{ .dashboardAuditURL }}" title="Read the audit report" class="text-black">{{.dashboardAuditDate}}</a>
+                <a href="{{ .dashboardAuditURL }}" title="Read the audit reports" class="text-black">Reports</a>
             {{- end -}}
         {{- end -}}
     </td>


### PR DESCRIPTION
This PR fixes all the theory and security links that this PR https://github.com/filecoin-project/specs/pull/1230 broke.

Also now that we have a new audit section with the all the audits content, we can just link to a specific sub section.  

<img width="1213" alt="Screenshot 2020-10-21 at 12 17 47" src="https://user-images.githubusercontent.com/314190/96712781-8b1f3600-1397-11eb-9ee2-0ff0de6754ea.png">
<img width="1215" alt="Screenshot 2020-10-21 at 12 16 33" src="https://user-images.githubusercontent.com/314190/96712788-8eb2bd00-1397-11eb-8111-410a0d94cd64.png">

Some frontmatter properties were removed because the audit section already has them and more.

closes #1232